### PR TITLE
Display non-scaled values in input fields of dialogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Ferrowl
+
+Thanks for your interest in contributing! This document covers the essentials to get you productive quickly.
+
+## Setup
+
+Ferrowl is written in Rust (stable toolchain, pinned via `rust-toolchain.toml`). Install the toolchain via [rustup.rs](https://rustup.rs/), then:
+
+```sh
+git clone <your-fork>
+cd ferrowl
+cargo build --release
+```
+
+Run the app during development with `cargo run --release -- --demo` (starts a demo server) or see `--help` for all runtime options.
+
+## Project Layout
+
+The repository is a Cargo workspace building the `ferrowl` binary. See the [Architecture section](./README.md#architecture) of the README for the crate dependency graph and each crate's responsibility.
+
+## Before Submitting
+
+Please make sure the following pass locally:
+
+```sh
+cargo check
+cargo test --workspace
+cargo clippy --workspace
+cargo fmt --check
+```
+
+CI runs `cargo check` and `cargo test` on every push (`check` workflow); a `nightly` workflow (only run on `main`) builds the prebuilt executables published on the Release page.
+
+## Pull Requests
+
+- Branch off `main` and open your PR against `main`.
+- Keep PRs focused — one feature or fix per PR.
+- Add or update tests for behavior changes; the existing unit tests live in `#[cfg(test)]` modules next to the code (`ut_*` naming).
+- Update the README when you change commands, keybindings, configuration fields or the Lua API.
+
+## Reporting Issues
+
+Open a GitHub issue with steps to reproduce, the ferrowl version (or commit), and your platform. For TUI rendering issues, the terminal emulator and size are helpful too.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ferrowl is a TUI application, written in Rust, to provide Modbus Client and Serv
 If you prefer a GUI application, this tool is not the right choice. In these cases refer to GUI application like [QModbus](https://github.com/ed-chemnitz/qmodbus/).
 
 > [!WARNING]
-> Prior to **v0.4.0** the application was based on a draft implementation. Over time additional features were added but messed up the architecture and made it difficult to add new views, dialogs and support of multiple instances. Thus, starting with **v0.4.0** the application got a full rewrite. This also affects the configurations files and their management. You can migrate configuration files create by versions prior to **v0.4.0** using the `migrate` subcommand - e.g. `ferrowl migrate -i old-config.json -o new-config.json` (supports JSON and TOML as input and output).
+> Prior to **v0.4.0** the application was based on a draft implementation. Over time additional features were added but messed up the architecture and made it difficult to add new views, dialogs and support of multiple instances. Thus, starting with **v0.4.0** the application got a full rewrite. This also affects the configuration files and their management. You can migrate configuration files created by versions prior to **v0.4.0** using the `migrate` subcommand - e.g. `ferrowl migrate -i old-config.json -o new-config.json` (supports JSON and TOML as input and output).
 
 ## Goal
 
@@ -91,7 +91,7 @@ If started without any additional parameters, the module setup dialog is shown. 
 | `:set <reg> <val>` | Write register value |
 | `:s \| :save \| :w \| :write [PATH]` | Save session |
 | `:wd \| :write-device [PATH]` | Save device configuration |
-| `:log [FILE]` | Set log output file for the active tab (`:log clear` clears the ring log) |
+| `:log <FILE>\|clear` | Set log output file for the active tab (`:log clear` clears the ring log) |
 | `:lua start\|stop` | Start/Stop lua execution |
 | `:reload` | Reload device configuration |
 | `:compact` | Toggle compact table mode |
@@ -114,6 +114,7 @@ If started without any additional parameters, the module setup dialog is shown. 
 | `g` | Move to top of table |
 | `0` | Move to left edge of table |
 | `$` | Move to right edge of table |
+| `z` | Toggle compact table mode |
 | `gt \| ]` | Switch to next tab |
 | `gT \| [` | Switch to previous tab |
 
@@ -169,18 +170,31 @@ If started without any additional parameters, the module setup dialog is shown. 
 
 ### Session Configuration
 
-The seesion configuration can be saved using `:write` and contains the module configuration consisting of the name, path to the device configuration, the role and endpoint information.
+The session configuration can be saved using `:write` and contains the module configuration consisting of the name, path to the device configuration, the role and endpoint information. Each module may also override the device timings per instance via `timeout_ms`, `delay_ms` and `interval_ms`.
 
 ```toml
 [[modules]]
 name = "evse-1"
 device = "configs/evse.toml"
 role = "server"
+interval_ms = 500      # optional per-instance timing override
 
 [modules.endpoint]
 transport = "tcp"
 ip = "127.0.0.1"
 port = 5020
+```
+
+Besides TCP, a serial RTU endpoint is supported. `parity` (`even`, `odd` or `none`, case-insensitive), `data_bits` and `stop_bits` are optional; `baud_rate` defaults to `19200`.
+
+```toml
+[modules.endpoint]
+transport = "rtu"
+path = "/dev/ttyUSB0"
+baud_rate = 19200
+parity = "none"
+data_bits = 8
+stop_bits = 1
 ```
 
 ### Device Configuration
@@ -239,7 +253,8 @@ values = [
 | `virtual` | `false` | Hold the value locally instead of mapping it to a Modbus address. |
 | `access` | `ReadWrite` | `ReadOnly`, `WriteOnly` or `ReadWrite`. |
 | `endian` | `Big` | Byte order: `Big` or `Little`. |
-| `resolution` | `1.0` | Scaling factor applied to the raw value. |
+| `resolution` | `1.0` | Scaling factor applied to the raw value for display; edit dialogs and `:set` take the unscaled raw value. |
+| `bitmask` | *(none)* | Bit-field mask for integer types, as a hex (`"0xFF00"`) or decimal string; the shift is derived from the mask's trailing zeros. Ignored for float and ASCII types. |
 | `length` | `1` | ASCII width in registers (ignored for numeric types). |
 | `alignment` | `Left` | ASCII alignment: `Left` or `Right`. |
 | `values` | `[]` | Named values for selection-style registers. |

--- a/ferrowl-reg/src/codec.rs
+++ b/ferrowl-reg/src/codec.rs
@@ -329,7 +329,7 @@ mod tests {
         let r = reg(u8_be());
         let words = r.encode("200").unwrap();
         let decoded = r.decode(&words).unwrap();
-        assert_eq!(decoded.as_str(), "200");
+        assert_eq!(decoded.to_string(), "200");
     }
 
     #[test]
@@ -337,7 +337,7 @@ mod tests {
         let r = reg(u8_le());
         let words = r.encode("42").unwrap();
         let decoded = r.decode(&words).unwrap();
-        assert_eq!(decoded.as_str(), "42");
+        assert_eq!(decoded.to_string(), "42");
     }
 
     // --- I8 decode ---
@@ -386,7 +386,7 @@ mod tests {
         for val in [-128i8, -1, 0, 1, 127] {
             let words = r.encode(&val.to_string()).unwrap();
             let decoded = r.decode(&words).unwrap();
-            assert_eq!(decoded.as_str(), val.to_string());
+            assert_eq!(decoded.to_string(), val.to_string());
         }
     }
 
@@ -445,7 +445,7 @@ mod tests {
         let r = reg(u32_be());
         let words = r.encode("123456789").unwrap();
         let decoded = r.decode(&words).unwrap();
-        assert_eq!(decoded.as_str(), "123456789");
+        assert_eq!(decoded.to_string(), "123456789");
     }
 
     #[test]
@@ -453,7 +453,7 @@ mod tests {
         let r = reg(u32_le());
         let words = r.encode("987654321").unwrap();
         let decoded = r.decode(&words).unwrap();
-        assert_eq!(decoded.as_str(), "987654321");
+        assert_eq!(decoded.to_string(), "987654321");
     }
 
     // --- I32 round-trip ---
@@ -464,7 +464,7 @@ mod tests {
         for val in [-2147483648i32, -1, 0, 1, 2147483647] {
             let words = r.encode(&val.to_string()).unwrap();
             let decoded = r.decode(&words).unwrap();
-            assert_eq!(decoded.as_str(), val.to_string(), "val={}", val);
+            assert_eq!(decoded.to_string(), val.to_string(), "val={}", val);
         }
     }
 
@@ -474,7 +474,7 @@ mod tests {
         for val in [-2147483648i32, -1, 0, 1, 2147483647] {
             let words = r.encode(&val.to_string()).unwrap();
             let decoded = r.decode(&words).unwrap();
-            assert_eq!(decoded.as_str(), val.to_string(), "val={}", val);
+            assert_eq!(decoded.to_string(), val.to_string(), "val={}", val);
         }
     }
 
@@ -594,7 +594,7 @@ mod tests {
         let words = r.encode("2048").unwrap();
         let decoded = r.decode(&words).unwrap();
         // 2048 * 0.5 = 1024.0
-        assert_eq!(decoded.as_str(), "1024");
+        assert_eq!(decoded.to_string(), "1024");
     }
 
     // --- Bit-field mask + derived shift ---

--- a/ferrowl-reg/src/format.rs
+++ b/ferrowl-reg/src/format.rs
@@ -51,6 +51,12 @@ impl std::fmt::Display for Endian {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Resolution(pub f64);
 
+impl Default for Resolution {
+    fn default() -> Self {
+        Resolution(1.0)
+    }
+}
+
 impl std::fmt::Display for Resolution {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "{}", self.0)

--- a/ferrowl-reg/src/value.rs
+++ b/ferrowl-reg/src/value.rs
@@ -4,11 +4,46 @@ use serde::{Deserialize, Serialize};
 
 use crate::format::Resolution;
 
+/// A decoded register value: the typed raw value plus.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum UnscaledValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    F32(f32),
+    F64(f64),
+    Ascii(String),
+}
+
+impl std::fmt::Display for UnscaledValue {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::U8(v) => write!(fmt, "{}", v),
+            Self::U16(v) => write!(fmt, "{}", v),
+            Self::U32(v) => write!(fmt, "{}", v),
+            Self::U64(v) => write!(fmt, "{}", v),
+            Self::U128(v) => write!(fmt, "{}", v),
+            Self::I8(v) => write!(fmt, "{}", v),
+            Self::I16(v) => write!(fmt, "{}", v),
+            Self::I32(v) => write!(fmt, "{}", v),
+            Self::I64(v) => write!(fmt, "{}", v),
+            Self::I128(v) => write!(fmt, "{}", v),
+            Self::F32(v) => write!(fmt, "{}", v),
+            Self::F64(v) => write!(fmt, "{}", v),
+            Self::Ascii(v) => write!(fmt, "{}", v),
+        }
+    }
+}
+
 /// A decoded register value: the typed raw value plus, for numeric variants,
 /// the display [`Resolution`] it is scaled by when formatted.
-///
-/// Produced by [`decode`](crate::decode); the `Display` implementation
-/// delegates to [`as_str`](Self::as_str).
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Value {
     U8((u8, Resolution)),
@@ -28,36 +63,57 @@ pub enum Value {
 
 impl std::fmt::Display for Value {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(fmt, "{}", self.as_str())
+        let val = {
+            // Every numeric variant scales by its resolution and prints the f64 result.
+            macro_rules! scaled {
+                ($v:expr, $r:expr) => {{
+                    let v = *$v as f64 * $r.0;
+                    format!("{v}")
+                }};
+            }
+            match self {
+                Self::U8((v, r)) => scaled!(v, r),
+                Self::U16((v, r)) => scaled!(v, r),
+                Self::U32((v, r)) => scaled!(v, r),
+                Self::U64((v, r)) => scaled!(v, r),
+                Self::U128((v, r)) => scaled!(v, r),
+                Self::I8((v, r)) => scaled!(v, r),
+                Self::I16((v, r)) => scaled!(v, r),
+                Self::I32((v, r)) => scaled!(v, r),
+                Self::I64((v, r)) => scaled!(v, r),
+                Self::I128((v, r)) => scaled!(v, r),
+                Self::F32((v, r)) => scaled!(v, r),
+                Self::F64((v, r)) => scaled!(v, r),
+                Self::Ascii(v) => v.chars().collect(),
+            }
+        };
+        write!(fmt, "{}", val)
     }
 }
 
 impl Value {
-    /// Formats the value for display: numeric variants are multiplied by
-    /// their resolution and printed as decimal, ASCII is returned verbatim.
-    pub fn as_str(&self) -> String {
-        // Every numeric variant scales by its resolution and prints the f64 result.
-        macro_rules! scaled {
-            ($v:expr, $r:expr) => {{
-                let v = *$v as f64 * $r.0;
-                format!("{v}")
-            }};
-        }
+    pub fn unscaled(self) -> UnscaledValue {
         match self {
-            Self::U8((v, r)) => scaled!(v, r),
-            Self::U16((v, r)) => scaled!(v, r),
-            Self::U32((v, r)) => scaled!(v, r),
-            Self::U64((v, r)) => scaled!(v, r),
-            Self::U128((v, r)) => scaled!(v, r),
-            Self::I8((v, r)) => scaled!(v, r),
-            Self::I16((v, r)) => scaled!(v, r),
-            Self::I32((v, r)) => scaled!(v, r),
-            Self::I64((v, r)) => scaled!(v, r),
-            Self::I128((v, r)) => scaled!(v, r),
-            Self::F32((v, r)) => scaled!(v, r),
-            Self::F64((v, r)) => scaled!(v, r),
-            Self::Ascii(v) => v.chars().collect(),
+            Self::U8((v, _r)) => UnscaledValue::U8(v),
+            Self::U16((v, _r)) => UnscaledValue::U16(v),
+            Self::U32((v, _r)) => UnscaledValue::U32(v),
+            Self::U64((v, _r)) => UnscaledValue::U64(v),
+            Self::U128((v, _r)) => UnscaledValue::U128(v),
+            Self::I8((v, _r)) => UnscaledValue::I8(v),
+            Self::I16((v, _r)) => UnscaledValue::I16(v),
+            Self::I32((v, _r)) => UnscaledValue::I32(v),
+            Self::I64((v, _r)) => UnscaledValue::I64(v),
+            Self::I128((v, _r)) => UnscaledValue::I128(v),
+            Self::F32((v, _r)) => UnscaledValue::F32(v),
+            Self::F64((v, _r)) => UnscaledValue::F64(v),
+            Self::Ascii(v) => UnscaledValue::Ascii(v),
         }
+    }
+
+    /// `true` only for an empty ASCII value — the "no value yet" sentinel;
+    /// numeric variants always carry a value.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::Ascii(s) if s.is_empty())
     }
 
     /// Formats the unscaled raw value as `0x`-prefixed, zero-padded hex
@@ -106,20 +162,44 @@ mod tests {
 
     #[test]
     fn ut_value_as_str_no_scaling() {
-        assert_eq!(Value::U8((42, res())).as_str(), "42");
-        assert_eq!(Value::U16((1000, res())).as_str(), "1000");
-        assert_eq!(Value::I8((-1, res())).as_str(), "-1");
-        assert_eq!(Value::I16((-100, res())).as_str(), "-100");
-        assert_eq!(Value::Ascii("hello".to_string()).as_str(), "hello");
+        assert_eq!(Value::U8((42, res())).to_string(), "42");
+        assert_eq!(Value::U16((1000, res())).to_string(), "1000");
+        assert_eq!(Value::I8((-1, res())).to_string(), "-1");
+        assert_eq!(Value::I16((-100, res())).to_string(), "-100");
+        assert_eq!(Value::Ascii("hello".to_string()).to_string(), "hello");
     }
 
     #[test]
     fn ut_value_as_str_with_scaling() {
         // Use resolution 2.0 so that integer * 2.0 is exact in f64
         let r = Resolution(2.0);
-        assert_eq!(Value::U16((5, r.clone())).as_str(), "10");
-        assert_eq!(Value::I32((-3, r.clone())).as_str(), "-6");
-        assert_eq!(Value::F32((1.5f32, r.clone())).as_str(), "3");
+        assert_eq!(Value::U16((5, r.clone())).to_string(), "10");
+        assert_eq!(Value::I32((-3, r.clone())).to_string(), "-6");
+        assert_eq!(Value::F32((1.5f32, r.clone())).to_string(), "3");
+    }
+
+    #[test]
+    fn ut_value_unscaled_drops_resolution() {
+        // The unscaled string is the raw value, regardless of resolution.
+        let r = Resolution(2.0);
+        assert_eq!(Value::U16((5, r.clone())).unscaled().to_string(), "5");
+        assert_eq!(Value::I32((-3, r.clone())).unscaled().to_string(), "-3");
+        assert_eq!(
+            Value::F32((1.5f32, r.clone())).unscaled().to_string(),
+            "1.5"
+        );
+        assert_eq!(
+            Value::Ascii("hello".to_string()).unscaled().to_string(),
+            "hello"
+        );
+    }
+
+    #[test]
+    fn ut_value_is_empty() {
+        // Only the empty ASCII sentinel counts as empty.
+        assert!(Value::Ascii(String::new()).is_empty());
+        assert!(!Value::Ascii("x".to_string()).is_empty());
+        assert!(!Value::U16((0, res())).is_empty());
     }
 
     #[test]

--- a/ferrowl/src/app/commands.rs
+++ b/ferrowl/src/app/commands.rs
@@ -248,7 +248,7 @@ impl App {
             if role == Role::Server {
                 self.tabs[self.active]
                     .module
-                    .set_virtual_value(register_name, value.to_string())
+                    .set_virtual_value(register_name, crate::module::str_to_value(value, &register))
                     .await;
                 self.log_active(format!("set {register_name} = {value} (virtual)"))
                     .await;

--- a/ferrowl/src/app/overlay.rs
+++ b/ferrowl/src/app/overlay.rs
@@ -306,12 +306,14 @@ impl App {
         let update_script = update_script.flatten();
         let current_default = current_default.flatten();
 
+        // Dialogs edit the raw (unscaled) value — the form `Register::encode` and `:set` accept.
+        let unscaled = def.value.clone().unscaled().to_string();
         if def.named_values.is_empty() {
             let dialog = EditInputDialog::from_register(
                 &def.name,
                 &def.description,
                 &def.register,
-                &def.value,
+                &unscaled,
                 update_script,
                 current_default,
             );
@@ -322,7 +324,7 @@ impl App {
                 &def.description,
                 &def.register,
                 def.named_values.clone(),
-                &def.value,
+                &unscaled,
                 &def.raw_value,
                 update_script,
                 current_default,
@@ -459,7 +461,8 @@ impl App {
                     && slot.register.address() == edited.register.address()
                     && !slot.value.is_empty()
                 {
-                    preserved_value = Some(slot.value.clone());
+                    // Unscaled string: `set_value` re-encodes it, and `encode` takes raw values.
+                    preserved_value = Some(slot.value.clone().unscaled().to_string());
                 }
 
                 // Issue 9: keep module's register cache in sync so rebuild_operations is correct.

--- a/ferrowl/src/app/registers.rs
+++ b/ferrowl/src/app/registers.rs
@@ -3,7 +3,7 @@
 
 use ferrowl_mem::{Kind as MemKind, Memory, Range, Type};
 use ferrowl_net::{Command, Key, SlaveKind};
-use ferrowl_reg::{Access, Address, Kind, Register};
+use ferrowl_reg::{Access, Address, Kind, Register, Value};
 
 use crate::config::device::{
     AccessCfg, AlignmentCfg, EndianCfg, RegisterDef, ValueType as DevValueType,
@@ -81,7 +81,7 @@ pub(super) fn write_command(register: &Register, slave: u8, addr: u16, raw: &[u1
 pub(super) fn decode_definition(
     mut d: Definition,
     memory: &Memory<Key<SlaveKind>>,
-    virtual_values: &std::collections::HashMap<String, String>,
+    virtual_values: &std::collections::HashMap<String, Value>,
 ) -> Definition {
     match d.register.address() {
         Address::Fixed(addr) => {
@@ -96,8 +96,8 @@ pub(super) fn decode_definition(
                 .read_unchecked(key, &Range::new(*addr as usize, width))
                 .unwrap_or_else(|| vec![0; width]);
             d.value = match d.register.decode(&raw) {
-                Ok(v) => format!("{v}"),
-                Err(_) => "Error".to_string(),
+                Ok(v) => v,
+                Err(_) => Value::Ascii("Error".to_string()),
             };
             d.raw_value = raw_hex(&raw);
         }
@@ -109,12 +109,12 @@ pub(super) fn decode_definition(
                     d.value = v.clone();
                     d.raw_value = d
                         .register
-                        .encode(v)
+                        .encode(&v.clone().unscaled().to_string())
                         .map(|raw| raw_hex(&raw))
                         .unwrap_or_default();
                 }
                 None => {
-                    d.value.clear();
+                    d.value = Value::Ascii(String::new());
                     d.raw_value.clear();
                 }
             }

--- a/ferrowl/src/config/device.rs
+++ b/ferrowl/src/config/device.rs
@@ -189,6 +189,14 @@ impl Scalar {
             Scalar::Text(s.to_string())
         }
     }
+
+    pub fn to_value(&self, res: f64) -> ferrowl_reg::Value {
+        match self {
+            Scalar::Int(i) => ferrowl_reg::Value::I64((*i, Resolution(res))),
+            Scalar::Float(f) => ferrowl_reg::Value::F64((*f, Resolution(res))),
+            Scalar::Text(s) => ferrowl_reg::Value::Ascii(s.clone()),
+        }
+    }
 }
 
 /// The value encoding of a register.
@@ -467,6 +475,20 @@ mod tests {
         assert!(matches!(def.kind(), Kind::HoldingRegister));
         assert!(matches!(def.mem_type(), Type::Register));
         assert_eq!(def.format().width(), 1);
+    }
+
+    #[test]
+    fn ut_parse_ranges() {
+        // Inclusive bounds; bare address = single-cell range; whitespace tolerated.
+        assert_eq!(
+            parse_ranges("0-100, 140-160 ,5"),
+            vec![Range::new(0, 101), Range::new(140, 21), Range::new(5, 1)]
+        );
+        // Malformed, reversed and empty entries are skipped.
+        assert_eq!(parse_ranges("abc,10-x,,9-3"), vec![]);
+        assert_eq!(parse_ranges(""), vec![]);
+        // Reversed bound dropped, valid neighbor kept.
+        assert_eq!(parse_ranges("9-3,4"), vec![Range::new(4, 1)]);
     }
 
     #[test]

--- a/ferrowl/src/dialog/edit/input.rs
+++ b/ferrowl/src/dialog/edit/input.rs
@@ -171,6 +171,13 @@ impl EditInputDialog {
                     if let Err(e) = encode(format, s) {
                         return Err(format!("Value: cannot convert '{s}' to number [{e}]"));
                     }
+                    let v = self.default_value.state.input();
+                    let s = v.trim();
+                    if !s.is_empty()
+                        && let Err(e) = encode(format, s)
+                    {
+                        return Err(format!("Value: cannot convert '{s}' to number [{e}]"));
+                    }
                 }
                 ValueType::Text => {
                     if let ValidateResult::Error(e) = usize::validate(self.text_width.state.input())
@@ -202,7 +209,7 @@ impl EditInputDialog {
 
         let vertical_layout: [Rect; 3] = Layout::vertical([
             Constraint::Min(1),
-            Constraint::Length(43),
+            Constraint::Length(44),
             Constraint::Min(1),
         ])
         .areas(horizontal_layout[1]);
@@ -232,7 +239,7 @@ impl EditInputDialog {
             Constraint::Length(3),
             Constraint::Length(6),
             Constraint::Length(3),
-            Constraint::Length(3),
+            Constraint::Length(4),
             Constraint::Length(1),
             Constraint::Length(1),
             Constraint::Length(1),
@@ -917,6 +924,7 @@ impl EditInputDialog {
                         vertical: 0,
                         horizontal: 1,
                     })
+                    .multiline(true)
                     .style(error_style.clone())
                     .build()
                     .unwrap(),

--- a/ferrowl/src/dialog/setup.rs
+++ b/ferrowl/src/dialog/setup.rs
@@ -144,7 +144,7 @@ impl Validate for ConfigPath {
 
         if input.is_empty() {
             ValidateResult::None
-        } else if let Some(_) = FileType::from_path(input) {
+        } else if FileType::from_path(input).is_some() {
             if path.exists() {
                 match crate::config::load_device(input) {
                     Ok(_) => ValidateResult::Success,

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -44,18 +44,6 @@ impl RegisterBridge {
     }
 }
 
-/// Infer a Lua `ValueType` from a virtual register's stored string (int, then float, else string).
-fn parse_value_type(s: &str) -> ValueType {
-    let t = s.trim();
-    if let Ok(i) = t.parse::<i128>() {
-        ValueType::Int(i)
-    } else if let Ok(f) = t.parse::<f64>() {
-        ValueType::Float(f)
-    } else {
-        ValueType::String(s.to_string())
-    }
-}
-
 impl Read for RegisterBridge {
     fn read(&self, name: String) -> Result<ValueType> {
         let register = self.register(&name)?;
@@ -66,7 +54,7 @@ impl Read for RegisterBridge {
                     .virtual_store
                     .blocking_read()
                     .get(&name)
-                    .map(|s| parse_value_type(s))
+                    .map(|v| value_to_type(v.clone()))
                     .ok_or_else(|| {
                         Error::RuntimeError(format!("virtual register '{name}' not set"))
                     });
@@ -97,6 +85,7 @@ impl Write for RegisterBridge {
         let addr = match register.address() {
             Address::Fixed(addr) => *addr,
             Address::Virtual => {
+                let value = crate::module::str_to_value(&value, register);
                 self.virtual_store.blocking_write().insert(name, value);
                 return Ok(());
             }
@@ -325,8 +314,8 @@ mod tests {
             virtual_store
                 .blocking_read()
                 .get("calc")
-                .map(String::as_str),
-            Some("7")
+                .map(|v| v.clone().unscaled().to_string()),
+            Some("7".to_string())
         );
     }
 

--- a/ferrowl/src/module.rs
+++ b/ferrowl/src/module.rs
@@ -28,7 +28,7 @@ pub type ModuleMemory = Arc<RwLock<Memory<Key<SlaveKind>>>>;
 pub type ModuleLog = Arc<RwLock<LogRing>>;
 /// Shared store of virtual-register values (no Modbus address), keyed by register name. Shared
 /// with the Lua sim thread so `update` scripts can drive virtual registers and the table shows them.
-pub type VirtualStore = Arc<RwLock<HashMap<String, String>>>;
+pub type VirtualStore = Arc<RwLock<HashMap<String, ferrowl_reg::Value>>>;
 /// Optional per-module log file, shared into the log/status callbacks; swappable at runtime so
 /// `:log` takes effect on already-running modules.
 pub type FileSink = Arc<Mutex<Option<BufWriter<std::fs::File>>>>;
@@ -63,7 +63,7 @@ impl Module {
         let mut memory = Memory::<Key<SlaveKind>>::default();
         let mut registers: Vec<(String, String, Register, Vec<NamedValue>)> = Vec::new();
         let mut scripts: Vec<(String, String)> = Vec::new();
-        let mut virtual_init: HashMap<String, String> = HashMap::new();
+        let mut virtual_init: HashMap<String, ferrowl_reg::Value> = HashMap::new();
 
         for (name, def) in &device.definitions {
             let register = def.register();
@@ -82,7 +82,7 @@ impl Module {
                 let init = def
                     .default
                     .as_ref()
-                    .map(|s| s.to_string())
+                    .map(|s| s.to_value(def.resolution))
                     .unwrap_or_else(|| default_value(&register));
                 virtual_init.insert(name.clone(), init);
             }
@@ -182,8 +182,8 @@ impl Module {
         &self.registers
     }
 
-    /// Store a string value for a virtual register (replaces any previous value).
-    pub async fn set_virtual_value(&self, name: &str, val: String) {
+    /// Store a value for a virtual register (replaces any previous value).
+    pub async fn set_virtual_value(&self, name: &str, val: ferrowl_reg::Value) {
         self.virtual_values
             .write()
             .await
@@ -369,12 +369,18 @@ impl Module {
 
 /// Initial display value for a register: its format decoded from all-zero words (e.g. "0").
 /// Used to seed virtual registers so the table isn't blank before a script or `:set` runs.
-pub(crate) fn default_value(register: &Register) -> String {
+pub(crate) fn default_value(register: &Register) -> ferrowl_reg::Value {
     let zeros = vec![0u16; register.format().width()];
     register
         .decode(&zeros)
-        .map(|v| format!("{v}"))
-        .unwrap_or_default()
+        .unwrap_or(ferrowl_reg::Value::Ascii(String::new()))
+}
+
+/// Parse user input (`:set`, Lua `write`) into a typed [`Value`](ferrowl_reg::Value),
+/// attaching the register's display resolution (1.0 when the format has none).
+pub(crate) fn str_to_value(s: &str, register: &Register) -> ferrowl_reg::Value {
+    let res = register.format().resolution().map(|r| r.0).unwrap_or(1.0);
+    crate::config::device::Scalar::from_input(s).to_value(res)
 }
 
 fn function_code(register: &Register) -> FunctionCode {
@@ -816,6 +822,42 @@ mod tests {
             Format::U16((Endian::Big, Resolution(1.0), BitField::default())),
             access,
         )
+    }
+
+    #[test]
+    fn ut_str_to_value_uses_register_resolution() {
+        use super::str_to_value;
+        use ferrowl_reg::Value;
+
+        let reg = entry(
+            1,
+            Kind::HoldingRegister,
+            0,
+            Format::U16((Endian::Big, Resolution(0.5), BitField::default())),
+            Access::ReadWrite,
+        )
+        .2;
+
+        // Integer and float inputs carry the register's resolution.
+        match str_to_value("10", &reg) {
+            Value::I64((v, r)) => {
+                assert_eq!(v, 10);
+                assert_eq!(r.0, 0.5);
+            }
+            other => panic!("expected I64, got {other:?}"),
+        }
+        match str_to_value("1.5", &reg) {
+            Value::F64((v, r)) => {
+                assert_eq!(v, 1.5);
+                assert_eq!(r.0, 0.5);
+            }
+            other => panic!("expected F64, got {other:?}"),
+        }
+        // Non-numeric input falls through to ASCII.
+        match str_to_value("idle", &reg) {
+            Value::Ascii(s) => assert_eq!(s, "idle"),
+            other => panic!("expected Ascii, got {other:?}"),
+        }
     }
 
     #[test]

--- a/ferrowl/src/view/main.rs
+++ b/ferrowl/src/view/main.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use derive_builder::Builder;
 use ferrowl_derive::{Focus, focusable};
-use ferrowl_reg::Register;
+use ferrowl_reg::{Register, Value};
 use ferrowl_ui::{
     state::{TableState, TableStateBuilder},
     style::TableStyleBuilder,
@@ -102,7 +102,7 @@ pub struct Definition {
     pub description: String,
     pub register: Register,
     pub named_values: Vec<NamedValue>,
-    pub value: String,
+    pub value: Value,
     pub raw_value: String,
 }
 
@@ -118,7 +118,7 @@ impl Definition {
             description: description.into(),
             register,
             named_values,
-            value: String::new(),
+            value: Value::Ascii(String::new()),
             raw_value: String::new(),
         }
     }


### PR DESCRIPTION
Previously the scaled value was set to the value input field. When not changing the value at all and confirming the dialog, the scale would be applied on top of the original scale (e.g. `scale=0.1, input=100 -> value=10 -> inputfield=10 -confirm-> value=1 -> ..`). This would change the value even if the user just changed the description or name and leaves the value untouched.

For this, we introduce `UnscaledValue` - works like `Value` but stores no resolution, `Display` prints value unscaled. Additionally the virtual storage is redesigned to store `Value` instead of storing all types as `String`. This required some additional changes.

Last but no least:
  * Validate default input field as done for value (except accept of empty)
  * Add CONTRIBUTING.md
  * Add missing updates to README.md

Closes #26 