### PR TITLE
Add autofill property to input fields

### DIFF
--- a/ferrowl-ui/src/state/input_field.rs
+++ b/ferrowl-ui/src/state/input_field.rs
@@ -30,6 +30,9 @@ pub struct InputFieldState {
     #[getset(get = "pub")]
     #[builder(default = "None")]
     placeholder: Option<String>,
+    #[getset(get = "pub")]
+    #[builder(default = "None")]
+    autofill: Option<String>,
 }
 
 impl GetValue for InputFieldState {
@@ -68,11 +71,17 @@ impl HandleEvents for InputFieldState {
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
                 if !self.disabled
                     && self.input.is_empty()
-                    && let Some(placeholder) = &self.placeholder
+                    && let Some(autofill) = &self.autofill()
                 {
-                    self.input = placeholder.clone();
+                    self.input = autofill.clone();
                     self.cursor = self.input.chars().count();
                 }
+                EventResult::Consumed
+            }
+            // Clear the input line
+            (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+                self.input.clear();
+                self.cursor = 0;
                 EventResult::Consumed
             }
             // Accept SHIFT so capital letters and shifted symbols are inserted; CTRL/ALT

--- a/ferrowl-ui/src/widgets/input_field.rs
+++ b/ferrowl-ui/src/widgets/input_field.rs
@@ -202,7 +202,11 @@ where
 
         let input = state.input();
         let mut text = if input.is_empty() {
-            state.placeholder().clone().unwrap_or_default()
+            state
+                .autofill()
+                .clone()
+                .or(state.placeholder().clone())
+                .unwrap_or("Enter value..".to_string())
         } else {
             input.clone()
         };

--- a/ferrowl/src/dialog/edit/mod.rs
+++ b/ferrowl/src/dialog/edit/mod.rs
@@ -157,6 +157,7 @@ pub(super) fn set_input<T: Validate>(
     value: &str,
 ) {
     widget.state.set_input(value.to_string());
+    widget.state.set_autofill(Some(value.to_string()));
     widget.state.set_cursor(value.chars().count());
 }
 


### PR DESCRIPTION
Previously the placeholder value was used to provide information to the user but also to be used as autofill using `ctrl+f`. Now we split it into two distinct properties, the placeholder and the autofill. If no autofill is present `ctrl+f` is a noop. But if it's present it is used. The placeholder is only shown on empty input without an autofill value present. This prevents the unintended insertion of the placeholder value into the input field since the placeholder is mostly used to contain information that is not designed to be used as input.

Additionally the `ctrl+d` shortcut is added for input fields. Using this shortcut will clear the input completely. This makes it handy if you want to instantly insert a completely different value.

Closes #30 