### PR TITLE
Support of `resolution` 

### DIFF
--- a/.woodpecker/check.yml
+++ b/.woodpecker/check.yml
@@ -2,9 +2,9 @@ steps:
   check:
     image: rust:latest
     commands:
-      cargo check
+      - rustup install nightly
+      - rustup default nightly
+      - cargo check
     when:
       - event: push
       - event: manual
-
-

--- a/.woodpecker/nightly.yml
+++ b/.woodpecker/nightly.yml
@@ -3,6 +3,8 @@ steps:
     image: rust:latest
     commands:
       - apt-get update && apt-get install -y mingw-w64 zip
+      - rustup install nightly
+      - rustup default nightly
       - rustup target add x86_64-pc-windows-gnu
       - cargo check
       - cargo build --release
@@ -18,10 +20,10 @@ steps:
     settings:
       api_key:
         from_secret: github_token
-      files: 
+      files:
         - modbus-cli-unix.tar.gz
         - modbus-cli-windows.zip
-      title: 'Nightly'
+      title: "Nightly"
       checksum:
         - sha256
         - md5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "modbus-cli-rs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ here optional, too. If none is provided, `slave_id = 0` is used.
     "access": "ReadOnly",
     "type": "I32",
     "reverse": false,
+    "resolution": 10,
     "on_update": "C_Register:GetString(\"Serial Number\")",
     "values": [
         { "name": "Waiting", "value": 1 },
@@ -203,6 +204,7 @@ Please refer to the section [Lua Support](#lua-support) for information about th
 - `on_update`: Lua script to run on each update. See Lua section for details.
 - `virtual`: Mark a register as virtual. Only required in client mode to prevent any read of the register.
 - `values`: List of predefined values for selection in edit dialog. Either a object with properties `name` (for display purposes) and `value` or simply the value. If this property ist omitted, an Input field ist displyed while editing.
+- `resolution`: The resolution to use for value interpretation. Only supported for non-string values. The resolution is applied before writing to memory and applied in reverse on read. E.g. `resolution = 10` will interpret a value of `1` as `10`. This also restricts the input values, e.g in this example, you will be unable to input values between 1-9.
 
 If you use the client mode `--client` the corresponding write codes for manipulating registers or coils are derived from the configured `read_code`. E.g. if you specify a `read_code` that corresponds to coils, the write code will be the function code associated with coils, and if you specify the `read_code` 3 or 4 for input and holding registers, the client will use function code 6 or 16 (depending on the length) to write the values. Please refer to `config.json` of this repository for a example configuration.
 

--- a/src/lua/module/register.rs
+++ b/src/lua/module/register.rs
@@ -215,7 +215,10 @@ impl Register {
             .definitions
             .get(&name)
         {
-            match register.get_type().encode(&value) {
+            match register
+                .get_type()
+                .encode(&value, register.get_resolution())
+            {
                 Ok(values) => {
                     if values.len() > register.length() as usize {
                         let _ = this.logger.try_send(LogMsg::err(

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,11 +113,21 @@ impl AppConfig {
     pub fn read(path: &str) -> anyhow::Result<Self> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        if let Ok(c) = serde_json::from_reader(reader) {
+        let result = serde_json::from_reader(reader);
+        if let Ok(c) = result {
             Ok(c)
         } else {
             let content = std::fs::read_to_string(path)?;
-            toml::from_str(&content).map_err(|e| e.into())
+            let res = toml::from_str(&content);
+            if let Ok(c) = res {
+                Ok(c)
+            } else {
+                Err(anyhow::anyhow!(
+                    "JSON: {}, TOML: {}",
+                    result.err().unwrap(),
+                    res.err().unwrap()
+                ))
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(f128)]
+
 mod lua;
 mod mem;
 mod msg;
@@ -306,7 +308,7 @@ fn main() {
                             Value::Num(v) => format!("{}", v),
                             Value::Float(v) => format!("{}", v),
                         };
-                        if let Ok(v) = def.get_type().encode(&s) {
+                        if let Ok(v) = def.get_type().encode(&s, def.get_resolution()) {
                             if memory
                                 .lock()
                                 .expect("Unable to lock memory")

--- a/src/mem/data.rs
+++ b/src/mem/data.rs
@@ -358,7 +358,8 @@ impl DataType {
         }
     }
 
-    pub fn as_str(&self, bytes: &[u16]) -> anyhow::Result<(String, String)> {
+    pub fn as_str(&self, bytes: &[u16], resolution: f64) -> anyhow::Result<(String, String)> {
+        let coefficient = resolution;
         match self.format {
             Format::F32 => {
                 if let (Some(b1), Some(b2)) = (
@@ -367,7 +368,10 @@ impl DataType {
                 ) {
                     let uval: u32 = ((b1 as u32) << 16) + (b2 as u32);
                     let val = f32::from_bits(uval);
-                    Ok((format!("0x{:01$X}", uval, 8), format!("{}", val)))
+                    Ok((
+                        format!("0x{:01$X}", uval, 8),
+                        format!("{}", val as f64 * coefficient),
+                    ))
                 } else {
                     Err(anyhow!("Not enough bytes"))
                 }
@@ -379,7 +383,10 @@ impl DataType {
                 ) {
                     let uval: u32 = ((b2 as u32) << 16) + (b1 as u32);
                     let val = f32::from_bits(uval);
-                    Ok((format!("0x{:01$X}", uval, 8), format!("{}", val)))
+                    Ok((
+                        format!("0x{:01$X}", uval, 8),
+                        format!("{}", val as f64 * coefficient),
+                    ))
                 } else {
                     Err(anyhow!("Not enough bytes"))
                 }
@@ -396,7 +403,10 @@ impl DataType {
                         + ((b3 as u64) << 16)
                         + (b4 as u64);
                     let val = f64::from_bits(uval);
-                    Ok((format!("0x{:01$X}", uval, 16), format!("{}", val)))
+                    Ok((
+                        format!("0x{:01$X}", uval, 16),
+                        format!("{}", val * coefficient as f64),
+                    ))
                 } else {
                     Err(anyhow!("Not enough bytes"))
                 }
@@ -413,7 +423,10 @@ impl DataType {
                         + ((b2 as u64) << 16)
                         + (b1 as u64);
                     let val = f64::from_bits(uval);
-                    Ok((format!("0x{:01$X}", uval, 16), format!("{}", val)))
+                    Ok((
+                        format!("0x{:01$X}", uval, 16),
+                        format!("{}", val * coefficient as f64),
+                    ))
                 } else {
                     Err(anyhow!("Not enough bytes"))
                 }
@@ -471,18 +484,27 @@ impl DataType {
             Format::U8 => {
                 let val: u8 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte")))
                     & 0xFF) as u8;
-                Ok((format!("{:#04X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#04X}", val),
+                    format!("{}", (val as f64 * coefficient) as u8),
+                ))
             }
             Format::U16 => {
                 let val: u16 = self.apply_order(*bytes.first().expect("Unable to retrieve byte"));
-                Ok((format!("{:#06X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#06X}", val),
+                    format!("{}", (val as f64 * coefficient) as u16),
+                ))
             }
             Format::U32 => {
                 let val: u32 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
                     as u32)
                     << 16)
                     + (self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as u32);
-                Ok((format!("0x{:01$X}", val, 8), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 8),
+                    format!("{}", (val as f64 * coefficient) as u32),
+                ))
             }
             Format::U64 => {
                 let val: u64 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
@@ -493,7 +515,10 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(2).expect("Unable to retrieve byte")) as u64)
                         << 16)
                     + self.apply_order(*bytes.get(3).expect("Unable to retrieve byte")) as u64;
-                Ok((format!("0x{:01$X}", val, 16), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 16),
+                    format!("{}", (val as f128 * coefficient as f128) as u64),
+                ))
             }
             Format::U128 => {
                 let val: u128 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
@@ -512,24 +537,36 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(6).expect("Unable to retrieve byte")) as u128)
                         << 16)
                     + self.apply_order(*bytes.get(7).expect("Unable to retrieve byte")) as u128;
-                Ok((format!("0x{:01$X}", val, 32), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 32),
+                    format!("{}", (val as f128 * coefficient as f128) as u128),
+                ))
             }
             Format::I8 => {
                 let val: i8 = (self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
                     & 0xFF) as i8;
-                Ok((format!("{:#04X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#04X}", val),
+                    format!("{}", (val as f64 * coefficient) as i8),
+                ))
             }
             Format::I16 => {
                 let val: i16 =
                     self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as i16;
-                Ok((format!("{:#06X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#06X}", val),
+                    format!("{}", (val as f64 * coefficient) as i16),
+                ))
             }
             Format::I32 => {
                 let val: i32 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
                     as i32)
                     << 16)
                     + (self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as i32);
-                Ok((format!("0x{:01$X}", val, 8), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 8),
+                    format!("{}", (val as f64 * coefficient) as i32),
+                ))
             }
             Format::I64 => {
                 let val: i64 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
@@ -540,7 +577,10 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(2).expect("Unable to retrieve byte")) as i64)
                         << 16)
                     + self.apply_order(*bytes.get(3).expect("Unable to retrieve byte")) as i64;
-                Ok((format!("0x{:01$X}", val, 16), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 16),
+                    format!("{}", (val as f128 * coefficient as f128) as i64),
+                ))
             }
             Format::I128 => {
                 let val: i128 = ((self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
@@ -559,18 +599,27 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(6).expect("Unable to retrieve byte")) as i128)
                         << 16)
                     + self.apply_order(*bytes.get(7).expect("Unable to retrieve byte")) as i128;
-                Ok((format!("0x{:01$X}", val, 32), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 32),
+                    format!("{}", (val as f128 * coefficient as f128) as i128),
+                ))
             }
             Format::U16le => {
                 let val: u16 = self.apply_order(*bytes.first().expect("Unable to retrieve byte"));
-                Ok((format!("{:#06X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#06X}", val),
+                    format!("{}", (val as f64 * coefficient) as u16),
+                ))
             }
             Format::U32le => {
                 let val: u32 = ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte"))
                     as u32)
                     << 16)
                     + (self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as u32);
-                Ok((format!("0x{:01$X}", val, 8), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 8),
+                    format!("{}", (val as f64 * coefficient) as u32),
+                ))
             }
             Format::U64le => {
                 let val: u64 = ((self.apply_order(*bytes.get(3).expect("Unable to retrieve byte"))
@@ -581,7 +630,10 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as u64)
                         << 16)
                     + self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as u64;
-                Ok((format!("0x{:01$X}", val, 16), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 16),
+                    format!("{}", (val as f128 * coefficient as f128) as u64),
+                ))
             }
             Format::U128le => {
                 let val: u128 = ((self.apply_order(*bytes.get(7).expect("Unable to retrieve byte"))
@@ -600,24 +652,36 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as u128)
                         << 16)
                     + self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as u128;
-                Ok((format!("0x{:01$X}", val, 32), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 32),
+                    format!("{}", (val as f128 * coefficient as f128) as u128),
+                ))
             }
             Format::I8le => {
                 let val: i8 = (self.apply_order(*bytes.first().expect("Unable to retrieve byte"))
                     & 0xFF) as i8;
-                Ok((format!("{:#04X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#04X}", val),
+                    format!("{}", (val as f64 * coefficient) as i8),
+                ))
             }
             Format::I16le => {
                 let val: i16 =
                     self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as i16;
-                Ok((format!("{:#06X}", val), format!("{}", val)))
+                Ok((
+                    format!("{:#06X}", val),
+                    format!("{}", (val as f64 * coefficient) as i16),
+                ))
             }
             Format::I32le => {
                 let val: i32 = ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte"))
                     as i32)
                     << 16)
                     + (self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as i32);
-                Ok((format!("0x{:01$X}", val, 8), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 8),
+                    format!("{}", (val as f64 * coefficient) as i32),
+                ))
             }
             Format::I64le => {
                 let val: i64 = ((self.apply_order(*bytes.get(3).expect("Unable to retrieve byte"))
@@ -628,7 +692,10 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as i64)
                         << 16)
                     + self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as i64;
-                Ok((format!("0x{:01$X}", val, 16), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 16),
+                    format!("{}", (val as f128 * coefficient as f128) as i64),
+                ))
             }
             Format::I128le => {
                 let val: i128 = ((self.apply_order(*bytes.get(7).expect("Unable to retrieve byte"))
@@ -647,18 +714,23 @@ impl DataType {
                     + ((self.apply_order(*bytes.get(1).expect("Unable to retrieve byte")) as i128)
                         << 16)
                     + self.apply_order(*bytes.first().expect("Unable to retrieve byte")) as i128;
-                Ok((format!("0x{:01$X}", val, 32), format!("{}", val)))
+                Ok((
+                    format!("0x{:01$X}", val, 32),
+                    format!("{}", (val as f128 * coefficient as f128) as i128),
+                ))
             }
         }
     }
 
-    pub fn encode(&self, s: &str) -> anyhow::Result<Vec<u16>> {
+    pub fn encode(&self, s: &str, resolution: f64) -> anyhow::Result<Vec<u16>> {
+        let coefficient = 1f64 / resolution;
         match self.format {
             Format::F32 => {
                 let val: f32 = if let Some(s) = s.strip_prefix("0x") {
                     u32::from_str_radix(s, 16).map(f32::from_bits)?
                 } else {
-                    s.parse()?
+                    let val: f32 = s.parse()?;
+                    (val as f64 * coefficient) as f32
                 };
                 let val = val.to_bits();
                 Ok(vec![
@@ -670,7 +742,8 @@ impl DataType {
                 let val: f32 = if let Some(s) = s.strip_prefix("0x") {
                     u32::from_str_radix(s, 16).map(f32::from_bits)?
                 } else {
-                    s.parse()?
+                    let val: f32 = s.parse()?;
+                    (val as f64 * coefficient) as f32
                 };
                 let val = val.to_bits();
                 Ok(vec![
@@ -682,7 +755,8 @@ impl DataType {
                 let val: f64 = if let Some(s) = s.strip_prefix("0x") {
                     u64::from_str_radix(s, 16).map(f64::from_bits)?
                 } else {
-                    s.parse()?
+                    let val: f64 = s.parse()?;
+                    val * coefficient
                 };
                 let val = val.to_bits();
                 Ok(vec![
@@ -696,7 +770,8 @@ impl DataType {
                 let val: f64 = if let Some(s) = s.strip_prefix("0x") {
                     u64::from_str_radix(s, 16).map(f64::from_bits)?
                 } else {
-                    s.parse()?
+                    let val: f64 = s.parse()?;
+                    val * coefficient
                 };
                 let val = val.to_bits();
                 Ok(vec![
@@ -770,7 +845,8 @@ impl DataType {
                 let val: u8 = if let Some(s) = s.strip_prefix("0x") {
                     u8::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u8 = s.parse()?;
+                    (val as f64 * coefficient) as u8
                 };
                 Ok(vec![self.apply_order(val as u16)])
             }
@@ -778,7 +854,8 @@ impl DataType {
                 let val: u16 = if let Some(s) = s.strip_prefix("0x") {
                     u16::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u16 = s.parse()?;
+                    (val as f64 * coefficient) as u16
                 };
                 Ok(vec![self.apply_order(val)])
             }
@@ -786,7 +863,8 @@ impl DataType {
                 let val: u32 = if let Some(s) = s.strip_prefix("0x") {
                     u32::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u32 = s.parse()?;
+                    (val as f64 * coefficient) as u32
                 };
                 Ok(vec![
                     self.apply_order((val >> 16) as u16),
@@ -797,7 +875,8 @@ impl DataType {
                 let val: u64 = if let Some(s) = s.strip_prefix("0x") {
                     u64::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u64 = s.parse()?;
+                    (val as f128 * coefficient as f128) as u64
                 };
                 Ok(vec![
                     self.apply_order(((val >> 48) & 0xFFFF) as u16),
@@ -810,7 +889,8 @@ impl DataType {
                 let val: u128 = if let Some(s) = s.strip_prefix("0x") {
                     u128::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u128 = s.parse()?;
+                    (val as f128 * coefficient as f128) as u128
                 };
                 Ok(vec![
                     self.apply_order(((val >> 112) & 0xFFFF) as u16),
@@ -834,7 +914,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i8."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i8 = s.parse()?;
+                    (val as f64 * coefficient) as i8
                 };
                 Ok(vec![self.apply_order(val as u16)])
             }
@@ -849,7 +930,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i16."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i16 = s.parse()?;
+                    (val as f64 * coefficient) as i16
                 };
                 Ok(vec![self.apply_order(val as u16)])
             }
@@ -864,7 +946,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i32."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i32 = s.parse()?;
+                    (val as f64 * coefficient) as i32
                 };
                 Ok(vec![
                     self.apply_order((val >> 16) as u16),
@@ -882,7 +965,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i64."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i64 = s.parse()?;
+                    (val as f128 * coefficient as f128) as i64
                 };
                 Ok(vec![
                     self.apply_order(((val >> 48) & 0xFFFF) as u16),
@@ -902,7 +986,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i128."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i128 = s.parse()?;
+                    (val as f128 * coefficient as f128) as i128
                 };
                 Ok(vec![
                     self.apply_order(((val >> 112) & 0xFFFF) as u16),
@@ -919,7 +1004,8 @@ impl DataType {
                 let val: u32 = if let Some(s) = s.strip_prefix("0x") {
                     u32::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u32 = s.parse()?;
+                    (val as f128 * coefficient as f128) as u32
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),
@@ -930,7 +1016,8 @@ impl DataType {
                 let val: u64 = if let Some(s) = s.strip_prefix("0x") {
                     u64::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u64 = s.parse()?;
+                    (val as f128 * coefficient as f128) as u64
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),
@@ -943,7 +1030,8 @@ impl DataType {
                 let val: u128 = if let Some(s) = s.strip_prefix("0x") {
                     u128::from_str_radix(s, 16)?
                 } else {
-                    s.parse()?
+                    let val: u128 = s.parse()?;
+                    (val as f128 * coefficient as f128) as u128
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),
@@ -967,7 +1055,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i32."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i32 = s.parse()?;
+                    (val as f128 * coefficient as f128) as i32
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),
@@ -985,7 +1074,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i64."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i64 = s.parse()?;
+                    (val as f128 * coefficient as f128) as i64
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),
@@ -1005,7 +1095,8 @@ impl DataType {
                         return Err(anyhow::anyhow!("Value too large for i128."));
                     }
                 } else {
-                    s.parse()?
+                    let val: i128 = s.parse()?;
+                    (val as f128 * coefficient as f128) as i128
                 };
                 Ok(vec![
                     self.apply_order((val & 0xFFFF) as u16),

--- a/src/mem/register.rs
+++ b/src/mem/register.rs
@@ -112,6 +112,7 @@ pub struct Definition {
     description: Option<String>,
     #[serde(skip, default = "next_counter")]
     index: usize,
+    resolution: Option<f64>,
 }
 
 impl Definition {
@@ -129,6 +130,7 @@ impl Definition {
         r#virtual: Option<bool>,
         values: Option<Vec<Values>>,
         description: Option<String>,
+        resolution: Option<f64>,
     ) -> Self {
         Self {
             id,
@@ -144,6 +146,7 @@ impl Definition {
             values,
             index: next_counter(),
             description,
+            resolution,
         }
     }
 
@@ -202,6 +205,10 @@ impl Definition {
     pub fn get_index(&self) -> usize {
         self.index
     }
+
+    pub fn get_resolution(&self) -> f64 {
+        self.resolution.clone().unwrap_or(1.0)
+    }
 }
 
 #[derive(Clone)]
@@ -217,6 +224,7 @@ pub struct Register {
     values: Option<Vec<Values>>,
     description: Option<String>,
     index: usize,
+    resolution: f64,
 }
 
 impl Register {
@@ -250,7 +258,7 @@ impl Register {
             .collect();
         let value = definition
             .get_type()
-            .as_str(&bytes)
+            .as_str(&bytes, definition.get_resolution())
             .unwrap_or((str!("Invalid data"), String::new()));
 
         Self {
@@ -265,6 +273,7 @@ impl Register {
             values: definition.values().clone(),
             index: definition.get_index(),
             description: definition.description(),
+            resolution: definition.get_resolution(),
         }
     }
 
@@ -298,6 +307,10 @@ impl Register {
 
     pub fn r#type(&self) -> &DataType {
         &self.r#type
+    }
+
+    pub fn get_resolution(&self) -> f64 {
+        self.resolution
     }
 
     pub fn function_code(&self) -> FunctionCode {

--- a/src/rtu/client.rs
+++ b/src/rtu/client.rs
@@ -326,7 +326,7 @@ impl Client {
                     if let Ok(Ok(Ok(vec))) = modbus_result {
                         let _ = self.log_sender
                             .send(LogMsg::info(&format!(
-                                "Read address space [ {start:#06X} ({start}), {end:#06X} ({end}) ) successful.",
+                                "Read address space [ {start:#06X} ({start}), {end:#06X} ({end}) ) = {vec:?} successful.",
                                 start = op.start(),
                                 end = op.end()
                             )))

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -494,6 +494,11 @@ impl App {
                             Some(entry.1.r#type().label().to_string()),
                             None,
                         );
+                        self.edit_dialog.set(
+                            EditFieldType::DataResolution,
+                            Some(format!("{}", entry.1.get_resolution())),
+                            None,
+                        );
                         let e = entry.1.value().clone();
                         self.edit_dialog.set(
                             EditFieldType::Value,
@@ -516,7 +521,7 @@ impl App {
                 match self.popup {
                     Popup::Edit(ref register) => {
                         if let Some(input) = self.edit_dialog.get_input(EditFieldType::Value) {
-                            match register.r#type().encode(&input) {
+                            match register.r#type().encode(&input, register.get_resolution()) {
                                 Ok(v) => {
                                     if v.len() > register.raw().len() {
                                         self.log_entries.push(LogMsg::err(
@@ -748,7 +753,15 @@ fn render_register(f: &mut Frame, app: &mut App, area: Rect) {
         .bg(app.colors.selected_color.bg);
 
     let cols = [
-        "Access", "SlaveId", "Name", "Address", "Type", "Length", "Value", "Raw Data",
+        "Access",
+        "SlaveId",
+        "Name",
+        "Address",
+        "Type",
+        "Length",
+        "Value",
+        "Resolution",
+        "Raw Data",
     ];
     let header = cols
         .into_iter()
@@ -809,6 +822,7 @@ fn render_register(f: &mut Frame, app: &mut App, area: Rect) {
                 } else {
                     format!("{} [{}]", alias, value)
                 },
+                format!("{}", r.get_resolution()),
                 if app.show_as_hex {
                     format!("[ {:#06X} ]", r.raw().iter().format(", "))
                 } else {
@@ -827,6 +841,7 @@ fn render_register(f: &mut Frame, app: &mut App, area: Rect) {
             cols[5].width() as u16,
             cols[6].width() as u16,
             cols[7].width() as u16,
+            cols[8].width() as u16,
         ),
         |acc, item| {
             (
@@ -838,12 +853,21 @@ fn render_register(f: &mut Frame, app: &mut App, area: Rect) {
                 std::cmp::max(acc.5, item[5].width() as u16),
                 std::cmp::max(acc.6, item[6].width() as u16),
                 std::cmp::max(acc.7, item[7].width() as u16),
+                std::cmp::max(acc.8, item[8].width() as u16),
             )
         },
     );
 
-    app.register_table.table_max_width =
-        limits.0 + limits.1 + limits.2 + limits.3 + limits.4 + limits.5 + limits.6 + limits.7 + 25;
+    app.register_table.table_max_width = limits.0
+        + limits.1
+        + limits.2
+        + limits.3
+        + limits.4
+        + limits.5
+        + limits.6
+        + limits.7
+        + limits.8
+        + 25;
 
     let compact = app.is_compact;
     let rows = items.iter().enumerate().map(|(i, item)| {
@@ -868,7 +892,8 @@ fn render_register(f: &mut Frame, app: &mut App, area: Rect) {
             Constraint::Min(limits.4 + 1),
             Constraint::Min(limits.5 + 1),
             Constraint::Min(limits.6 + 1),
-            Constraint::Min(limits.7 + 3),
+            Constraint::Min(limits.7 + 1),
+            Constraint::Min(limits.8 + 3),
         ],
     )
     .header(header)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -42,7 +42,6 @@ const LOGGER_INFO_TEXT: &str = "(m) up | (n) down | (b) left | (,) right | (v) t
 const LOG_HEADER: &str = " Modbus Log";
 
 const ITEM_SPACING: usize = 1;
-const ITEM_HEIGHT: usize = 1 + 2 * ITEM_SPACING;
 
 enum LoopAction {
     Break,
@@ -260,7 +259,7 @@ impl App {
             mode,
             ordering: Order::Default,
             register_handler,
-            register_table: UiTable::new(len, ITEM_HEIGHT),
+            register_table: UiTable::new(len, 1),
             log_entries: Vec::new(),
             log_table: UiTable::new(history_len, 1),
             colors,
@@ -339,10 +338,7 @@ impl App {
             - 1;
 
         self.register_table.table_state.select(Some(i));
-        self.register_table.vertical_scroll = self
-            .register_table
-            .vertical_scroll
-            .position(i * ITEM_HEIGHT);
+        self.register_table.vertical_scroll = self.register_table.vertical_scroll.position(i);
     }
 
     pub fn move_top(&mut self) {
@@ -365,10 +361,7 @@ impl App {
                 .map(|i| std::cmp::min(i + 1, std::cmp::max(len, 1) - 1))
                 .unwrap_or(0);
             self.register_table.table_state.select(Some(i));
-            self.register_table.vertical_scroll = self
-                .register_table
-                .vertical_scroll
-                .position(i * ITEM_HEIGHT);
+            self.register_table.vertical_scroll = self.register_table.vertical_scroll.position(i);
         }
     }
 
@@ -381,10 +374,7 @@ impl App {
                 .map(|i| std::cmp::max(i, 1) - 1)
                 .unwrap_or(0);
             self.register_table.table_state.select(Some(i));
-            self.register_table.vertical_scroll = self
-                .register_table
-                .vertical_scroll
-                .position(i * ITEM_HEIGHT);
+            self.register_table.vertical_scroll = self.register_table.vertical_scroll.position(i);
         }
     }
 
@@ -630,9 +620,16 @@ impl App {
         let mut status = str!("");
         let mut action = AppAction::Exit;
 
+        let mut last_update = std::time::SystemTime::now();
+
         loop {
             if self.exec_lua {
-                lua_runtime.execute();
+                let now = std::time::SystemTime::now();
+                let diff = now.duration_since(last_update);
+                if diff.is_err() || diff.unwrap().as_secs() >= 1 {
+                    lua_runtime.execute();
+                    last_update = now;
+                }
             }
 
             // Update status
@@ -664,7 +661,7 @@ impl App {
             terminal.draw(|f| ui(f, &mut self, status.clone()))?;
 
             // Handle inputs
-            if event::poll(Duration::from_millis(50))? {
+            if event::poll(Duration::from_millis(200))? {
                 if let Event::Key(key) = event::read()? {
                     if key.kind == KeyEventKind::Press {
                         match self.popup {

--- a/src/widgets/edit_dialog.rs
+++ b/src/widgets/edit_dialog.rs
@@ -15,6 +15,7 @@ pub enum FieldType {
     Register,
     DataType,
     Value,
+    DataResolution,
 }
 
 pub struct EditDialog {
@@ -22,6 +23,7 @@ pub struct EditDialog {
     name: InputField,
     register: InputField,
     value_type: InputField,
+    value_resolution: InputField,
     input: InputField,
     selection: Selection,
     values: Vec<Values>,
@@ -50,6 +52,14 @@ impl EditDialog {
                 .disabled(),
             value_type: InputField::new()
                 .title(str!("Type"))
+                .bordered(true)
+                .margins(Margin {
+                    vertical: 0,
+                    horizontal: 1,
+                })
+                .disabled(),
+            value_resolution: InputField::new()
+                .title(str!("Resolution"))
                 .bordered(true)
                 .margins(Margin {
                     vertical: 0,
@@ -100,6 +110,7 @@ impl EditDialog {
             FieldType::Name => &mut self.name,
             FieldType::Register => &mut self.register,
             FieldType::DataType => &mut self.value_type,
+            FieldType::DataResolution => &mut self.value_resolution,
             FieldType::Value => &mut self.input,
         };
         if let Some(v) = input {
@@ -132,6 +143,7 @@ impl EditDialog {
             FieldType::Name => self.name.get_input(),
             FieldType::Register => self.register.get_input(),
             FieldType::DataType => self.value_type.get_input(),
+            FieldType::DataResolution => self.value_type.get_input(),
             FieldType::Value => {
                 if self.values.is_empty() {
                     self.input.get_input()
@@ -157,7 +169,7 @@ impl EditDialog {
 
 impl WidgetRef for EditDialog {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        let mut min_height = if self.values.is_empty() { 19 } else { 27 };
+        let mut min_height = if self.values.is_empty() { 23 } else { 31 };
         if self.description.is_some() {
             min_height += 9;
         }
@@ -202,6 +214,8 @@ impl WidgetRef for EditDialog {
                 Constraint::Length(1),
                 Constraint::Length(3),
                 Constraint::Length(1),
+                Constraint::Length(3),
+                Constraint::Length(1),
                 input_length,
             ])
             .split(inner.inner(Margin {
@@ -210,6 +224,8 @@ impl WidgetRef for EditDialog {
             }))
         } else {
             Layout::vertical([
+                Constraint::Length(3),
+                Constraint::Length(1),
                 Constraint::Length(3),
                 Constraint::Length(1),
                 Constraint::Length(3),
@@ -229,10 +245,11 @@ impl WidgetRef for EditDialog {
         self.name.render_ref(area[0], buf);
         self.register.render_ref(area[2], buf);
         self.value_type.render_ref(area[4], buf);
+        self.value_resolution.render_ref(area[6], buf);
         if self.values.is_empty() {
-            self.input.render_ref(area[6], buf);
+            self.input.render_ref(area[8], buf);
         } else {
-            self.selection.render_ref(area[6], buf);
+            self.selection.render_ref(area[8], buf);
         }
         if let Some(ref c) = self.description {
             let area = Layout::vertical([Constraint::Length(8)]).split(area[8].inner(Margin {


### PR DESCRIPTION
Closes: #14 

<img width="959" height="82" alt="image" src="https://github.com/user-attachments/assets/4321e5e5-c5d9-4c65-aead-9d0eb1ed86fd" />

The resolution can be configured and is displayed in the overview.

<img width="268" height="268" alt="image" src="https://github.com/user-attachments/assets/5be01570-e4d2-4bf4-89d0-fd7447abb94e" />

And it is displayed in the edit dialog. The value in brackets is the value respective to the resolution. By default the resolution is 1.