### PR TITLE
Allow non-empty, non-existing config path in new dialog

### DIFF
--- a/ferrowl-reg/src/codec.rs
+++ b/ferrowl-reg/src/codec.rs
@@ -98,7 +98,7 @@ pub fn encode(format: &Format, s: &str) -> anyhow::Result<Vec<u16>> {
             } else {
                 $s.parse()?
             };
-            let val = ((((val as u128) << $bf.shift()) & $bf.mask)) as $ty;
+            let val = (((val as u128) << $bf.shift()) & $bf.mask) as $ty;
             Ok(match $e {
                 Endian::Big => val.to_be_bytes().iter().into_vec()?,
                 Endian::Little => val.to_le_bytes().iter().into_vec()?,
@@ -117,8 +117,7 @@ pub fn encode(format: &Format, s: &str) -> anyhow::Result<Vec<u16>> {
             } else {
                 $s.parse()?
             };
-            let val =
-                (((((val as $uty) as u128) << $bf.shift()) & $bf.mask) as $uty) as $ty;
+            let val = (((((val as $uty) as u128) << $bf.shift()) & $bf.mask) as $uty) as $ty;
             Ok(match $e {
                 Endian::Big => val.to_be_bytes().iter().into_vec()?,
                 Endian::Little => val.to_le_bytes().iter().into_vec()?,
@@ -167,7 +166,7 @@ pub fn encode(format: &Format, s: &str) -> anyhow::Result<Vec<u16>> {
             } else {
                 s.parse()?
             };
-            let val = ((((val as u128) << bf.shift()) & bf.mask)) as u8;
+            let val = (((val as u128) << bf.shift()) & bf.mask) as u8;
             Ok(match e {
                 Endian::Big => vec![val as u16],
                 Endian::Little => vec![(val as u16) << 8],
@@ -625,7 +624,10 @@ mod tests {
     #[test]
     fn ut_encode_u16_high_byte_field() {
         // value 0x12 placed into mask 0xFF00 → word 0x1200, other bits zero.
-        assert_eq!(reg(u16_be_mask(0xFF00)).encode("0x12").unwrap(), vec![0x1200u16]);
+        assert_eq!(
+            reg(u16_be_mask(0xFF00)).encode("0x12").unwrap(),
+            vec![0x1200u16]
+        );
     }
 
     #[test]
@@ -658,7 +660,11 @@ mod tests {
         // Full U16 mask narrows to 0xFFFF.
         assert_eq!(reg(u16_be_mask(u128::MAX)).write_mask(), vec![0xFFFFu16]);
         // U32 big-endian mask spans two words.
-        let r = reg(Format::U32((Endian::Big, res(), BitField { mask: 0xFFFF_0000 })));
+        let r = reg(Format::U32((
+            Endian::Big,
+            res(),
+            BitField { mask: 0xFFFF_0000 },
+        )));
         assert_eq!(r.write_mask(), vec![0xFFFFu16, 0x0000u16]);
         // U8 full mask only owns the low byte of its word.
         assert_eq!(reg(u8_be()).write_mask(), vec![0x00FFu16]);

--- a/ferrowl-reg/src/format.rs
+++ b/ferrowl-reg/src/format.rs
@@ -243,9 +243,18 @@ mod tests {
             Format::U16((Endian::Big, res(), bitfield.clone())).bitfield(),
             bitfield
         );
-        assert_eq!(Format::U16((Endian::Big, res(), bitfield)).bitfield().shift(), 8);
+        assert_eq!(
+            Format::U16((Endian::Big, res(), bitfield))
+                .bitfield()
+                .shift(),
+            8
+        );
         assert!(Format::F32((Endian::Big, res())).bitfield().is_full());
-        assert!(Format::Ascii((Alignment::Left, Width(1))).bitfield().is_full());
+        assert!(
+            Format::Ascii((Alignment::Left, Width(1)))
+                .bitfield()
+                .is_full()
+        );
     }
 
     #[test]

--- a/ferrowl-ui/examples/dialog.rs
+++ b/ferrowl-ui/examples/dialog.rs
@@ -13,7 +13,10 @@ use ferrowl_ui::{
     style::{InputFieldStyle, SelectionStyle},
     traits::{HandleEvents, Margins},
     types::Border,
-    widgets::{InputField, InputFieldBuilder, Selection, SelectionBuilder, Validate, Widget},
+    widgets::{
+        InputField, InputFieldBuilder, Selection, SelectionBuilder, Validate, ValidateResult,
+        Widget,
+    },
 };
 
 use ferrowl_derive::{Focus, focusable};
@@ -22,16 +25,16 @@ use ferrowl_derive::{Focus, focusable};
 struct Day {}
 
 impl Validate for Day {
-    fn validate(input: &str) -> Result<(), String> {
+    fn validate(input: &str) -> ValidateResult {
         let day = input.parse::<usize>();
         if let Ok(day) = day {
             if day < 32 {
-                Ok(())
+                ValidateResult::Success
             } else {
-                Err("Invalid day input".into())
+                ValidateResult::Error("Invalid day input".into())
             }
         } else {
-            Err("Input is not numerical".into())
+            ValidateResult::Error("Input is not numerical".into())
         }
     }
 }
@@ -40,12 +43,12 @@ impl Validate for Day {
 struct Year {}
 
 impl Validate for Year {
-    fn validate(input: &str) -> Result<(), String> {
+    fn validate(input: &str) -> ValidateResult {
         let year = input.parse::<usize>();
         if year.is_ok() {
-            Ok(())
+            ValidateResult::Success
         } else {
-            Err("Input is not numerical".into())
+            ValidateResult::Error("Input is not numerical".into())
         }
     }
 }
@@ -54,16 +57,16 @@ impl Validate for Year {
 struct Code {}
 
 impl Validate for Code {
-    fn validate(input: &str) -> Result<(), String> {
+    fn validate(input: &str) -> ValidateResult {
         let code = input.parse::<usize>();
         if let Ok(code) = code {
             if (10000..=99999).contains(&code) {
-                Ok(())
+                ValidateResult::Success
             } else {
-                Err("Invalid postal code".into())
+                ValidateResult::Error("Invalid postal code".into())
             }
         } else {
-            Err("Input is not numerical".into())
+            ValidateResult::Error("Input is not numerical".into())
         }
     }
 }
@@ -100,11 +103,11 @@ struct Person {
 
 impl App {
     fn result(&self) -> Result<Person, String> {
-        if Day::validate(self.day.state.input()).is_err() {
+        if let ValidateResult::Error(_) = Day::validate(self.day.state.input()) {
             Err("Invalid input for day".into())
-        } else if Year::validate(self.year.state.input()).is_err() {
+        } else if let ValidateResult::Error(_) = Year::validate(self.year.state.input()) {
             Err("Invalid input for year".into())
-        } else if Code::validate(self.code.state.input()).is_err() {
+        } else if let ValidateResult::Error(_) = Code::validate(self.code.state.input()) {
             Err("Invalid input for postal code".into())
         } else {
             let name = format!(

--- a/ferrowl-ui/src/style/input_field.rs
+++ b/ferrowl-ui/src/style/input_field.rs
@@ -8,17 +8,24 @@ use ratatui::style::Style;
 #[derive(Builder, Debug, Clone, Getters, Setters, CopyGetters)]
 #[getset(set = "pub")]
 pub struct InputFieldStyle {
+    #[getset(get = "pub")]
     #[builder(default = "Style::default().fg(COLOR_SCHEME.text).bg(COLOR_SCHEME.bg)")]
     pub general: Style,
+    #[getset(get = "pub")]
     #[builder(default = "Style::default().fg(COLOR_SCHEME.hi).bg(COLOR_SCHEME.bg)")]
     pub focused: Style,
-    #[builder(default = "Style::default().fg(COLOR_SCHEME.placeholder)")]
+    #[getset(get = "pub")]
+    #[builder(default = "Style::default().fg(COLOR_SCHEME.placeholder).bg(COLOR_SCHEME.bg)")]
     pub placeholder: Style,
+    #[getset(get = "pub")]
     #[builder(default = "Style::default().fg(COLOR_SCHEME.text_dark).bg(COLOR_SCHEME.hi)")]
     pub cursor: Style,
     #[getset(get = "pub")]
     #[builder(default = "Style::default().fg(COLOR_SCHEME.error).bg(COLOR_SCHEME.bg)")]
     pub error: Style,
+    #[getset(get = "pub")]
+    #[builder(default = "Style::default().fg(COLOR_SCHEME.success).bg(COLOR_SCHEME.bg)")]
+    pub success: Style,
 }
 
 impl Default for InputFieldStyle {

--- a/ferrowl-ui/src/widgets/input_field.rs
+++ b/ferrowl-ui/src/widgets/input_field.rs
@@ -14,6 +14,12 @@ use crate::traits::Margins;
 use crate::types::Border;
 use crate::widgets::Title;
 
+pub enum ValidateResult {
+    Success,
+    None,
+    Error(String),
+}
+
 /// Validates raw input text for an [`InputField`].
 ///
 /// Implemented for `String` (always valid) and all numeric primitives
@@ -21,23 +27,23 @@ use crate::widgets::Title;
 /// the field's error style.
 pub trait Validate {
     /// Returns `Err` with a message if `input` is not a valid value.
-    fn validate(input: &str) -> Result<(), String>;
+    fn validate(input: &str) -> ValidateResult;
 }
 
 impl Validate for String {
-    fn validate(_input: &str) -> Result<(), String> {
-        Ok(())
+    fn validate(_input: &str) -> ValidateResult {
+        ValidateResult::None
     }
 }
 
 macro_rules! generate_validate {
     ($v:ty) => {
         impl Validate for $v {
-            fn validate(input: &str) -> Result<(), String> {
+            fn validate(input: &str) -> ValidateResult {
                 let result = input.parse::<$v>();
                 match result {
-                    Ok(_) => Ok(()),
-                    Err(e) => Err(format!("{}", e)),
+                    Ok(_) => ValidateResult::None,
+                    Err(e) => ValidateResult::Error(format!("{}", e)),
                 }
             }
         }
@@ -178,22 +184,13 @@ where
         ])
         .split(area)[1];
 
-        let valid = if state.input().is_empty() {
-            Ok(())
-        } else {
-            ValueType::validate(state.input())
-        };
+        let valid = ValueType::validate(state.input());
 
         // Create block if border is required
         let border_style = if state.focused() && !state.disabled() {
             self.style.focused
         } else {
             self.style.general
-        };
-        let border_style = if valid.is_ok() {
-            border_style
-        } else {
-            self.style.error
         };
         let area = crate::widgets::render_border(
             area,
@@ -246,10 +243,12 @@ where
 
         let text_style = if state.input().is_empty() {
             self.style.placeholder
-        } else if valid.is_ok() {
-            self.style.general
         } else {
-            self.style.error
+            match valid {
+                ValidateResult::Success => self.style.success,
+                ValidateResult::None => self.style.general,
+                ValidateResult::Error(_) => self.style.error,
+            }
         };
 
         let mut text_area = area;

--- a/ferrowl-ui/src/widgets/mod.rs
+++ b/ferrowl-ui/src/widgets/mod.rs
@@ -13,11 +13,11 @@ pub use button::*;
 pub use code_input_field::*;
 use crossterm::event::{KeyCode, KeyModifiers};
 pub use input_field::*;
-pub use scrolling_tabs::*;
 use ratatui::layout::{HorizontalAlignment, Margin};
 use ratatui::style::Style;
 use ratatui::widgets::{Block, StatefulWidget, Widget as RenderWidget};
 use ratatui::{buffer::Buffer, layout::Rect};
+pub use scrolling_tabs::*;
 
 use crate::types::Border;
 

--- a/ferrowl/src/app/commands.rs
+++ b/ferrowl/src/app/commands.rs
@@ -290,7 +290,9 @@ impl App {
                     let mut guard = memory.write().await;
                     // Read-modify-write: merge the masked field into the existing word so a
                     // sibling register aliasing this address keeps its bits.
-                    let old = guard.read_unchecked(key.clone(), &range).unwrap_or_default();
+                    let old = guard
+                        .read_unchecked(key.clone(), &range)
+                        .unwrap_or_default();
                     let merged = register.merge_write(&old, &raw);
                     guard.write_unchecked(key, &range, &merged)
                 };

--- a/ferrowl/src/app/overlay.rs
+++ b/ferrowl/src/app/overlay.rs
@@ -267,7 +267,8 @@ impl App {
 
     /// Open the new-module dialog (`:n`/`:new`).
     pub(super) fn enter_new(&mut self) {
-        let dialog = SetupDialog::create((DEFAULT_TIMEOUT_MS, DEFAULT_DELAY_MS, DEFAULT_INTERVAL_MS));
+        let dialog =
+            SetupDialog::create((DEFAULT_TIMEOUT_MS, DEFAULT_DELAY_MS, DEFAULT_INTERVAL_MS));
         self.overlay = Some(Overlay::Setup(dialog));
         self.focus = Focus::Dialog;
     }
@@ -564,8 +565,10 @@ impl App {
         self.tabs[active].device.interval_ms = values.interval_ms;
         self.tabs[active].device.read_ranges = values.read_ranges.clone();
 
-        let timing =
-            crate::module::Module::resolve_timing(&self.tabs[active].spec, &self.tabs[active].device);
+        let timing = crate::module::Module::resolve_timing(
+            &self.tabs[active].spec,
+            &self.tabs[active].device,
+        );
         if let Err(e) = self.tabs[active]
             .module
             .reconfigure(&values.endpoint, values.role, timing, values.read_ranges)

--- a/ferrowl/src/app/render.rs
+++ b/ferrowl/src/app/render.rs
@@ -58,12 +58,15 @@ pub(super) fn render(
         })
         .build()
         .unwrap();
-    let mut status_label = if online {
-        "ONLINE".to_string()
-    } else {
-        "OFFLINE".to_string()
-    };
-    StatefulWidget::render(&status, status_area, buf, &mut status_label);
+
+    if !tabs.is_empty() {
+        let mut status_label = if online {
+            "ONLINE".to_string()
+        } else {
+            "OFFLINE".to_string()
+        };
+        StatefulWidget::render(&status, status_area, buf, &mut status_label);
+    }
 
     if let Some(tab) = tabs.get_mut(active) {
         tab.table.table.state.set_focused(focus == Focus::Table);

--- a/ferrowl/src/config/mod.rs
+++ b/ferrowl/src/config/mod.rs
@@ -39,4 +39,3 @@ pub fn load_device(path: &str) -> Result<DeviceConfig, ConfigError> {
 pub fn load_session(path: &str) -> Result<Session, ConfigError> {
     load(path)
 }
-

--- a/ferrowl/src/dialog/edit/add_value.rs
+++ b/ferrowl/src/dialog/edit/add_value.rs
@@ -8,7 +8,7 @@ use ferrowl_ui::{
     state::{InputFieldState, InputFieldStateBuilder},
     style::{InputFieldStyle, TextStyle},
     types::Border,
-    widgets::{InputField, InputFieldBuilder, Text, TextBuilder, Validate, Widget},
+    widgets::{InputField, InputFieldBuilder, Text, TextBuilder, Validate, ValidateResult, Widget},
 };
 use ratatui::{
     buffer::Buffer,
@@ -125,7 +125,7 @@ impl AddNamedValueDialog {
     }
 
     fn validate(&self) -> Result<(), String> {
-        if let Err(e) = String::validate(self.label.state.input()) {
+        if let ValidateResult::Error(e) = String::validate(self.label.state.input()) {
             return Err(format!("Label: {e}"));
         }
         if self.label.state.input().trim().is_empty() {

--- a/ferrowl/src/dialog/edit/input.rs
+++ b/ferrowl/src/dialog/edit/input.rs
@@ -21,7 +21,8 @@ use ferrowl_ui::{
     types::Border,
     widgets::{
         Button, ButtonBuilder, CodeInputField, CodeInputFieldBuilder, GetValue, InputField,
-        InputFieldBuilder, Selection, SelectionBuilder, Text, TextBuilder, Validate, Widget,
+        InputFieldBuilder, Selection, SelectionBuilder, Text, TextBuilder, Validate,
+        ValidateResult, Widget,
     },
 };
 use ratatui::{
@@ -142,9 +143,9 @@ impl EditInputDialog {
     }
 
     fn validate(&self) -> Result<(), String> {
-        if let Err(e) = String::validate(self.label.state.input()) {
+        if let ValidateResult::Error(e) = String::validate(self.label.state.input()) {
             return Err(format!("Label: {e}"));
-        } else if let Err(e) = u8::validate(self.slave_id.state.input()) {
+        } else if let ValidateResult::Error(e) = u8::validate(self.slave_id.state.input()) {
             return Err(format!("Slave ID: {e}"));
         } else if let Err(e) = parse_address(self.address.state.input()) {
             return Err(format!("Address: {e}"));
@@ -153,7 +154,9 @@ impl EditInputDialog {
         if !self.is_boolean_kind() {
             match self.value_type.state.values()[self.value_type.state.selection()] {
                 ValueType::Number => {
-                    if let Err(e) = f64::validate(self.number_resolution.state.input()) {
+                    if let ValidateResult::Error(e) =
+                        f64::validate(self.number_resolution.state.input())
+                    {
                         return Err(format!("Resolution: {e}"));
                     }
                     let format =
@@ -170,7 +173,8 @@ impl EditInputDialog {
                     }
                 }
                 ValueType::Text => {
-                    if let Err(e) = usize::validate(self.text_width.state.input()) {
+                    if let ValidateResult::Error(e) = usize::validate(self.text_width.state.input())
+                    {
                         return Err(format!("Width: {e}"));
                     }
                 }
@@ -731,7 +735,7 @@ impl EditInputDialog {
                     .unwrap(),
                 widget: InputFieldBuilder::default()
                     .border(Border::Full(Margin::new(1, 0)))
-                    .title(Some(("Resolution", HorizontalAlignment::Right).into()))
+                    .title(Some(("Resolution", HorizontalAlignment::Center).into()))
                     .margin(Margin {
                         vertical: 0,
                         horizontal: 1,
@@ -1043,7 +1047,10 @@ impl EditInputDialog {
                 set_input(&mut dialog.number_resolution, &resolution.0.to_string());
                 // Show the mask only when it actually selects a sub-field.
                 if !bitfield.is_full() {
-                    set_input(&mut dialog.number_bitmask, &format!("0x{:X}", bitfield.mask));
+                    set_input(
+                        &mut dialog.number_bitmask,
+                        &format!("0x{:X}", bitfield.mask),
+                    );
                 }
             }
         }

--- a/ferrowl/src/dialog/edit/selection.rs
+++ b/ferrowl/src/dialog/edit/selection.rs
@@ -29,7 +29,8 @@ use ferrowl_ui::{
     types::Border,
     widgets::{
         Button, ButtonBuilder, CodeInputField, CodeInputFieldBuilder, GetValue, InputField,
-        InputFieldBuilder, Selection, SelectionBuilder, Text, TextBuilder, Validate, Widget,
+        InputFieldBuilder, Selection, SelectionBuilder, Text, TextBuilder, Validate,
+        ValidateResult, Widget,
     },
 };
 use ratatui::{
@@ -142,9 +143,9 @@ where
 
 impl<V: ToLabel + Clone> EditSelectionDialog<V> {
     fn validate(&self) -> Result<(), String> {
-        if let Err(e) = String::validate(self.label.state.input()) {
+        if let ValidateResult::Error(e) = String::validate(self.label.state.input()) {
             return Err(format!("Label: {e}"));
-        } else if let Err(e) = u8::validate(self.slave_id.state.input()) {
+        } else if let ValidateResult::Error(e) = u8::validate(self.slave_id.state.input()) {
             return Err(format!("Slave ID: {e}"));
         } else if let Err(e) = parse_address(self.address.state.input()) {
             return Err(format!("Address: {e}"));
@@ -152,7 +153,9 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
 
         match self.value_type.state.values()[self.value_type.state.selection()] {
             ValueType::Number => {
-                if let Err(e) = f64::validate(self.number_resolution.state.input()) {
+                if let ValidateResult::Error(e) =
+                    f64::validate(self.number_resolution.state.input())
+                {
                     return Err(format!("Resolution: {e}"));
                 }
                 let format =
@@ -164,7 +167,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
                 }
             }
             ValueType::Text => {
-                if let Err(e) = usize::validate(self.text_width.state.input()) {
+                if let ValidateResult::Error(e) = usize::validate(self.text_width.state.input()) {
                     return Err(format!("Width: {e}"));
                 }
             }
@@ -1056,7 +1059,10 @@ impl EditSelectionDialog<NamedValue> {
                 set_input(&mut dialog.number_resolution, &resolution.0.to_string());
                 // Show the mask only when it actually selects a sub-field.
                 if !bitfield.is_full() {
-                    set_input(&mut dialog.number_bitmask, &format!("0x{:X}", bitfield.mask));
+                    set_input(
+                        &mut dialog.number_bitmask,
+                        &format!("0x{:X}", bitfield.mask),
+                    );
                 }
             }
         }

--- a/ferrowl/src/dialog/setup.rs
+++ b/ferrowl/src/dialog/setup.rs
@@ -14,7 +14,7 @@ use ferrowl_ui::{
     types::Border,
     widgets::{
         GetValue, InputField, InputFieldBuilder, Selection, SelectionBuilder, Text, TextBuilder,
-        Widget,
+        Validate, ValidateResult, Widget,
     },
 };
 use ferrowl_util::convert::FileType;
@@ -134,13 +134,38 @@ pub struct SetupOutcome {
     pub device: Option<(String, DeviceConfig)>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ConfigPath;
+
+impl Validate for ConfigPath {
+    fn validate(input: &str) -> ValidateResult {
+        let input = input.trim();
+        let path = std::path::Path::new(input);
+
+        if input.is_empty() {
+            ValidateResult::None
+        } else if let Some(_) = FileType::from_path(input) {
+            if path.exists() {
+                match crate::config::load_device(input) {
+                    Ok(_) => ValidateResult::Success,
+                    Err(e) => ValidateResult::Error(format!("Config: {e}")),
+                }
+            } else {
+                ValidateResult::None
+            }
+        } else {
+            ValidateResult::Error("Invalid filetype, TOML or JSON expected.".to_string())
+        }
+    }
+}
+
 #[focusable]
 #[derive(Builder, Focus)]
 pub struct SetupDialog {
     #[focus]
     pub name: Widget<InputFieldState, InputField<String>>,
     #[focus]
-    pub config_path: Widget<InputFieldState, InputField<String>>,
+    pub config_path: Widget<InputFieldState, InputField<ConfigPath>>,
     #[focus]
     pub transport: Widget<SelectionState<Transport>, Selection<Transport>>,
     #[focus]
@@ -245,7 +270,7 @@ impl SetupDialog {
         let mut name_field = input("Name", None, "module name", &input_style, true);
         set_input(&mut name_field, name);
         let mut config_path_field = input(
-            "Config Path (optional)",
+            "Config Path [TOML/JSON] (optional)",
             None,
             "device.toml",
             &input_style,
@@ -378,8 +403,8 @@ impl SetupDialog {
         let values = self.values()?;
         let device = if self.mode == DialogMode::New {
             let path = self.config_path.state.input().trim().to_string();
-            if path.is_empty() {
-                Some(("".to_string(), DeviceConfig::default()))
+            if path.is_empty() || !std::path::Path::new(&path).exists() {
+                Some((path, DeviceConfig::default()))
             } else {
                 let device =
                     crate::config::load_device(&path).map_err(|e| format!("Config: {e}"))?;
@@ -666,13 +691,13 @@ fn select_u8(state: &mut SelectionState<U8Choice>, current: Option<u8>) {
     }
 }
 
-fn input(
+fn input<T: Validate + Clone>(
     title: &str,
     title_alignment: Option<HorizontalAlignment>,
     placeholder: &str,
     style: &InputFieldStyle,
     focused: bool,
-) -> Widget<InputFieldState, InputField<String>> {
+) -> Widget<InputFieldState, InputField<T>> {
     Widget {
         state: InputFieldStateBuilder::default()
             .focused(focused)
@@ -722,7 +747,10 @@ fn selection<T: ToLabel + Clone>(
     }
 }
 
-fn set_input(widget: &mut Widget<InputFieldState, InputField<String>>, value: &str) {
+fn set_input<T: Validate + Clone>(
+    widget: &mut Widget<InputFieldState, InputField<T>>,
+    value: &str,
+) {
     widget.state.set_input(value.to_string());
     widget.state.set_cursor(value.chars().count());
 }

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -254,7 +254,11 @@ mod tests {
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(addr))
-            .format(Format::U16((Endian::Big, Resolution(1.0), BitField::default())))
+            .format(Format::U16((
+                Endian::Big,
+                Resolution(1.0),
+                BitField::default(),
+            )))
             .build()
             .unwrap()
     }
@@ -298,7 +302,11 @@ mod tests {
                 .access(Access::ReadWrite)
                 .kind(Kind::HoldingRegister)
                 .address(ferrowl_reg::Address::Virtual)
-                .format(Format::U16((Endian::Big, Resolution(1.0), BitField::default())))
+                .format(Format::U16((
+                    Endian::Big,
+                    Resolution(1.0),
+                    BitField::default(),
+                )))
                 .build()
                 .unwrap(),
         );

--- a/ferrowl/src/module.rs
+++ b/ferrowl/src/module.rs
@@ -153,7 +153,10 @@ impl Module {
                 .timeout_ms
                 .or(device.timeout_ms)
                 .unwrap_or(DEFAULT_TIMEOUT_MS),
-            delay_ms: spec.delay_ms.or(device.delay_ms).unwrap_or(DEFAULT_DELAY_MS),
+            delay_ms: spec
+                .delay_ms
+                .or(device.delay_ms)
+                .unwrap_or(DEFAULT_DELAY_MS),
             interval_ms: spec
                 .interval_ms
                 .or(device.interval_ms)
@@ -951,7 +954,11 @@ mod tests {
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))
-            .format(Format::U16((Endian::Big, Resolution(1.0), BitField::default())))
+            .format(Format::U16((
+                Endian::Big,
+                Resolution(1.0),
+                BitField::default(),
+            )))
             .build()
             .unwrap();
 


### PR DESCRIPTION
Previously the config path could just be either empty or would have to point to a valid device configuration. This way it you could only configure the config path to a new file (for save by `:wd`) after confirming a new module with empty path and editing it afterwards.

Now it is possible to input any path to a non-existing TOML or JSON file that is used by `:wd` directly in the new dialog. The workaround is not needed anymore.

Additionally the input field validation is reworked, including the `Validate` trait. This way, it is possible to return one of three states: `Success`, `None` and `Error`. In case of `Success` the text is colored green, for `None` it stays default, and for `Error` is turns red (default colors, can be changed by the `InputFieldStyle`). Also a `ConfigPath` type with an updated `Validate` implementation is now used for the config path inputfield. It more precisely colorizes the input to give better user feedback.

Closes: #27 