### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/TumbleOwlee/ferrowl/security/code-scanning/2](https://github.com/TumbleOwlee/ferrowl/security/code-scanning/2)

In general, to fix this type of problem you add a `permissions:` block either at the top level of the workflow (applies to all jobs) or inside individual jobs, explicitly granting only the scopes that the job actually needs. This prevents the `GITHUB_TOKEN` from inheriting broad repository defaults and documents the intended privileges.

For this specific workflow, the `build` job needs to read the repository (for `actions/checkout`) and, when on `main`, update a tag using `EndBug/latest-tag`. Tag creation/modification requires write access to repository contents, so this job needs `contents: write`. No other permissions appear necessary. The minimal, non-breaking fix is to add a `permissions:` block under `jobs.build` (indented to the same level as `runs-on:`) setting `contents: write`. There is only one job, so adding it at the job level is clear and localized.

Concretely: edit `.github/workflows/nightly.yml`. Under line 14 (`runs-on: ubuntu-latest`), insert a new line `permissions:` followed by an indented `contents: write`. No imports or additional methods are required, since this is pure YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
