### PR TITLE
Update test coverage

### DIFF
--- a/ferrowl-derive/tests/focus.rs
+++ b/ferrowl-derive/tests/focus.rs
@@ -119,3 +119,52 @@ fn ut_handle_events_routes_to_focused_widget() {
     assert_eq!(app.second.events, 1);
     assert_eq!(app.third.events, 0);
 }
+
+// A view whose middle widget is focusable only when `second_enabled` is set, exercising the
+// `#[focus(when = ...)]` gating path of the derive macro.
+#[focusable]
+#[derive(Builder, Debug, Focus)]
+struct GatedApp {
+    #[focus]
+    pub first: Widget,
+    #[focus(when = self.second_enabled)]
+    pub second: Widget,
+    #[focus]
+    pub third: Widget,
+    pub second_enabled: bool,
+}
+
+fn make_gated(second_enabled: bool, start: GatedAppFocus) -> GatedApp {
+    GatedAppBuilder::default()
+        .first(Widget::default())
+        .second(Widget::default())
+        .third(Widget::default())
+        .second_enabled(second_enabled)
+        .focus(start)
+        .build()
+        .expect("GatedApp builder failed")
+}
+
+#[test]
+fn ut_focus_next_skips_disabled_gated_widget() {
+    let mut app = make_gated(false, GatedAppFocus::First);
+    app.focus_next(); // First → (Second disabled, skipped) → Third
+    assert!(app.third.is_focused());
+    assert!(!app.second.is_focused());
+}
+
+#[test]
+fn ut_focus_next_lands_on_enabled_gated_widget() {
+    let mut app = make_gated(true, GatedAppFocus::First);
+    app.focus_next(); // First → Second (enabled)
+    assert!(app.second.is_focused());
+    assert!(!app.third.is_focused());
+}
+
+#[test]
+fn ut_focus_previous_skips_disabled_gated_widget() {
+    let mut app = make_gated(false, GatedAppFocus::Third);
+    app.focus_previous(); // Third → (Second disabled, skipped) → First
+    assert!(app.first.is_focused());
+    assert!(!app.second.is_focused());
+}

--- a/ferrowl-log/src/lib.rs
+++ b/ferrowl-log/src/lib.rs
@@ -199,4 +199,56 @@ mod tests {
         let second = log.take().unwrap();
         assert_eq!(&second.1, "abcde");
     }
+
+    #[test]
+    fn ut_log_fills_to_capacity_then_evicts_in_order() {
+        // LOG_SIZE=4 → holds at most 3 entries.
+        let mut log: Log<10, 4> = Log::init();
+        log.write("msg1______");
+        log.write("msg2______");
+        log.write("msg3______");
+        // At capacity: all three present, oldest first.
+        let full = log.peak_n(10).unwrap();
+        assert_eq!(full.len(), 3);
+        assert!(full[0].1.starts_with("msg1"));
+
+        // One more evicts the oldest (msg1) and keeps the window at 3.
+        log.write("msg4______");
+        let rolled = log.peak_n(10).unwrap();
+        assert_eq!(rolled.len(), 3);
+        assert!(rolled[0].1.starts_with("msg2"));
+        assert!(rolled[2].1.starts_with("msg4"));
+    }
+
+    #[test]
+    fn ut_log_peak_n_zero_returns_none() {
+        let mut log: Log<10, 5> = Log::init();
+        log.write("something_");
+        assert!(log.peak_n(0).is_none());
+        assert!(log.take_n(0).is_none());
+        // The entry is untouched by the zero-count calls.
+        assert!(log.peak().is_some());
+    }
+
+    #[test]
+    fn ut_log_clear_empties_the_buffer() {
+        let mut log: Log<10, 5> = Log::init();
+        log.write("a_________");
+        log.write("b_________");
+        log.clear();
+        assert!(log.peak().is_none());
+        assert!(log.take_n(5).is_none());
+        // Usable again after clear.
+        log.write("c_________");
+        assert!(log.peak().unwrap().1.starts_with("c"));
+    }
+
+    #[test]
+    fn ut_log_records_timestamp_on_write() {
+        let mut log: Log<10, 5> = Log::init();
+        log.write("stamped___");
+        let (ts, _) = log.peak().unwrap();
+        // A real Unix-millis timestamp is far from zero.
+        assert!(ts > 0);
+    }
 }

--- a/ferrowl-net/src/server_core.rs
+++ b/ferrowl-net/src/server_core.rs
@@ -290,7 +290,7 @@ where
             };
             let mut guard = memory.write().await;
             let values: Vec<u16> = values.iter().map(|v| *v as u16).collect();
-            match guard.write(key, &Type::Coil, &Range::new(addr as usize, 1), &values) {
+            match guard.write(key, &Type::Coil, &Range::new(addr as usize, values.len()), &values) {
                 true => {
                     if verbose {
                         log.invoke(format!(
@@ -575,5 +575,299 @@ mod tests {
         let quiet = buf.lock().unwrap().clone();
         assert_eq!(quiet.len(), 1);
         assert!(quiet[0].contains("received"));
+    }
+
+    /// Build a memory for slave `1` of the given register `kind`/value `ty` over `[0, len)`,
+    /// optionally seeded with `seed` at addr 0. ReadWrite so both read and write paths work.
+    fn seeded(
+        kind: RegKind,
+        ty: Type,
+        len: usize,
+        seed: &[u16],
+    ) -> Arc<RwLock<Memory<Key<SlaveKind>>>> {
+        let key = Key {
+            id: SlaveKind { slave_id: 1, kind },
+        };
+        let mut mem = Memory::<Key<SlaveKind>>::default();
+        mem.add_ranges(key.clone(), &MemKind::ReadWrite(ty), &[Range::new(0, len)]);
+        if !seed.is_empty() {
+            mem.write(key, &ty, &Range::new(0, seed.len()), seed);
+        }
+        Arc::new(RwLock::new(mem))
+    }
+
+    // ---- WriteMultipleCoils: regression for the hard-coded range length bug ----
+
+    #[tokio::test]
+    async fn ut_write_multiple_coils_persists_every_bit() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 8, &[]);
+        let (log, _) = recording_log();
+        let coils = vec![true, false, true, true, false];
+
+        let resp = handle_request::<SlaveKind, _>(
+            1,
+            Request::WriteMultipleCoils(1, coils.clone().into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        // Regression: the write range length must equal values.len(), not 1. Before the fix
+        // `Memory::write` rejected any multi-coil write (range.length() != values.len()).
+        assert!(matches!(resp, Response::WriteMultipleCoils(1, 5)));
+
+        let read =
+            handle_request::<SlaveKind, _>(1, Request::ReadCoils(1, 5), &mem, &log, false)
+                .await
+                .unwrap();
+        assert!(matches!(read, Response::ReadCoils(v) if v == coils));
+    }
+
+    #[tokio::test]
+    async fn ut_write_multiple_coils_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 8, &[]);
+        let (log, _) = recording_log();
+        // addr 6 + 5 coils overruns the registered [0, 8) region.
+        let err = handle_request::<SlaveKind, _>(
+            1,
+            Request::WriteMultipleCoils(6, vec![true; 5].into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    // ---- Coil / discrete-input reads ----
+
+    #[tokio::test]
+    async fn ut_read_coils_returns_seeded_bits() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 4, &[1, 0, 1, 0]);
+        let (log, _) = recording_log();
+        let resp = handle_request::<SlaveKind, _>(1, Request::ReadCoils(0, 4), &mem, &log, false)
+            .await
+            .unwrap();
+        assert!(matches!(resp, Response::ReadCoils(v) if v == vec![true, false, true, false]));
+    }
+
+    #[tokio::test]
+    async fn ut_read_coils_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 4, &[]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(1, Request::ReadCoils(10, 2), &mem, &log, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    #[tokio::test]
+    async fn ut_read_discrete_inputs_returns_seeded_bits() {
+        let mem = seeded(RegKind::DiscreteInput, Type::Coil, 3, &[0, 1, 1]);
+        let (log, _) = recording_log();
+        let resp =
+            handle_request::<SlaveKind, _>(1, Request::ReadDiscreteInputs(0, 3), &mem, &log, false)
+                .await
+                .unwrap();
+        assert!(matches!(resp, Response::ReadDiscreteInputs(v) if v == vec![false, true, true]));
+    }
+
+    #[tokio::test]
+    async fn ut_read_discrete_inputs_unknown_slave_is_illegal_function() {
+        let mem = seeded(RegKind::DiscreteInput, Type::Coil, 3, &[]);
+        let (log, _) = recording_log();
+        let err =
+            handle_request::<SlaveKind, _>(2, Request::ReadDiscreteInputs(0, 3), &mem, &log, false)
+                .await
+                .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    // ---- Register reads ----
+
+    #[tokio::test]
+    async fn ut_read_input_registers_returns_seeded_values() {
+        let mem = seeded(RegKind::InputRegister, Type::Register, 3, &[7, 8, 9]);
+        let (log, _) = recording_log();
+        let resp =
+            handle_request::<SlaveKind, _>(1, Request::ReadInputRegisters(0, 3), &mem, &log, false)
+                .await
+                .unwrap();
+        assert!(matches!(resp, Response::ReadInputRegisters(v) if v == vec![7, 8, 9]));
+    }
+
+    #[tokio::test]
+    async fn ut_read_input_registers_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::InputRegister, Type::Register, 3, &[]);
+        let (log, _) = recording_log();
+        let err =
+            handle_request::<SlaveKind, _>(1, Request::ReadInputRegisters(2, 5), &mem, &log, false)
+                .await
+                .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    #[tokio::test]
+    async fn ut_read_holding_registers_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(
+            1,
+            Request::ReadHoldingRegisters(3, 4),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    // ---- Single writes ----
+
+    #[tokio::test]
+    async fn ut_write_single_coil_persists() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 4, &[]);
+        let (log, _) = recording_log();
+        let resp =
+            handle_request::<SlaveKind, _>(1, Request::WriteSingleCoil(2, true), &mem, &log, false)
+                .await
+                .unwrap();
+        assert!(matches!(resp, Response::WriteSingleCoil(2, true)));
+        let read =
+            handle_request::<SlaveKind, _>(1, Request::ReadCoils(2, 1), &mem, &log, false)
+                .await
+                .unwrap();
+        assert!(matches!(read, Response::ReadCoils(v) if v == vec![true]));
+    }
+
+    #[tokio::test]
+    async fn ut_write_single_coil_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::Coil, Type::Coil, 4, &[]);
+        let (log, _) = recording_log();
+        let err =
+            handle_request::<SlaveKind, _>(1, Request::WriteSingleCoil(9, true), &mem, &log, false)
+                .await
+                .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    #[tokio::test]
+    async fn ut_write_single_register_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(
+            1,
+            Request::WriteSingleRegister(99, 1),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    // ---- WriteMultipleRegisters ----
+
+    #[tokio::test]
+    async fn ut_write_multiple_registers_persists_all() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 8, &[]);
+        let (log, _) = recording_log();
+        let resp = handle_request::<SlaveKind, _>(
+            1,
+            Request::WriteMultipleRegisters(1, vec![11, 22, 33].into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(resp, Response::WriteMultipleRegisters(1, 3)));
+        let read = handle_request::<SlaveKind, _>(
+            1,
+            Request::ReadHoldingRegisters(1, 3),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(read, Response::ReadHoldingRegisters(v) if v == vec![11, 22, 33]));
+    }
+
+    #[tokio::test]
+    async fn ut_write_multiple_registers_out_of_range_is_illegal_function() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(
+            1,
+            Request::WriteMultipleRegisters(3, vec![1, 2, 3].into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+    }
+
+    // ---- ReadWriteMultipleRegisters (reads and writes the same holding region) ----
+
+    #[tokio::test]
+    async fn ut_read_write_multiple_registers_writes_then_returns_read() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 8, &[5, 6, 7, 8]);
+        let (log, _) = recording_log();
+        // Read [0,2), write [2,4) = [77, 88].
+        let resp = handle_request::<SlaveKind, _>(
+            1,
+            Request::ReadWriteMultipleRegisters(0, 2, 2, vec![77, 88].into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(resp, Response::ReadWriteMultipleRegisters(v) if v == vec![5, 6]));
+        let read = handle_request::<SlaveKind, _>(
+            1,
+            Request::ReadHoldingRegisters(2, 2),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(read, Response::ReadHoldingRegisters(v) if v == vec![77, 88]));
+    }
+
+    #[tokio::test]
+    async fn ut_read_write_multiple_registers_out_of_range_is_illegal_data_address() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[1, 2, 3, 4]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(
+            1,
+            Request::ReadWriteMultipleRegisters(0, 2, 10, vec![1, 2].into()),
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalDataAddress);
+    }
+
+    // ---- Unsupported function codes ----
+
+    #[tokio::test]
+    async fn ut_report_server_id_is_illegal_function() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[]);
+        let (log, _) = recording_log();
+        let err = handle_request::<SlaveKind, _>(1, Request::ReportServerId, &mem, &log, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
     }
 }

--- a/ferrowl-ui/src/state/code_input_field.rs
+++ b/ferrowl-ui/src/state/code_input_field.rs
@@ -290,4 +290,94 @@ mod tests {
         assert_eq!(s.content(), "hello\nworl");
         assert_eq!(s.cursor_col(), 4);
     }
+
+    #[test]
+    fn up_down_navigate_and_clamp_to_shorter_line() {
+        let mut s = state();
+        s.set_content("longline\nx");
+        // Cursor sits at end of "x" (line 1, col 1). Move up onto "longline".
+        press(&mut s, KeyModifiers::NONE, KeyCode::Up);
+        assert_eq!(s.active_line(), 0);
+        assert_eq!(s.cursor_col(), 1);
+        // Move back down; cursor clamps to the shorter line's length.
+        press(&mut s, KeyModifiers::NONE, KeyCode::Down);
+        assert_eq!(s.active_line(), 1);
+        assert_eq!(s.cursor_col(), 1);
+    }
+
+    #[test]
+    fn up_at_first_line_and_down_at_last_are_noops() {
+        let mut s = state();
+        s.set_content("a\nb");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Down); // already last line
+        assert_eq!(s.active_line(), 1);
+        press(&mut s, KeyModifiers::NONE, KeyCode::Up);
+        assert_eq!(s.active_line(), 0);
+        press(&mut s, KeyModifiers::NONE, KeyCode::Up); // already first line
+        assert_eq!(s.active_line(), 0);
+    }
+
+    #[test]
+    fn left_wraps_to_previous_line_end() {
+        let mut s = state();
+        s.set_content("ab\ncd");
+        // At line 1, col 0 (move there from end).
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left); // col 2 -> 1
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left); // col 1 -> 0
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left); // wrap to prev line end
+        assert_eq!(s.active_line(), 0);
+        assert_eq!(s.cursor_col(), 2);
+    }
+
+    #[test]
+    fn right_wraps_to_next_line_start() {
+        let mut s = state();
+        s.set_content("ab\ncd");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Up); // line 0, clamp col to 2
+        // cursor is at col 2 (end of "ab"); Right wraps to next line start.
+        press(&mut s, KeyModifiers::NONE, KeyCode::Right);
+        assert_eq!(s.active_line(), 1);
+        assert_eq!(s.cursor_col(), 0);
+    }
+
+    #[test]
+    fn enter_splits_line_at_cursor() {
+        let mut s = state();
+        s.set_content("abcd");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left);
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left); // cursor at col 2
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "ab\ncd");
+        assert_eq!(s.active_line(), 1);
+        assert_eq!(s.cursor_col(), 0);
+    }
+
+    #[test]
+    fn multibyte_chars_count_by_character() {
+        let mut s = state();
+        type_char(&mut s, 'é');
+        type_char(&mut s, '语');
+        type_char(&mut s, 'x');
+        assert_eq!(s.content(), "é语x");
+        assert_eq!(s.cursor_col(), 3);
+        backspace(&mut s);
+        assert_eq!(s.content(), "é语");
+        assert_eq!(s.cursor_col(), 2);
+        // Insert between the two multi-byte chars.
+        press(&mut s, KeyModifiers::NONE, KeyCode::Left);
+        type_char(&mut s, 'Z');
+        assert_eq!(s.content(), "éZ语");
+        assert_eq!(s.cursor_col(), 2);
+    }
+
+    #[test]
+    fn disabled_state_ignores_keys() {
+        let mut s = CodeInputFieldStateBuilder::default()
+            .disabled(true)
+            .build()
+            .unwrap();
+        let r = s.handle_events(KeyModifiers::NONE, KeyCode::Char('a'));
+        assert!(matches!(r, EventResult::Unhandled(..)));
+        assert_eq!(s.content(), "");
+    }
 }

--- a/ferrowl-ui/src/state/input_field.rs
+++ b/ferrowl-ui/src/state/input_field.rs
@@ -151,3 +151,129 @@ impl HandleEvents for InputFieldState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field() -> InputFieldState {
+        InputFieldStateBuilder::default().build().unwrap()
+    }
+
+    fn type_str(s: &mut InputFieldState, text: &str) {
+        for c in text.chars() {
+            s.handle_events(KeyModifiers::NONE, KeyCode::Char(c));
+        }
+    }
+
+    #[test]
+    fn typing_appends_and_advances_cursor() {
+        let mut s = field();
+        type_str(&mut s, "abc");
+        assert_eq!(s.input(), "abc");
+        assert_eq!(s.cursor(), 3);
+    }
+
+    #[test]
+    fn insert_at_cursor_mid_string() {
+        let mut s = field();
+        type_str(&mut s, "ac");
+        s.handle_events(KeyModifiers::NONE, KeyCode::Left); // cursor between a|c
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('b'));
+        assert_eq!(s.input(), "abc");
+        assert_eq!(s.cursor(), 2);
+    }
+
+    #[test]
+    fn backspace_at_start_is_noop() {
+        let mut s = field();
+        type_str(&mut s, "ab");
+        s.handle_events(KeyModifiers::NONE, KeyCode::Home);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Backspace);
+        assert_eq!(s.input(), "ab");
+        assert_eq!(s.cursor(), 0);
+    }
+
+    #[test]
+    fn delete_removes_char_under_cursor() {
+        let mut s = field();
+        type_str(&mut s, "abc");
+        s.handle_events(KeyModifiers::NONE, KeyCode::Home);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Delete);
+        assert_eq!(s.input(), "bc");
+        assert_eq!(s.cursor(), 0);
+    }
+
+    #[test]
+    fn home_and_end_move_cursor_to_bounds() {
+        let mut s = field();
+        type_str(&mut s, "hello");
+        s.handle_events(KeyModifiers::NONE, KeyCode::Home);
+        assert_eq!(s.cursor(), 0);
+        s.handle_events(KeyModifiers::NONE, KeyCode::End);
+        assert_eq!(s.cursor(), 5);
+    }
+
+    #[test]
+    fn left_right_clamp_at_bounds() {
+        let mut s = field();
+        type_str(&mut s, "ab");
+        s.handle_events(KeyModifiers::NONE, KeyCode::Right); // already at end
+        assert_eq!(s.cursor(), 2);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Left);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Left);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Left); // clamp at 0
+        assert_eq!(s.cursor(), 0);
+    }
+
+    #[test]
+    fn multibyte_backspace_removes_one_character() {
+        let mut s = field();
+        type_str(&mut s, "aé语");
+        assert_eq!(s.cursor(), 3);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Backspace);
+        assert_eq!(s.input(), "aé");
+        assert_eq!(s.cursor(), 2);
+    }
+
+    #[test]
+    fn ctrl_f_fills_empty_field_from_autofill() {
+        let mut s = InputFieldStateBuilder::default()
+            .autofill(Some("default".to_string()))
+            .build()
+            .unwrap();
+        s.handle_events(KeyModifiers::CONTROL, KeyCode::Char('f'));
+        assert_eq!(s.input(), "default");
+        assert_eq!(s.cursor(), 7);
+    }
+
+    #[test]
+    fn ctrl_f_does_not_overwrite_non_empty_field() {
+        let mut s = InputFieldStateBuilder::default()
+            .autofill(Some("default".to_string()))
+            .build()
+            .unwrap();
+        type_str(&mut s, "x");
+        s.handle_events(KeyModifiers::CONTROL, KeyCode::Char('f'));
+        assert_eq!(s.input(), "x");
+    }
+
+    #[test]
+    fn ctrl_d_clears_the_input() {
+        let mut s = field();
+        type_str(&mut s, "abc");
+        s.handle_events(KeyModifiers::CONTROL, KeyCode::Char('d'));
+        assert_eq!(s.input(), "");
+        assert_eq!(s.cursor(), 0);
+    }
+
+    #[test]
+    fn disabled_field_ignores_typing() {
+        let mut s = InputFieldStateBuilder::default()
+            .disabled(true)
+            .build()
+            .unwrap();
+        type_str(&mut s, "abc");
+        assert_eq!(s.input(), "");
+    }
+}

--- a/ferrowl-ui/src/state/selection.rs
+++ b/ferrowl-ui/src/state/selection.rs
@@ -67,6 +67,9 @@ where
     ValueType: ToLabel + Clone,
 {
     pub fn move_down(&mut self) {
+        if self.values.is_empty() {
+            return;
+        }
         self.selection = if self.selection >= self.values.len() - 1 {
             0
         } else {
@@ -75,6 +78,9 @@ where
     }
 
     pub fn move_up(&mut self) {
+        if self.values.is_empty() {
+            return;
+        }
         self.selection = if self.selection == 0 {
             self.values.len() - 1
         } else {
@@ -119,5 +125,70 @@ where
             }
             _ => EventResult::Unhandled(modifiers, code),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sel(n: usize) -> SelectionState<String> {
+        let values = (0..n).map(|i| i.to_string()).collect::<Vec<_>>();
+        SelectionStateBuilder::default()
+            .values(values)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn move_down_advances_then_wraps() {
+        let mut s = sel(3);
+        assert_eq!(s.selection(), 0);
+        s.move_down();
+        assert_eq!(s.selection(), 1);
+        s.move_down();
+        assert_eq!(s.selection(), 2);
+        s.move_down(); // wraps to top
+        assert_eq!(s.selection(), 0);
+    }
+
+    #[test]
+    fn move_up_wraps_to_bottom() {
+        let mut s = sel(3);
+        s.move_up(); // from 0 wraps to last
+        assert_eq!(s.selection(), 2);
+        s.move_up();
+        assert_eq!(s.selection(), 1);
+    }
+
+    #[test]
+    fn empty_values_navigation_is_noop_without_panic() {
+        let mut s = sel(0);
+        s.move_down();
+        assert_eq!(s.selection(), 0);
+        s.move_up();
+        assert_eq!(s.selection(), 0);
+    }
+
+    #[test]
+    fn move_left_does_not_underflow_at_zero() {
+        let mut s = sel(3);
+        s.move_left();
+        assert_eq!(s.horizontal_offset(), 0);
+        s.move_right();
+        assert_eq!(s.horizontal_offset(), 1);
+        s.move_left();
+        assert_eq!(s.horizontal_offset(), 0);
+    }
+
+    #[test]
+    fn handle_events_dispatches_navigation() {
+        let mut s = sel(3);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('j'));
+        assert_eq!(s.selection(), 1);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Up);
+        assert_eq!(s.selection(), 0);
+        let r = s.handle_events(KeyModifiers::NONE, KeyCode::Char('z'));
+        assert!(matches!(r, EventResult::Unhandled(..)));
     }
 }

--- a/ferrowl-ui/src/state/table.rs
+++ b/ferrowl-ui/src/state/table.rs
@@ -197,3 +197,119 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Default, Debug, PartialEq)]
+    struct Row(String);
+
+    impl TableEntry<1> for Row {
+        fn values(&self) -> [String; 1] {
+            [self.0.clone()]
+        }
+        fn height(&self) -> u16 {
+            1
+        }
+    }
+
+    fn table(n: usize) -> TableState<Row, 1> {
+        let values = (0..n).map(|i| Row(i.to_string())).collect::<Vec<_>>();
+        TableStateBuilder::default().values(values).build().unwrap()
+    }
+
+    fn selected(s: &TableState<Row, 1>) -> Option<usize> {
+        s.table_state().selected()
+    }
+
+    #[test]
+    fn starts_with_first_row_selected() {
+        assert_eq!(selected(&table(3)), Some(0));
+    }
+
+    #[test]
+    fn move_down_advances_and_clamps_at_bottom() {
+        let mut s = table(3);
+        s.move_down();
+        assert_eq!(selected(&s), Some(1));
+        s.move_down();
+        assert_eq!(selected(&s), Some(2));
+        s.move_down(); // already at last row, stays
+        assert_eq!(selected(&s), Some(2));
+    }
+
+    #[test]
+    fn move_up_retreats_and_clamps_at_top() {
+        let mut s = table(3);
+        s.move_to_bottom();
+        assert_eq!(selected(&s), Some(2));
+        s.move_up();
+        assert_eq!(selected(&s), Some(1));
+        s.move_up();
+        assert_eq!(selected(&s), Some(0));
+        s.move_up(); // already at top, stays
+        assert_eq!(selected(&s), Some(0));
+    }
+
+    #[test]
+    fn move_to_top_and_bottom_jump() {
+        let mut s = table(5);
+        s.move_to_bottom();
+        assert_eq!(selected(&s), Some(4));
+        s.move_to_top();
+        assert_eq!(selected(&s), Some(0));
+    }
+
+    #[test]
+    fn empty_table_navigation_selects_none_without_panic() {
+        let mut s = table(0);
+        s.move_down();
+        assert_eq!(selected(&s), None);
+        s.move_up();
+        assert_eq!(selected(&s), None);
+        s.move_to_bottom();
+        assert_eq!(selected(&s), None);
+        s.move_to_top();
+        assert_eq!(selected(&s), None);
+    }
+
+    #[test]
+    fn single_row_navigation_stays_put() {
+        let mut s = table(1);
+        s.move_down();
+        assert_eq!(selected(&s), Some(0));
+        s.move_up();
+        assert_eq!(selected(&s), Some(0));
+    }
+
+    #[test]
+    fn horizontal_scroll_does_not_underflow_at_left_edge() {
+        let mut s = table(3);
+        s.move_left();
+        assert_eq!(s.horizontal_scroll(), 0);
+        // With zero measured widths there is nothing to scroll into.
+        s.move_right();
+        assert_eq!(s.horizontal_scroll(), 0);
+    }
+
+    #[test]
+    fn handle_events_dispatches_vim_keys() {
+        let mut s = table(4);
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('j'));
+        assert_eq!(selected(&s), Some(1));
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('G'));
+        assert_eq!(selected(&s), Some(3));
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('k'));
+        assert_eq!(selected(&s), Some(2));
+        s.handle_events(KeyModifiers::NONE, KeyCode::Char('g'));
+        assert_eq!(selected(&s), Some(0));
+    }
+
+    #[test]
+    fn handle_events_returns_unhandled_for_unknown_key() {
+        let mut s = table(2);
+        let r = s.handle_events(KeyModifiers::NONE, KeyCode::Char('z'));
+        assert!(matches!(r, EventResult::Unhandled(..)));
+    }
+}


### PR DESCRIPTION
These changes improve the code coverage by adding additional test cases. Additional a bug is fixed that would prevent the execution of `ReadMultipleCoils` because the length was fixed to 1 instead of using the length of the values.