### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: release ${{ matrix.target }}


### PR DESCRIPTION
Potential fix for [https://github.com/TumbleOwlee/ferrowl/security/code-scanning/1](https://github.com/TumbleOwlee/ferrowl/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/release.yml` so token scopes are documented and restricted.  
Best single fix (without changing intended behavior): set workflow-level permissions with:
- `contents: write` (required for creating/updating release assets)
- no other scopes unless clearly needed.

Place this block at the top level (after `on:` block and before `jobs:`), so it applies to all jobs in this workflow. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
