### PR TITLE
Add additional generated test cases to improve total test coverage

### DIFF
--- a/ferrowl-lua/src/builder.rs
+++ b/ferrowl-lua/src/builder.rs
@@ -70,3 +70,25 @@ where
         self.context
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ContextBuilder;
+    use crate::Context;
+
+    #[test]
+    fn ut_builder_from_ok_context() {
+        let builder = ContextBuilder::<String>::from(Ok(Context::default()));
+        assert!(builder.build().is_ok());
+    }
+
+    #[test]
+    fn ut_builder_from_err_context_short_circuits() {
+        // An already-failed context is carried through unchanged, and further
+        // chained calls are no-ops.
+        let builder = ContextBuilder::<String>::from(Err(mlua::Error::BindError))
+            .with_stdlib()
+            .with_script("k".to_string(), "local x = 1");
+        assert!(builder.build().is_err());
+    }
+}

--- a/ferrowl-lua/tests/modules.rs
+++ b/ferrowl-lua/tests/modules.rs
@@ -1,0 +1,155 @@
+//! Integration tests exercising the host modules (Time, Statics, Register)
+//! end-to-end through a real Lua context built with [`ContextBuilder`].
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use ferrowl_lua::module::{
+    Read, RegisterModule, StaticsModule, TimeModule, ValueType, Write,
+};
+use ferrowl_lua::{Context, ContextBuilder, Error, Result};
+
+/// A host register handle whose reads are keyed by name so each typed getter
+/// and each error path can be driven from Lua.
+struct Handle;
+
+impl Read for Handle {
+    fn read(&self, name: String) -> Result<ValueType> {
+        match name.as_str() {
+            "i" => Ok(ValueType::Int(7)),
+            "f" => Ok(ValueType::Float(1.5)),
+            "s" => Ok(ValueType::String("hi".to_string())),
+            "b" => Ok(ValueType::Bool(true)),
+            // Surfaces the `Err(e)` arm of every getter.
+            "err" => Err(Error::RuntimeError("boom".to_string())),
+            // Any other name returns an Int, which is the wrong type for the
+            // float/string/bool getters -> exercises the type-mismatch arm.
+            _ => Ok(ValueType::Int(0)),
+        }
+    }
+}
+
+impl Write for Handle {
+    fn write(&self, _name: String, _value: String) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn statics_module() -> StaticsModule {
+    let mut s = StaticsModule::default();
+    // Exercises `add` (returns previous value, here None).
+    assert!(s.add("i".to_string(), ValueType::Int(42)).is_none());
+    s.add("f".to_string(), ValueType::Float(1.5));
+    s.add("s".to_string(), ValueType::String("hi".to_string()));
+    s.add("b".to_string(), ValueType::Bool(true));
+    s
+}
+
+const TIME_SCRIPT: &str = r#"
+    assert(C_Time:Get() >= 0)
+    assert(C_Time:GetMs() >= 0)
+"#;
+
+const STATICS_SCRIPT: &str = r#"
+    assert(C_Statics:GetInt("i") == 42)
+    assert(C_Statics:GetFloat("f") == 1.5)
+    assert(C_Statics:GetString("s") == "hi")
+    assert(C_Statics:GetBool("b") == true)
+    -- Missing/typed-wrong keys error out.
+    assert(not pcall(function() return C_Statics:GetInt("missing") end))
+    assert(not pcall(function() return C_Statics:GetFloat("i") end))
+    assert(not pcall(function() return C_Statics:GetString("i") end))
+    assert(not pcall(function() return C_Statics:GetBool("i") end))
+"#;
+
+const REGISTER_SCRIPT: &str = r#"
+    assert(C_Register:GetInt("i") == 7)
+    assert(C_Register:GetFloat("f") == 1.5)
+    assert(C_Register:GetString("s") == "hi")
+    assert(C_Register:GetBool("b") == true)
+    C_Register:Set("x", "99")
+    -- Host read error propagates.
+    assert(not pcall(function() return C_Register:GetInt("err") end))
+    assert(not pcall(function() return C_Register:GetFloat("err") end))
+    assert(not pcall(function() return C_Register:GetString("err") end))
+    assert(not pcall(function() return C_Register:GetBool("err") end))
+    -- Wrong-type reads error.
+    assert(not pcall(function() return C_Register:GetInt("f") end))
+    assert(not pcall(function() return C_Register:GetFloat("i") end))
+    assert(not pcall(function() return C_Register:GetString("i") end))
+    assert(not pcall(function() return C_Register:GetBool("i") end))
+"#;
+
+fn build_context() -> Context<String> {
+    ContextBuilder::<String>::default()
+        .with_stdlib()
+        .with_module(TimeModule::default())
+        .with_module(statics_module())
+        .with_module(RegisterModule::init(Handle))
+        .with_script("time".to_string(), TIME_SCRIPT)
+        .with_script("statics".to_string(), STATICS_SCRIPT)
+        .with_script("register".to_string(), REGISTER_SCRIPT)
+        .build()
+        .expect("context build failed")
+}
+
+#[test]
+fn ut_modules_run_via_call() {
+    let mut ctx = build_context();
+    ctx.call(&"time".to_string()).unwrap();
+    ctx.call(&"statics".to_string()).unwrap();
+    ctx.call(&"register".to_string()).unwrap();
+}
+
+#[test]
+fn ut_iter_lists_loaded_scripts() {
+    let ctx = build_context();
+    assert_eq!(ctx.iter().count(), 3);
+}
+
+#[test]
+fn ut_call_all_ok_when_no_script_errors() {
+    let mut ctx = build_context();
+    // Every script asserts cleanly, so call_all reports success (the Ok arm).
+    assert!(ctx.call_all(Duration::ZERO).is_ok());
+}
+
+#[test]
+fn ut_refresh_all_runs_then_throttles() {
+    let mut ctx = build_context();
+    // First pass with a zero window runs everything successfully.
+    assert!(ctx.refresh_all(Duration::ZERO).is_ok());
+    // A large window skips the just-run scripts (still Ok, nothing executed).
+    assert!(ctx.refresh_all(Duration::from_secs(3600)).is_ok());
+}
+
+#[test]
+fn ut_refresh_all_collects_errors() {
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_script("boom".to_string(), "error('x')")
+        .build()
+        .unwrap();
+    let errs = ctx.refresh_all(Duration::ZERO).unwrap_err();
+    assert_eq!(errs.len(), 1);
+}
+
+#[test]
+fn ut_statics_from_constructor() {
+    let mut data = HashMap::new();
+    data.insert("k".to_string(), ValueType::Int(1));
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_module(StaticsModule::from(data))
+        .with_script("s".to_string(), r#"assert(C_Statics:GetInt("k") == 1)"#)
+        .build()
+        .unwrap();
+    ctx.call(&"s".to_string()).unwrap();
+}
+
+#[test]
+fn ut_builder_propagates_script_error() {
+    // Invalid Lua makes the builder carry the error through to build().
+    let result = ContextBuilder::<String>::default()
+        .with_script("bad".to_string(), "this is ! not lua")
+        .build();
+    assert!(result.is_err());
+}

--- a/ferrowl-mem/src/memory.rs
+++ b/ferrowl-mem/src/memory.rs
@@ -394,4 +394,115 @@ mod tests {
 
         assert!(!memory.readable(&1u8, &Type::Coil, &Range::new(0, 5)));
     }
+
+    #[test]
+    fn ut_memory_add_ranges_empty() {
+        let mut memory: Memory<u8> = Memory::default();
+        // Vacant key with no ranges: nothing to insert, still succeeds.
+        assert!(memory.add_ranges(1u8, &Kind::Read(Type::Coil), &[]));
+        assert!(memory.slices.get(&1u8).is_none());
+    }
+
+    #[test]
+    fn ut_memory_widen_read_then_write() {
+        // Read cell + overlapping Write of same type -> ReadWrite.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Read(Type::Register), &[Range::new(0, 5)]);
+        assert!(memory.add_ranges(1u8, &Kind::Write(Type::Register), &[Range::new(0, 5)]));
+        assert!(memory.readable(&1u8, &Type::Register, &Range::new(0, 5)));
+        assert!(memory.writable(&1u8, &Type::Register, &Range::new(0, 5)));
+    }
+
+    #[test]
+    fn ut_memory_widen_write_then_read() {
+        // Write cell + overlapping Read of same type -> ReadWrite.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Write(Type::Coil), &[Range::new(0, 5)]);
+        assert!(memory.add_ranges(1u8, &Kind::Read(Type::Coil), &[Range::new(0, 5)]));
+        assert!(memory.readable(&1u8, &Type::Coil, &Range::new(0, 5)));
+        assert!(memory.writable(&1u8, &Type::Coil, &Range::new(0, 5)));
+    }
+
+    #[test]
+    fn ut_memory_widen_write_then_write_noop() {
+        // Write cell + overlapping Write of same type -> unchanged, still write-only.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Write(Type::Coil), &[Range::new(0, 5)]);
+        assert!(memory.add_ranges(1u8, &Kind::Write(Type::Coil), &[Range::new(0, 5)]));
+        assert!(!memory.readable(&1u8, &Type::Coil, &Range::new(0, 5)));
+        assert!(memory.writable(&1u8, &Type::Coil, &Range::new(0, 5)));
+    }
+
+    #[test]
+    fn ut_memory_widen_readwrite_then_readwrite_noop() {
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::ReadWrite(Type::Coil), &[Range::new(0, 5)]);
+        assert!(memory.add_ranges(1u8, &Kind::ReadWrite(Type::Coil), &[Range::new(0, 5)]));
+        assert!(memory.readable(&1u8, &Type::Coil, &Range::new(0, 5)));
+        assert!(memory.writable(&1u8, &Type::Coil, &Range::new(0, 5)));
+    }
+
+    #[test]
+    fn ut_memory_widen_incompatible_read_cell() {
+        // Read cell + overlapping incompatible access (wrong type) -> false.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Read(Type::Coil), &[Range::new(0, 5)]);
+        assert!(!memory.add_ranges(1u8, &Kind::Write(Type::Register), &[Range::new(0, 5)]));
+    }
+
+    #[test]
+    fn ut_memory_widen_incompatible_write_cell() {
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Write(Type::Coil), &[Range::new(0, 5)]);
+        assert!(!memory.add_ranges(1u8, &Kind::Read(Type::Register), &[Range::new(0, 5)]));
+    }
+
+    #[test]
+    fn ut_memory_widen_incompatible_readwrite_cell() {
+        // ReadWrite cell + non-ReadWrite overlapping access -> false.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::ReadWrite(Type::Coil), &[Range::new(0, 5)]);
+        assert!(!memory.add_ranges(1u8, &Kind::Read(Type::Coil), &[Range::new(0, 5)]));
+    }
+
+    #[test]
+    fn ut_memory_write_read_unchecked() {
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::Read(Type::Register), &[Range::new(0, 5)]);
+
+        // Checked write fails on read-only cells; unchecked forces it.
+        let values: Vec<u16> = vec![5, 6, 7, 8, 9];
+        assert!(!memory.write(1u8, &Type::Register, &Range::new(0, 5), &values));
+        assert!(memory.write_unchecked(1u8, &Range::new(0, 5), &values));
+        assert_eq!(memory.read_unchecked(1u8, &Range::new(0, 5)), Some(values));
+
+        // Length mismatch and unknown key both fail / return None.
+        assert!(!memory.write_unchecked(1u8, &Range::new(0, 5), &[1, 2]));
+        assert!(!memory.write_unchecked(9u8, &Range::new(0, 5), &[1, 2, 3, 4, 5]));
+        assert!(memory.read_unchecked(9u8, &Range::new(0, 5)).is_none());
+    }
+
+    #[test]
+    fn ut_memory_walk_multiple_slices() {
+        // Two adjacent but non-overlapping slices: a read/write spanning both
+        // walks each slice in turn.
+        let mut memory: Memory<u8> = Memory::default();
+        memory.add_ranges(1u8, &Kind::ReadWrite(Type::Register), &[Range::new(0, 5)]);
+        memory.add_ranges(1u8, &Kind::ReadWrite(Type::Register), &[Range::new(5, 5)]);
+        assert_eq!(memory.slices.get(&1u8).unwrap().len(), 2);
+
+        let values: Vec<u16> = (1..=10).collect();
+        assert!(memory.write(1u8, &Type::Register, &Range::new(0, 10), &values));
+        assert_eq!(
+            memory.read(1u8, &Type::Register, &Range::new(0, 10)),
+            Some(values)
+        );
+
+        // A range living only in the second slice: the first slice is skipped.
+        assert!(memory.write(1u8, &Type::Register, &Range::new(7, 3), &[70, 80, 90]));
+        assert_eq!(
+            memory.read(1u8, &Type::Register, &Range::new(7, 3)),
+            Some(vec![70, 80, 90])
+        );
+    }
 }

--- a/ferrowl-mem/src/range.rs
+++ b/ferrowl-mem/src/range.rs
@@ -215,4 +215,10 @@ mod tests {
         let b = Range::new(6, 8);
         assert_eq!(a.intersect(&b), b.intersect(&a));
     }
+
+    #[test]
+    fn ut_range_display() {
+        assert_eq!(format!("{}", Range::new(10, 5)), "[10, 15)");
+        assert_eq!(format!("{}", Range::new(0, 0)), "[0, 0)");
+    }
 }

--- a/ferrowl-mem/src/slice.rs
+++ b/ferrowl-mem/src/slice.rs
@@ -466,4 +466,49 @@ mod tests {
         assert!(slice.read(&Range::new(190, 20)).is_none());
         assert!(slice.read(&Range::new(500, 20)).is_none());
     }
+
+    #[test]
+    fn ut_slice_extend_non_adjacent() {
+        let mut slice = Slice::from_range(&Kind::Read(Type::Coil), Range::new(100, 10));
+        // Range neither ends at start nor starts at end -> no-op, returns false.
+        assert!(!slice.extend(&Kind::Write(Type::Coil), &Range::new(200, 10)));
+        assert_eq!(slice.buffer.len(), 10);
+        assert_eq!(slice.range, Range::new(100, 10));
+    }
+
+    #[test]
+    fn ut_slice_write_unchecked() {
+        let mut slice = Slice::from_range(&Kind::Read(Type::Coil), Range::new(0, 5));
+        slice.extend(&Kind::Write(Type::Coil), &Range::new(5, 3));
+        slice.extend(&Kind::ReadWrite(Type::Coil), &Range::new(8, 2));
+
+        // Forces writes into Read, Write and ReadWrite cells alike.
+        let values: Vec<u16> = (1..=10).collect();
+        assert!(slice.write_unchecked(&Range::new(0, 10), &values));
+        let read = slice.read_unchecked(&Range::new(0, 10)).unwrap();
+        assert_eq!(read, values);
+
+        // Out of bounds and length-mismatch both fail.
+        assert!(!slice.write_unchecked(&Range::new(0, 20), &(1..=20).collect::<Vec<u16>>()));
+        assert!(!slice.write_unchecked(&Range::new(0, 5), &[1, 2, 3]));
+    }
+
+    #[test]
+    fn ut_slice_read_unchecked() {
+        let mut slice = Slice::from_range(&Kind::Write(Type::Register), Range::new(0, 4));
+        // Write-only cells are unreadable via read() but read_unchecked returns stored values.
+        assert!(slice.read(&Range::new(0, 4)).is_none());
+        assert!(slice.write(&Range::new(0, 4), &[11, 22, 33, 44]));
+        assert_eq!(slice.read_unchecked(&Range::new(0, 4)).unwrap(), vec![11, 22, 33, 44]);
+
+        // Out of bounds -> None.
+        assert!(slice.read_unchecked(&Range::new(0, 99)).is_none());
+    }
+
+    #[test]
+    fn ut_slice_readable_out_of_range() {
+        let slice = Slice::from_range(&Kind::Read(Type::Coil), Range::new(10, 5));
+        assert!(!slice.readable(&Type::Coil, &Range::new(0, 5)));
+        assert!(!slice.writable(&Type::Coil, &Range::new(0, 5)));
+    }
 }

--- a/ferrowl-mem/src/value.rs
+++ b/ferrowl-mem/src/value.rs
@@ -135,4 +135,19 @@ mod tests {
         assert_eq!(range.range.start, 100);
         assert_eq!(range.range.end, 120);
     }
+
+    #[test]
+    fn ut_kind_get_type() {
+        assert_eq!(Kind::Read(Type::Coil).get_type(), Type::Coil);
+        assert_eq!(Kind::Write(Type::Register).get_type(), Type::Register);
+        assert_eq!(Kind::ReadWrite(Type::Coil).get_type(), Type::Coil);
+    }
+
+    #[test]
+    fn ut_value_range_accessors() {
+        let values: Vec<u16> = vec![7, 8, 9];
+        let range = ValueRange::new(50, &values);
+        assert_eq!(range.get_values(), &[7, 8, 9]);
+        assert_eq!(range.get_range(), crate::range::Range::new(50, 3));
+    }
 }

--- a/ferrowl-net/Cargo.toml
+++ b/ferrowl-net/Cargo.toml
@@ -23,5 +23,9 @@ clap = { version = "4.5.51", features = ["derive"] }
 
 [dev-dependencies]
 # Async test harness for the `handle_request` server logic (the crate's own tokio dep is
-# `time`-only since the library never spins up a runtime itself).
-tokio = { version = "1.48.0", features = ["rt", "macros", "sync", "time"] }
+# `time`-only since the library never spins up a runtime itself). `rt-multi-thread` is required by
+# the TCP loopback integration test: the server's `block_in_place` needs a multi-threaded runtime.
+# `ferrowl-mem`/`ferrowl-reg` let that test build and seed memory directly.
+tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
+ferrowl-mem = { path = "../ferrowl-mem" }
+ferrowl-reg = { path = "../ferrowl-reg" }

--- a/ferrowl-net/src/common.rs
+++ b/ferrowl-net/src/common.rs
@@ -107,6 +107,12 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ut_serial_config_accepts_both_stop_bits() {
+        assert!(serial_config_from("/dev/null", 9600, None, Some(1), None).is_ok());
+        assert!(serial_config_from("/dev/null", 9600, None, Some(2), None).is_ok());
+    }
+
     // Verifies the stable `LogFn` blanket impl (replacing the former nightly `async_fn_traits`
     // bound) is satisfied by an ordinary closure returning a `Send` async block. Compile-time
     // check only — no runtime needed (this crate's tokio has no `rt` feature).

--- a/ferrowl-net/src/server_core.rs
+++ b/ferrowl-net/src/server_core.rs
@@ -870,4 +870,123 @@ mod tests {
             .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalFunction);
     }
+
+    // ---- Verbose logging: every arm's success/failure log branch ----
+
+    #[tokio::test]
+    async fn ut_verbose_logs_success_for_every_request() {
+        macro_rules! ok {
+            ($mem:expr, $req:expr) => {{
+                let mem = $mem;
+                let (log, buf) = recording_log();
+                handle_request::<SlaveKind, _>(1, $req, &mem, &log, true)
+                    .await
+                    .unwrap();
+                assert!(
+                    buf.lock().unwrap().iter().any(|l| l.contains("successful")),
+                    "missing success log line"
+                );
+            }};
+        }
+        ok!(
+            seeded(RegKind::Coil, Type::Coil, 8, &[1, 0, 1, 0, 1, 0, 1, 0]),
+            Request::ReadCoils(0, 4)
+        );
+        ok!(
+            seeded(RegKind::Coil, Type::Coil, 8, &[]),
+            Request::WriteSingleCoil(0, true)
+        );
+        ok!(
+            seeded(RegKind::Coil, Type::Coil, 8, &[]),
+            Request::WriteMultipleCoils(0, vec![true, false, true].into())
+        );
+        ok!(
+            seeded(RegKind::DiscreteInput, Type::Coil, 4, &[1, 1, 1, 1]),
+            Request::ReadDiscreteInputs(0, 4)
+        );
+        ok!(
+            seeded(RegKind::InputRegister, Type::Register, 4, &[1, 2, 3, 4]),
+            Request::ReadInputRegisters(0, 4)
+        );
+        ok!(
+            seeded(RegKind::HoldingRegister, Type::Register, 8, &[]),
+            Request::WriteSingleRegister(0, 9)
+        );
+        ok!(
+            seeded(RegKind::HoldingRegister, Type::Register, 8, &[]),
+            Request::WriteMultipleRegisters(0, vec![1, 2, 3].into())
+        );
+        ok!(
+            seeded(RegKind::HoldingRegister, Type::Register, 8, &[5, 6, 7, 8]),
+            Request::ReadWriteMultipleRegisters(0, 2, 2, vec![7, 8].into())
+        );
+    }
+
+    #[tokio::test]
+    async fn ut_verbose_logs_failure_for_every_request() {
+        macro_rules! fail {
+            ($mem:expr, $req:expr) => {{
+                let mem = $mem;
+                let (log, buf) = recording_log();
+                let _ = handle_request::<SlaveKind, _>(1, $req, &mem, &log, true).await;
+                assert!(
+                    buf.lock().unwrap().iter().any(|l| l.contains("failed")),
+                    "missing failure log line"
+                );
+            }};
+        }
+        fail!(
+            seeded(RegKind::Coil, Type::Coil, 4, &[]),
+            Request::ReadCoils(10, 2)
+        );
+        fail!(
+            seeded(RegKind::Coil, Type::Coil, 4, &[]),
+            Request::WriteSingleCoil(9, true)
+        );
+        fail!(
+            seeded(RegKind::Coil, Type::Coil, 4, &[]),
+            Request::WriteMultipleCoils(6, vec![true; 5].into())
+        );
+        fail!(
+            seeded(RegKind::DiscreteInput, Type::Coil, 4, &[]),
+            Request::ReadDiscreteInputs(10, 2)
+        );
+        fail!(
+            seeded(RegKind::InputRegister, Type::Register, 4, &[]),
+            Request::ReadInputRegisters(10, 2)
+        );
+        fail!(
+            seeded(RegKind::HoldingRegister, Type::Register, 4, &[]),
+            Request::ReadHoldingRegisters(10, 2)
+        );
+        fail!(
+            seeded(RegKind::HoldingRegister, Type::Register, 4, &[]),
+            Request::WriteSingleRegister(99, 1)
+        );
+        fail!(
+            seeded(RegKind::HoldingRegister, Type::Register, 4, &[]),
+            Request::WriteMultipleRegisters(3, vec![1, 2, 3].into())
+        );
+        // Write address out of range -> writable check fails (verbose failure branch).
+        fail!(
+            seeded(RegKind::HoldingRegister, Type::Register, 4, &[1, 2, 3, 4]),
+            Request::ReadWriteMultipleRegisters(0, 2, 10, vec![1, 2].into())
+        );
+    }
+
+    #[tokio::test]
+    async fn ut_unsupported_function_codes_are_illegal() {
+        let mem = seeded(RegKind::HoldingRegister, Type::Register, 4, &[]);
+        let (log, _) = recording_log();
+        for req in [
+            Request::MaskWriteRegister(0, 0, 0),
+            Request::ReadDeviceIdentification(tokio_modbus::prelude::ReadCode::Basic, 0),
+            Request::Custom(0x65, vec![].into()),
+        ] {
+            let err = handle_request::<SlaveKind, _>(1, req, &mem, &log, false)
+                .await
+                .unwrap_err();
+            assert_eq!(err, ExceptionCode::IllegalFunction);
+        }
+    }
 }

--- a/ferrowl-net/tests/tcp_loopback.rs
+++ b/ferrowl-net/tests/tcp_loopback.rs
@@ -1,0 +1,259 @@
+//! End-to-end TCP test: a ferrowl Modbus TCP server and client talk over a
+//! loopback socket. Drives the shared client loop (`client_core`) through every
+//! read function code and every write command, plus graceful termination.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrowl_mem::{Kind as MemKind, Memory, Range, Type};
+use ferrowl_reg::Kind as RegKind;
+use ferrowl_net::tcp;
+use ferrowl_net::{Command, FunctionCode, Key, Operation, SlaveKind};
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<RwLock<Memory<Key<SlaveKind>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKind> {
+    Key::new(SlaveKind { slave_id: 1, kind })
+}
+
+/// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
+fn sink() -> impl ferrowl_net::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+/// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn config(port: u16) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+    }
+}
+
+/// Server memory seeded with distinct values in all four register tables.
+fn server_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKind>>::default();
+    mem.add_ranges(key(RegKind::Coil), &MemKind::ReadWrite(Type::Coil), &[Range::new(0, 8)]);
+    mem.write(key(RegKind::Coil), &Type::Coil, &Range::new(0, 4), &[1, 0, 1, 0]);
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(Type::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.write(key(RegKind::DiscreteInput), &Type::Coil, &Range::new(0, 4), &[0, 1, 1, 0]);
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(Type::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::InputRegister),
+        &Type::Register,
+        &Range::new(0, 4),
+        &[100, 200, 300, 400],
+    );
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(Type::Register),
+        &[Range::new(0, 8)],
+    );
+    mem.write(
+        key(RegKind::HoldingRegister),
+        &Type::Register,
+        &Range::new(0, 4),
+        &[10, 20, 30, 40],
+    );
+    Arc::new(RwLock::new(mem))
+}
+
+/// Client memory with the same regions declared but no values (the client fills them from reads).
+fn client_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKind>>::default();
+    mem.add_ranges(key(RegKind::Coil), &MemKind::ReadWrite(Type::Coil), &[Range::new(0, 8)]);
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(Type::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(Type::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(Type::Register),
+        &[Range::new(0, 8)],
+    );
+    Arc::new(RwLock::new(mem))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tcp_client_polls_server_and_executes_commands() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // Start the server.
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem.clone())
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // Operations cover every read function code the client supports.
+    let operations = Arc::new(RwLock::new(vec![
+        Operation { slave_id: 1, fn_code: FunctionCode::ReadCoils, range: Range::new(0, 4) },
+        Operation {
+            slave_id: 1,
+            fn_code: FunctionCode::ReadDiscreteInputs,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: 1,
+            fn_code: FunctionCode::ReadInputRegisters,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: 1,
+            fn_code: FunctionCode::ReadHoldingRegisters,
+            range: Range::new(0, 4),
+        },
+    ]));
+
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Let the client poll every operation at least once.
+    sleep(Duration::from_millis(800)).await;
+
+    {
+        let g = cli_mem.read().await;
+        assert_eq!(
+            g.read(key(RegKind::HoldingRegister), &Type::Register, &Range::new(0, 4)),
+            Some(vec![10, 20, 30, 40])
+        );
+        assert_eq!(
+            g.read(key(RegKind::InputRegister), &Type::Register, &Range::new(0, 4)),
+            Some(vec![100, 200, 300, 400])
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &Type::Coil, &Range::new(0, 4)),
+            Some(vec![1, 0, 1, 0])
+        );
+        assert_eq!(
+            g.read(key(RegKind::DiscreteInput), &Type::Coil, &Range::new(0, 4)),
+            Some(vec![0, 1, 1, 0])
+        );
+    }
+
+    // Exercise every write command against the server.
+    tx.send(Command::WriteSingleRegister(1, 0, 99)).await.unwrap();
+    tx.send(Command::WriteMultipleRegister(1, 1, vec![5, 6])).await.unwrap();
+    tx.send(Command::WriteSingleCoil(1, 5, true)).await.unwrap();
+    tx.send(Command::WriteMultipleCoils(1, 6, vec![true, false])).await.unwrap();
+    sleep(Duration::from_millis(600)).await;
+
+    {
+        let g = srv_mem.read().await;
+        assert_eq!(
+            g.read(key(RegKind::HoldingRegister), &Type::Register, &Range::new(0, 3)),
+            Some(vec![99, 5, 6])
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &Type::Coil, &Range::new(5, 3)),
+            Some(vec![1, 1, 0])
+        );
+    }
+
+    // Graceful termination returns Ok and ends the client task.
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn tcp_client_handles_server_rejections() {
+    let port = free_port();
+    // Server with no registered regions: every request for slave 1 is rejected.
+    let srv_mem: Mem = Arc::new(RwLock::new(Memory::<Key<SlaveKind>>::default()));
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        client_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Several poll cycles let the exception-retry counter pass MAX_RETRIES.
+    sleep(Duration::from_millis(800)).await;
+
+    // Writes the server rejects -> the "invalid" command branches.
+    tx.send(Command::WriteSingleRegister(1, 0, 1)).await.unwrap();
+    tx.send(Command::WriteMultipleRegister(1, 0, vec![1, 2])).await.unwrap();
+    tx.send(Command::WriteSingleCoil(1, 0, true)).await.unwrap();
+    tx.send(Command::WriteMultipleCoils(1, 0, vec![true])).await.unwrap();
+    sleep(Duration::from_millis(600)).await;
+
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test]
+async fn tcp_client_connect_refused_is_error() {
+    // Nothing is listening on this port, so the connect fails.
+    let port = free_port();
+    assert!(tcp::Client::connect(&config(port)).await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tcp_server_bind_conflict_is_error() {
+    let port = free_port();
+    // Occupy the port so the server's bind fails.
+    let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let mem: Mem = Arc::new(RwLock::new(Memory::<Key<SlaveKind>>::default()));
+    let res = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), mem)
+        .spawn(sink())
+        .await;
+    assert!(res.is_err());
+}

--- a/ferrowl-reg/src/codec.rs
+++ b/ferrowl-reg/src/codec.rs
@@ -670,6 +670,93 @@ mod tests {
         assert_eq!(reg(u8_be()).write_mask(), vec![0x00FFu16]);
     }
 
+    // --- Wider integer variants, both endians (decode/encode/mask) ---
+
+    #[test]
+    fn ut_roundtrip_wide_ints() {
+        let e = [Endian::Big, Endian::Little];
+        for endian in e {
+            let u64f = Format::U64((endian.clone(), res(), bf()));
+            let u128f = Format::U128((endian.clone(), res(), bf()));
+            let i16f = Format::I16((endian.clone(), res(), bf()));
+            let i64f = Format::I64((endian.clone(), res(), bf()));
+            let i128f = Format::I128((endian.clone(), res(), bf()));
+
+            // Display scales through f64, so values stay within f64's exact
+            // integer range (< 2^53) to survive the round-trip string compare.
+            for (f, s) in [
+                (u64f, "1234567890123"),
+                (u128f, "123456789012345"),
+                (i16f, "-12345"),
+                (i64f, "-1234567890123"),
+                (i128f, "-123456789012345"),
+            ] {
+                let r = reg(f);
+                let words = r.encode(s).unwrap();
+                assert_eq!(r.decode(&words).unwrap().to_string(), s);
+            }
+        }
+    }
+
+    #[test]
+    fn ut_roundtrip_floats_little_endian() {
+        let f32le = reg(Format::F32((Endian::Little, res())));
+        let words = f32le.encode("1.5").unwrap();
+        match f32le.decode(&words).unwrap() {
+            Value::F32((f, _)) => assert!((f - 1.5f32).abs() < 1e-6),
+            _ => panic!("Wrong variant"),
+        }
+
+        let f64le = reg(Format::F64((Endian::Little, res())));
+        let words = f64le.encode("2.25").unwrap();
+        match f64le.decode(&words).unwrap() {
+            Value::F64((f, _)) => assert!((f - 2.25f64).abs() < 1e-10),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn ut_encode_f64_hex() {
+        let bits = 2.5f64.to_bits();
+        let hex_str = format!("0x{:016X}", bits);
+        let r = reg(f64_be());
+        let words = r.encode(&hex_str).unwrap();
+        match r.decode(&words).unwrap() {
+            Value::F64((f, _)) => assert!((f - 2.5f64).abs() < 1e-10),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn ut_encode_i8_little_endian() {
+        // I8 little-endian places the byte in the high byte of the word.
+        let r = reg(Format::I8((Endian::Little, res(), bf())));
+        assert_eq!(r.encode("-1").unwrap(), vec![(-1i8 as u16) << 8]);
+    }
+
+    #[test]
+    fn ut_mask_words_all_widths() {
+        // U8 little-endian mask sits in the high byte.
+        assert_eq!(reg(u8_le()).write_mask(), vec![0xFF00u16]);
+        // U64 / U128 masks span multiple words.
+        assert_eq!(
+            reg(Format::U64((Endian::Big, res(), BitField { mask: u64::MAX as u128 })))
+                .write_mask(),
+            vec![0xFFFFu16; 4]
+        );
+        assert_eq!(
+            reg(Format::U128((Endian::Big, res(), BitField { mask: u128::MAX })))
+                .write_mask(),
+            vec![0xFFFFu16; 8]
+        );
+        // Float / ASCII masks are all-ones across their width.
+        assert_eq!(reg(f32_be()).write_mask(), vec![0xFFFFu16; 2]);
+        assert_eq!(
+            reg(Format::Ascii((Alignment::Left, Width(3)))).write_mask(),
+            vec![0xFFFFu16; 3]
+        );
+    }
+
     #[test]
     fn ut_merge_write_preserves_sibling_bits() {
         // Two U16 regs aliasing one address: low byte and high byte.

--- a/ferrowl-reg/src/enums.rs
+++ b/ferrowl-reg/src/enums.rs
@@ -67,3 +67,34 @@ impl Display for Access {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Access, Address, Kind};
+
+    #[test]
+    fn ut_kind_display() {
+        assert_eq!(Kind::Coil.to_string(), "Coil");
+        assert_eq!(Kind::DiscreteInput.to_string(), "Discrete Input");
+        assert_eq!(Kind::HoldingRegister.to_string(), "Holding Register");
+        assert_eq!(Kind::InputRegister.to_string(), "Input Register");
+    }
+
+    #[test]
+    fn ut_kind_default() {
+        assert_eq!(Kind::default(), Kind::HoldingRegister);
+    }
+
+    #[test]
+    fn ut_address_display() {
+        assert_eq!(Address::Fixed(42).to_string(), "42");
+        assert_eq!(Address::Virtual.to_string(), "virtual");
+    }
+
+    #[test]
+    fn ut_access_display() {
+        assert_eq!(Access::ReadOnly.to_string(), "ReadOnly");
+        assert_eq!(Access::WriteOnly.to_string(), "WriteOnly");
+        assert_eq!(Access::ReadWrite.to_string(), "ReadWrite");
+    }
+}

--- a/ferrowl-reg/src/format.rs
+++ b/ferrowl-reg/src/format.rs
@@ -293,4 +293,94 @@ mod tests {
             0.5
         );
     }
+
+    #[test]
+    fn ut_format_resolution_all_variants() {
+        let r = Resolution(0.25);
+        let e = Endian::Big;
+        for f in [
+            Format::U16((e.clone(), r.clone(), bf())),
+            Format::I8((e.clone(), r.clone(), bf())),
+            Format::U32((e.clone(), r.clone(), bf())),
+            Format::I32((e.clone(), r.clone(), bf())),
+            Format::U64((e.clone(), r.clone(), bf())),
+            Format::I64((e.clone(), r.clone(), bf())),
+            Format::U128((e.clone(), r.clone(), bf())),
+            Format::I128((e.clone(), r.clone(), bf())),
+            Format::F64((e.clone(), r.clone())),
+        ] {
+            assert_eq!(f.resolution().unwrap().0, 0.25);
+        }
+    }
+
+    #[test]
+    fn ut_format_bitfield_all_variants() {
+        let m = BitField { mask: 0x0FF0 };
+        let e = Endian::Big;
+        for f in [
+            Format::U8((e.clone(), res(), m.clone())),
+            Format::U32((e.clone(), res(), m.clone())),
+            Format::U64((e.clone(), res(), m.clone())),
+            Format::U128((e.clone(), res(), m.clone())),
+            Format::I8((e.clone(), res(), m.clone())),
+            Format::I16((e.clone(), res(), m.clone())),
+            Format::I32((e.clone(), res(), m.clone())),
+            Format::I64((e.clone(), res(), m.clone())),
+            Format::I128((e.clone(), res(), m.clone())),
+        ] {
+            assert_eq!(f.bitfield(), m);
+        }
+        // Float variant reports the no-op default.
+        assert!(Format::F64((e, res())).bitfield().is_full());
+    }
+
+    #[test]
+    fn ut_alignment_display() {
+        assert_eq!(Alignment::Left.to_string(), "Left");
+        assert_eq!(Alignment::Right.to_string(), "Right");
+    }
+
+    #[test]
+    fn ut_endian_display() {
+        assert_eq!(Endian::Little.to_string(), "Little Endian");
+        assert_eq!(Endian::Big.to_string(), "Big Endian");
+    }
+
+    #[test]
+    fn ut_resolution_default_and_display() {
+        assert_eq!(Resolution::default().0, 1.0);
+        assert_eq!(Resolution(2.5).to_string(), "2.5");
+    }
+
+    #[test]
+    fn ut_bitfield_default_shift_is_full_display() {
+        assert_eq!(BitField::default().mask, u128::MAX);
+        assert!(BitField::default().is_full());
+        // Zero mask is the degenerate case: shift is 0, not a panic.
+        assert_eq!(BitField { mask: 0 }.shift(), 0);
+        assert_eq!(BitField { mask: 0xFF00 }.shift(), 8);
+        assert!(!BitField { mask: 0xFF00 }.is_full());
+        assert_eq!(BitField { mask: 0xABCD }.to_string(), "0xABCD");
+    }
+
+    #[test]
+    fn ut_format_display_all_variants() {
+        assert_eq!(
+            Format::Ascii((Alignment::Left, Width(2))).to_string(),
+            "ASCII (Left)"
+        );
+        let e = Endian::Big;
+        assert_eq!(Format::U8((e.clone(), res(), bf())).to_string(), "U8 (Big Endian)");
+        assert_eq!(Format::U16((e.clone(), res(), bf())).to_string(), "U16 (Big Endian)");
+        assert_eq!(Format::U32((e.clone(), res(), bf())).to_string(), "U32 (Big Endian)");
+        assert_eq!(Format::U64((e.clone(), res(), bf())).to_string(), "U64 (Big Endian)");
+        assert_eq!(Format::U128((e.clone(), res(), bf())).to_string(), "U128 (Big Endian)");
+        assert_eq!(Format::I8((e.clone(), res(), bf())).to_string(), "I8 (Big Endian)");
+        assert_eq!(Format::I16((e.clone(), res(), bf())).to_string(), "I16 (Big Endian)");
+        assert_eq!(Format::I32((e.clone(), res(), bf())).to_string(), "I32 (Big Endian)");
+        assert_eq!(Format::I64((e.clone(), res(), bf())).to_string(), "I64 (Big Endian)");
+        assert_eq!(Format::I128((e.clone(), res(), bf())).to_string(), "I128 (Big Endian)");
+        assert_eq!(Format::F32((e.clone(), res())).to_string(), "F32 (Big Endian)");
+        assert_eq!(Format::F64((e, res())).to_string(), "F64 (Big Endian)");
+    }
 }

--- a/ferrowl-reg/src/value.rs
+++ b/ferrowl-reg/src/value.rs
@@ -228,4 +228,88 @@ mod tests {
         let expected = format!("0x{:016X}", bits);
         assert_eq!(Value::F64((1.5f64, res())).as_hex_str(), expected);
     }
+
+    #[test]
+    fn ut_unscaled_value_display_all_variants() {
+        use super::UnscaledValue;
+        assert_eq!(UnscaledValue::U8(8).to_string(), "8");
+        assert_eq!(UnscaledValue::U16(16).to_string(), "16");
+        assert_eq!(UnscaledValue::U32(32).to_string(), "32");
+        assert_eq!(UnscaledValue::U64(64).to_string(), "64");
+        assert_eq!(UnscaledValue::U128(128).to_string(), "128");
+        assert_eq!(UnscaledValue::I8(-8).to_string(), "-8");
+        assert_eq!(UnscaledValue::I16(-16).to_string(), "-16");
+        assert_eq!(UnscaledValue::I32(-32).to_string(), "-32");
+        assert_eq!(UnscaledValue::I64(-64).to_string(), "-64");
+        assert_eq!(UnscaledValue::I128(-128).to_string(), "-128");
+        assert_eq!(UnscaledValue::F32(1.5).to_string(), "1.5");
+        assert_eq!(UnscaledValue::F64(2.5).to_string(), "2.5");
+        assert_eq!(UnscaledValue::Ascii("hi".to_string()).to_string(), "hi");
+    }
+
+    #[test]
+    fn ut_value_display_all_numeric_variants() {
+        // Resolution 1.0 keeps the scaled value equal to the raw value.
+        assert_eq!(Value::U32((32, res())).to_string(), "32");
+        assert_eq!(Value::U64((64, res())).to_string(), "64");
+        assert_eq!(Value::U128((128, res())).to_string(), "128");
+        assert_eq!(Value::I64((-64, res())).to_string(), "-64");
+        assert_eq!(Value::I128((-128, res())).to_string(), "-128");
+        assert_eq!(Value::F64((2.5, res())).to_string(), "2.5");
+    }
+
+    #[test]
+    fn ut_value_unscaled_all_variants() {
+        use super::UnscaledValue;
+        assert!(matches!(Value::U8((8, res())).unscaled(), UnscaledValue::U8(8)));
+        assert!(matches!(
+            Value::U32((32, res())).unscaled(),
+            UnscaledValue::U32(32)
+        ));
+        assert!(matches!(
+            Value::U64((64, res())).unscaled(),
+            UnscaledValue::U64(64)
+        ));
+        assert!(matches!(
+            Value::U128((128, res())).unscaled(),
+            UnscaledValue::U128(128)
+        ));
+        assert!(matches!(
+            Value::I8((-8, res())).unscaled(),
+            UnscaledValue::I8(-8)
+        ));
+        assert!(matches!(
+            Value::I16((-16, res())).unscaled(),
+            UnscaledValue::I16(-16)
+        ));
+        assert!(matches!(
+            Value::I64((-64, res())).unscaled(),
+            UnscaledValue::I64(-64)
+        ));
+        assert!(matches!(
+            Value::I128((-128, res())).unscaled(),
+            UnscaledValue::I128(-128)
+        ));
+        assert!(matches!(
+            Value::F64((2.5, res())).unscaled(),
+            UnscaledValue::F64(_)
+        ));
+    }
+
+    #[test]
+    fn ut_value_as_hex_str_remaining_variants() {
+        assert_eq!(
+            Value::U128((0x1, res())).as_hex_str(),
+            "0x00000000000000000000000000000001"
+        );
+        assert_eq!(Value::I32((-1i32, res())).as_hex_str(), "0xFFFFFFFF");
+        assert_eq!(
+            Value::I64((-1i64, res())).as_hex_str(),
+            "0xFFFFFFFFFFFFFFFF"
+        );
+        assert_eq!(
+            Value::I128((-1i128, res())).as_hex_str(),
+            "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        );
+    }
 }

--- a/ferrowl-ui/src/state/button.rs
+++ b/ferrowl-ui/src/state/button.rs
@@ -40,3 +40,27 @@ impl HandleEvents for ButtonState {
         EventResult::Unhandled(modifiers, code)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ut_button_state_focus_toggles() {
+        let mut s = ButtonStateBuilder::default().label("ok".to_string()).build().unwrap();
+        assert!(s.is_focused()); // focused defaults to true
+        // Call the trait method explicitly: getset also generates an inherent `set_focused`
+        // that would otherwise shadow the `SetFocus` impl.
+        SetFocus::set_focused(&mut s, false);
+        assert!(!IsFocus::is_focused(&s));
+        assert_eq!(s.label(), "ok");
+        assert!(!s.disabled());
+    }
+
+    #[test]
+    fn ut_button_state_never_consumes_keys() {
+        let mut s = ButtonState::default();
+        let r = s.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+        assert!(matches!(r, EventResult::Unhandled(..)));
+    }
+}

--- a/ferrowl-ui/tests/render.rs
+++ b/ferrowl-ui/tests/render.rs
@@ -1,0 +1,330 @@
+//! Render-path coverage for the `widgets`, `style`, and `traits` modules:
+//! every widget is drawn into an off-screen [`Buffer`] in the configurations
+//! that exercise its border, focus, wrapping, scrolling, and placeholder
+//! branches. We assert that rendering does not panic and (where cheap) that
+//! something was drawn; the goal is to drive the layout/scroll logic.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::{HorizontalAlignment, Margin, Rect};
+use ratatui::widgets::{StatefulWidget, Widget as RWidget};
+
+use ferrowl_ui::state::{
+    ButtonStateBuilder, CodeInputFieldStateBuilder, InputFieldStateBuilder, ScrollingTabsState,
+    SelectionStateBuilder, TableStateBuilder,
+};
+use ferrowl_ui::style::{
+    ButtonStyle, InputFieldStyle, ScrollingTabsStyle, SelectionStyle, TableStyle, TextStyle,
+};
+use ferrowl_ui::traits::{Init, ToLabel};
+use ferrowl_ui::types::Border;
+use ferrowl_ui::widgets::{
+    ButtonBuilder, CodeInputFieldBuilder, Header, InputFieldBuilder, ScrollingTabsBuilder,
+    SelectionBuilder, TableBuilder, TableEntry, TextBuilder, Title, Width,
+};
+
+fn buffer(w: u16, h: u16) -> Buffer {
+    Buffer::empty(Rect::new(0, 0, w, h))
+}
+
+fn full_border() -> Border {
+    Border::Full(Margin::new(0, 0))
+}
+
+// ---- traits ----
+
+#[test]
+fn init_and_to_label() {
+    // `Init` for the standard streams.
+    let _o = std::io::Stdout::init();
+    let _e = std::io::Stderr::init();
+    // `ToLabel` for owned and borrowed strings.
+    assert_eq!(String::from("x").to_label(), "x");
+    assert_eq!("y".to_label(), "y");
+}
+
+// ---- styles ----
+
+#[test]
+fn style_defaults_build() {
+    let _ = ButtonStyle::default();
+    let _ = InputFieldStyle::default();
+    let _ = ScrollingTabsStyle::default();
+    let _ = SelectionStyle::default();
+    let _ = TableStyle::default();
+    let _ = TextStyle::default();
+}
+
+// ---- Button ----
+
+#[test]
+fn button_render_variants() {
+    let widget = ButtonBuilder::default().build().unwrap();
+
+    // Focused (default), short label.
+    let mut st = ButtonStateBuilder::default().label("OK".to_string()).build().unwrap();
+    let mut b = buffer(20, 3);
+    StatefulWidget::render(&widget, Rect::new(0, 0, 20, 3), &mut b, &mut st);
+
+    // Disabled -> general style; owned-widget render path.
+    let mut st = ButtonStateBuilder::default()
+        .label("NO".to_string())
+        .disabled(true)
+        .build()
+        .unwrap();
+    let mut b = buffer(20, 3);
+    StatefulWidget::render(widget.clone(), Rect::new(0, 0, 20, 3), &mut b, &mut st);
+
+    // Long label in a narrow area -> wrapping fold; multiline + alignment.
+    let wide = ButtonBuilder::default()
+        .multiline(true)
+        .horizontal_alignment(HorizontalAlignment::Center)
+        .build()
+        .unwrap();
+    let mut st = ButtonStateBuilder::default()
+        .label("a very long button label that wraps".to_string())
+        .build()
+        .unwrap();
+    let mut b = buffer(8, 6);
+    StatefulWidget::render(&wide, Rect::new(0, 0, 8, 6), &mut b, &mut st);
+}
+
+// ---- Text ----
+
+#[test]
+fn text_render_variants() {
+    // Borderless, short.
+    let t = TextBuilder::default().build().unwrap();
+    let mut s = "hello".to_string();
+    let mut b = buffer(20, 3);
+    StatefulWidget::render(&t, Rect::new(0, 0, 20, 3), &mut b, &mut s);
+
+    // Bordered + title + multiline + long text that wraps; owned render path.
+    let t = TextBuilder::default()
+        .border(full_border())
+        .title(Some("title".into()))
+        .multiline(true)
+        .build()
+        .unwrap();
+    let mut s = "a fairly long string that should wrap across rows".to_string();
+    let mut b = buffer(10, 8);
+    StatefulWidget::render(t, Rect::new(0, 0, 10, 8), &mut b, &mut s);
+}
+
+// ---- InputField ----
+
+#[test]
+fn input_field_render_variants() {
+    // Empty + focused -> placeholder fallback text and cursor drawn.
+    let f = InputFieldBuilder::<String>::default().build().unwrap();
+    let mut st = InputFieldStateBuilder::default().build().unwrap();
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(&f, Rect::new(0, 0, 20, 1), &mut b, &mut st);
+
+    // Autofill on an empty field.
+    let mut st = InputFieldStateBuilder::default()
+        .autofill(Some("auto".to_string()))
+        .build()
+        .unwrap();
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(&f, Rect::new(0, 0, 20, 1), &mut b, &mut st);
+
+    // Numeric field with invalid, overflowing input -> error style + scroll window.
+    let f = InputFieldBuilder::<i32>::default()
+        .border(full_border())
+        .title(Some("n".into()))
+        .build()
+        .unwrap();
+    let mut st = InputFieldStateBuilder::default()
+        .input("not-a-number-and-very-long-indeed".to_string())
+        .cursor(12)
+        .build()
+        .unwrap();
+    let mut b = buffer(24, 3);
+    StatefulWidget::render(&f, Rect::new(0, 0, 24, 3), &mut b, &mut st);
+
+    // Disabled (no cursor) and the plain `Widget` impl (builds default state).
+    let f = InputFieldBuilder::<String>::default().build().unwrap();
+    let mut st = InputFieldStateBuilder::default().disabled(true).build().unwrap();
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(&f, Rect::new(0, 0, 20, 1), &mut b, &mut st);
+
+    let mut b = buffer(20, 1);
+    RWidget::render(
+        InputFieldBuilder::<String>::default().build().unwrap(),
+        Rect::new(0, 0, 20, 1),
+        &mut b,
+    );
+}
+
+// ---- CodeInputField ----
+
+#[test]
+fn code_input_field_render_variants() {
+    // Empty + unfocused + placeholder -> placeholder branch (bordered, titled).
+    let w = CodeInputFieldBuilder::default()
+        .border(full_border())
+        .title(Some("code".into()))
+        .build()
+        .unwrap();
+    let mut st = CodeInputFieldStateBuilder::default()
+        .focused(false)
+        .placeholder(Some("type lua...".to_string()))
+        .build()
+        .unwrap();
+    let mut b = buffer(20, 6);
+    StatefulWidget::render(&w, Rect::new(0, 0, 20, 6), &mut b, &mut st);
+
+    // Multi-line content, focused, narrow area -> gutter, scroll, cursor, h-scroll.
+    let w = CodeInputFieldBuilder::default().build().unwrap();
+    let mut st = CodeInputFieldStateBuilder::default().build().unwrap();
+    st.set_content("local x = 1\nlocal y = 2\nprint(x + y)\nreturn x");
+    st.set_active_line(3);
+    st.set_cursor_col(50);
+    let mut b = buffer(8, 2);
+    StatefulWidget::render(w, Rect::new(0, 0, 8, 2), &mut b, &mut st);
+}
+
+// ---- ScrollingTabs ----
+
+#[test]
+fn scrolling_tabs_render_variants() {
+    let w = ScrollingTabsBuilder::<String>::default().build().unwrap();
+
+    // Empty -> early return.
+    let mut st = ScrollingTabsState::<String> { titles: vec![], selected: 0 };
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(&w, Rect::new(0, 0, 20, 1), &mut b, &mut st);
+
+    // Several tabs, selected in the middle, narrow width -> centering logic.
+    let titles = vec![
+        "alpha".to_string(),
+        "beta".to_string(),
+        "gamma".to_string(),
+        "delta".to_string(),
+        "epsilon".to_string(),
+    ];
+    let mut st = ScrollingTabsState { titles, selected: 2 };
+    let mut b = buffer(12, 1);
+    StatefulWidget::render(w, Rect::new(0, 0, 12, 1), &mut b, &mut st);
+}
+
+// ---- Selection ----
+
+#[test]
+fn selection_render_variants() {
+    // Borderless, focused, selected item wider than the area -> horizontal offset.
+    let w = SelectionBuilder::<String>::default().build().unwrap();
+    let values: Vec<String> = vec![
+        "short".to_string(),
+        "a selected entry that is wider than the area".to_string(),
+        "tail".to_string(),
+    ];
+    let mut st = SelectionStateBuilder::default().values(values.clone()).build().unwrap();
+    st.move_down(); // select the wide row
+    st.move_right(); // give it a horizontal offset
+    let mut b = buffer(10, 5);
+    StatefulWidget::render(&w, Rect::new(0, 0, 10, 5), &mut b, &mut st);
+
+    // Bordered + title, unfocused; plain Widget impl (default state).
+    let w = SelectionBuilder::<String>::default()
+        .border(full_border())
+        .title(Some("pick".into()))
+        .build()
+        .unwrap();
+    let mut st = SelectionStateBuilder::default().values(values).focused(false).build().unwrap();
+    let mut b = buffer(20, 6);
+    StatefulWidget::render(&w, Rect::new(0, 0, 20, 6), &mut b, &mut st);
+
+}
+
+// ---- Title conversions + Widget<S, W> pair forwarding ----
+
+#[test]
+fn title_conversions_and_widget_pair() {
+    use ferrowl_ui::traits::{HandleEvents, IsFocus, Margins, SetFocus};
+    use ferrowl_ui::widgets::{GetValue, Widget as WidgetPair};
+    use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+    // All four `From` impls for `Title`.
+    let _: Title = "t".into();
+    let _: Title = String::from("t").into();
+    let _: Title = ("t", HorizontalAlignment::Center).into();
+    let _: Title = (String::from("t"), HorizontalAlignment::Right).into();
+
+    // The pair forwards each trait to the appropriate half.
+    let state = InputFieldStateBuilder::default().input("hi".to_string()).build().unwrap();
+    let widget = InputFieldBuilder::<String>::default().build().unwrap();
+    let mut pair = WidgetPair { state, widget };
+
+    assert_eq!(pair.get_value(), "hi");
+    let _ = pair.margins();
+    pair.set_focused(false);
+    assert!(!pair.is_focused());
+    let _ = pair.handle_events(KeyModifiers::NONE, KeyCode::Char('x'));
+
+    // Render through both the borrowed and owned `RenderWidget`/`StatefulWidget` impls.
+    let mut b = buffer(20, 1);
+    RWidget::render(&pair, Rect::new(0, 0, 20, 1), &mut b);
+    let mut b = buffer(20, 1);
+    RWidget::render(pair.clone(), Rect::new(0, 0, 20, 1), &mut b);
+
+    let mut s = InputFieldStateBuilder::default().build().unwrap();
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(&pair, Rect::new(0, 0, 20, 1), &mut b, &mut s);
+    let mut b = buffer(20, 1);
+    StatefulWidget::render(pair, Rect::new(0, 0, 20, 1), &mut b, &mut s);
+}
+
+// ---- Table ----
+
+#[derive(Clone, Default)]
+struct Row(String, String);
+
+impl TableEntry<2> for Row {
+    fn values(&self) -> [String; 2] {
+        [self.0.clone(), self.1.clone()]
+    }
+    fn height(&self) -> u16 {
+        1
+    }
+}
+
+#[derive(Clone)]
+struct Cols;
+
+impl Header<2> for Cols {
+    fn header() -> [String; 2] {
+        ["Name".to_string(), "Value".to_string()]
+    }
+    fn widths() -> [Width; 2] {
+        [Width { min: 4, max: 8 }, Width { min: 4, max: 20 }]
+    }
+}
+
+#[test]
+fn table_render_variants() {
+    let rows = vec![
+        Row("alpha".to_string(), "a value with several words to wrap".to_string()),
+        Row("beta".to_string(), "short".to_string()),
+        Row("gamma".to_string(), "supercalifragilisticexpialidocious".to_string()),
+    ];
+
+    // Focused, area wide enough that total_width <= area.width (no h-scroll).
+    let w = TableBuilder::<Row, Cols, 2>::default().build().unwrap();
+    let mut st = TableStateBuilder::default().values(rows.clone()).build().unwrap();
+    let mut b = buffer(40, 8);
+    StatefulWidget::render(&w, Rect::new(0, 0, 40, 8), &mut b, &mut st);
+
+    // Bordered + title, unfocused, narrow area -> total_width > area.width (h-scroll copy),
+    // and a column rendered without whitespace splitting.
+    let w = TableBuilder::<Row, Cols, 2>::default()
+        .border(full_border())
+        .title(Some("regs".into()))
+        .split_by_whitespace([true, false])
+        .build()
+        .unwrap();
+    let mut st = TableStateBuilder::default().values(rows.clone()).focused(false).build().unwrap();
+    let mut b = buffer(14, 8);
+    StatefulWidget::render(&w, Rect::new(0, 0, 14, 8), &mut b, &mut st);
+
+}

--- a/ferrowl-util/src/convert.rs
+++ b/ferrowl-util/src/convert.rs
@@ -199,6 +199,85 @@ mod tests {
     }
 
     #[test]
+    fn ut_convert_json_to_toml_preserves_data() {
+        // Exercises the JSON-source read path and the TOML-destination write path.
+        let src = tmp_path("json");
+        let dst = tmp_path("toml");
+        let value = Sample {
+            a: 11,
+            b: "y".into(),
+        };
+        Converter::save(&value, &src, FileType::Json).unwrap();
+        Converter::convert::<Sample>(&src, FileType::Json, &dst, FileType::Toml).unwrap();
+        let loaded: Sample = Converter::load(&dst, FileType::Toml).unwrap();
+        assert_eq!(loaded, value);
+        let _ = std::fs::remove_file(&src);
+        let _ = std::fs::remove_file(&dst);
+    }
+
+    #[test]
+    fn ut_convert_json_source_open_error() {
+        let dst = tmp_path("toml");
+        let r = Converter::convert::<Sample>(
+            "/no/such/ferrowl/src.json",
+            FileType::Json,
+            &dst,
+            FileType::Toml,
+        );
+        assert!(matches!(r, Err(Error::Serialize(_))));
+    }
+
+    #[test]
+    fn ut_convert_json_source_malformed_error() {
+        let src = tmp_path("json");
+        std::fs::write(&src, "{ not valid json ").unwrap();
+        let dst = tmp_path("toml");
+        let r = Converter::convert::<Sample>(&src, FileType::Json, &dst, FileType::Toml);
+        assert!(matches!(r, Err(Error::Serialize(_))));
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn ut_convert_toml_dest_create_error() {
+        // Valid source, but the destination directory does not exist -> create fails.
+        let src = tmp_path("toml");
+        Converter::save(&Sample { a: 1, b: "z".into() }, &src, FileType::Toml).unwrap();
+        let r = Converter::convert::<Sample>(
+            &src,
+            FileType::Toml,
+            "/no/such/ferrowl/dir/out.toml",
+            FileType::Toml,
+        );
+        assert!(matches!(r, Err(Error::Serialize(_))));
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn ut_convert_json_dest_create_error() {
+        let src = tmp_path("toml");
+        Converter::save(&Sample { a: 1, b: "z".into() }, &src, FileType::Toml).unwrap();
+        let r = Converter::convert::<Sample>(
+            &src,
+            FileType::Toml,
+            "/no/such/ferrowl/dir/out.json",
+            FileType::Json,
+        );
+        assert!(matches!(r, Err(Error::Serialize(_))));
+        let _ = std::fs::remove_file(&src);
+    }
+
+    #[test]
+    fn ut_save_create_error() {
+        // Destination directory missing -> File::create fails in save().
+        let r = Converter::save(
+            &Sample { a: 1, b: "z".into() },
+            "/no/such/ferrowl/dir/out.toml",
+            FileType::Toml,
+        );
+        assert!(matches!(r, Err(Error::Serialize(_))));
+    }
+
+    #[test]
     fn ut_load_missing_file_errors() {
         let r = Converter::load::<Sample>("/no/such/ferrowl/file.toml", FileType::Toml);
         assert!(matches!(r, Err(Error::Deserialize(_))));

--- a/ferrowl-util/src/tokio.rs
+++ b/ferrowl-util/src/tokio.rs
@@ -209,3 +209,38 @@ pub async fn join_all_of_context(ctx: &'static str) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{join_all, join_all_of_context, spawn_detach, spawn_detach_with_context};
+    use std::time::Duration;
+
+    // All spawn/join coverage lives in one test: the background context is a
+    // process-global static, so running these assertions concurrently across
+    // tests would let one drain another's handles.
+    #[tokio::test]
+    async fn ut_spawn_and_join_contexts() {
+        // Global context: first spawn inserts the vec, second pushes onto it.
+        spawn_detach(async {}).await;
+        spawn_detach(async {}).await;
+        // A still-running task exercises the `!is_finished` await branch of join.
+        spawn_detach(async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        })
+        .await;
+
+        // Named context: same insert-then-push pattern.
+        spawn_detach_with_context("ctxA", async {}).await;
+        spawn_detach_with_context("ctxA", async {}).await;
+
+        // Join the named context only.
+        join_all_of_context("ctxA").await;
+        // Unknown context: nothing stored -> empty -> immediate break.
+        join_all_of_context("unknown").await;
+
+        // Join everything remaining in the global context.
+        join_all().await;
+        // Nothing left -> immediate break.
+        join_all().await;
+    }
+}

--- a/ferrowl/src/cli.rs
+++ b/ferrowl/src/cli.rs
@@ -238,4 +238,76 @@ mod tests {
     fn ut_missing_port_errors() {
         assert!(parse_module_spec("name=m,device=d.toml,transport=tcp").is_err());
     }
+
+    #[test]
+    fn ut_module_specs_combines_all_sources() {
+        use ferrowl_util::convert::{Converter, FileType};
+        let session = config::Session {
+            version: None,
+            modules: vec![create_module_spec_by_device("S".into(), "s.toml".into())],
+        };
+        let path = std::env::temp_dir().join("ferrowl_cli_session.toml");
+        let path = path.to_str().unwrap().to_string();
+        Converter::save(&session, &path, FileType::Toml).unwrap();
+
+        let args = CliArgs {
+            command: None,
+            modules: vec!["name=m,device=d.toml,port=1".into()],
+            sessions: vec![path],
+            devices: vec!["dev.toml".into()],
+            demo: false,
+        };
+        let specs = args.module_specs().unwrap();
+        assert_eq!(specs.len(), 3); // session + module + device
+    }
+
+    #[test]
+    fn ut_module_specs_session_load_error() {
+        let args = CliArgs {
+            command: None,
+            modules: vec![],
+            sessions: vec!["/no/such/ferrowl.toml".into()],
+            devices: vec![],
+            demo: false,
+        };
+        assert!(args.module_specs().is_err());
+    }
+
+    #[test]
+    fn ut_parse_empty_parts_and_error_paths() {
+        // Empty comma segment is skipped.
+        assert_eq!(
+            parse_module_spec("name=m,,device=d.toml,port=1").unwrap().name,
+            "m"
+        );
+        // Invalid role / transport.
+        assert!(parse_module_spec("name=m,device=d,port=1,role=bogus").is_err());
+        assert!(parse_module_spec("name=m,device=d,transport=usb").is_err());
+        // Segment without '='.
+        assert!(parse_module_spec("name=m,oops,device=d,port=1").is_err());
+        // RTU missing path; invalid numeric option; invalid port.
+        assert!(parse_module_spec("name=m,device=d,transport=rtu").is_err());
+        assert!(
+            parse_module_spec("name=m,device=d,transport=rtu,path=/x,data_bits=foo").is_err()
+        );
+        assert!(parse_module_spec("name=m,device=d,port=notanum").is_err());
+    }
+
+    #[test]
+    fn ut_parse_rtu_full_options() {
+        let spec = parse_module_spec(
+            "name=m,device=d,transport=rtu,path=/dev/x,baud_rate=4800,parity=even,data_bits=7,stop_bits=2",
+        )
+        .unwrap();
+        assert_eq!(
+            spec.endpoint,
+            Endpoint::Rtu {
+                path: "/dev/x".into(),
+                baud_rate: 4800,
+                parity: Some("even".into()),
+                data_bits: Some(7),
+                stop_bits: Some(2),
+            }
+        );
+    }
 }

--- a/ferrowl/src/config/device.rs
+++ b/ferrowl/src/config/device.rs
@@ -511,4 +511,136 @@ mod tests {
         def.value_type = ValueType::F32;
         assert!(def.format().bitfield().is_full());
     }
+
+    fn def_with(value_type: ValueType, read_code: u8, address: Option<u16>, is_virtual: bool) -> RegisterDef {
+        RegisterDef {
+            slave_id: 1,
+            read_code,
+            address,
+            is_virtual,
+            access: AccessCfg::ReadWrite,
+            value_type,
+            endian: EndianCfg::Little,
+            resolution: 1.0,
+            bitmask: None,
+            length: 4,
+            alignment: AlignmentCfg::Right,
+            values: vec![],
+            update: None,
+            description: String::new(),
+            default: None,
+        }
+    }
+
+    #[test]
+    fn ut_read_ranges_is_empty_and_ranges_for() {
+        let mut rr = ReadRanges::default();
+        assert!(rr.is_empty());
+        rr.holding = Some("1".into());
+        rr.input = Some("0-3".into());
+        rr.coils = Some("5".into());
+        rr.discrete = Some("7-8".into());
+        assert!(!rr.is_empty());
+        assert_eq!(rr.ranges_for(Kind::HoldingRegister), vec![Range::new(1, 1)]);
+        assert_eq!(rr.ranges_for(Kind::InputRegister), vec![Range::new(0, 4)]);
+        assert_eq!(rr.ranges_for(Kind::Coil), vec![Range::new(5, 1)]);
+        assert_eq!(rr.ranges_for(Kind::DiscreteInput), vec![Range::new(7, 2)]);
+        // Unconfigured kind -> empty.
+        assert!(ReadRanges::default().ranges_for(Kind::Coil).is_empty());
+    }
+
+    #[test]
+    fn ut_scalar_and_named_value() {
+        assert_eq!(Scalar::Int(5).to_string(), "5");
+        assert_eq!(Scalar::Float(1.5).to_string(), "1.5");
+        assert_eq!(Scalar::Text("hi".into()).to_string(), "hi");
+        assert!(matches!(Scalar::from_input(" 7 "), Scalar::Int(7)));
+        assert!(matches!(Scalar::from_input("2.5"), Scalar::Float(_)));
+        assert!(matches!(Scalar::from_input("abc"), Scalar::Text(_)));
+        assert!(matches!(Scalar::Int(1).to_value(1.0), ferrowl_reg::Value::I64(_)));
+        assert!(matches!(Scalar::Float(1.0).to_value(1.0), ferrowl_reg::Value::F64(_)));
+        assert!(matches!(
+            Scalar::Text("x".into()).to_value(1.0),
+            ferrowl_reg::Value::Ascii(_)
+        ));
+        let nv = NamedValue {
+            name: "n".into(),
+            value: Scalar::Int(0),
+        };
+        assert_eq!(nv.to_label(), "n");
+    }
+
+    #[test]
+    fn ut_cfg_conversions() {
+        assert!(matches!(Access::from(AccessCfg::ReadOnly), Access::ReadOnly));
+        assert!(matches!(Access::from(AccessCfg::WriteOnly), Access::WriteOnly));
+        assert!(matches!(Access::from(AccessCfg::ReadWrite), Access::ReadWrite));
+        assert!(matches!(Endian::from(EndianCfg::Big), Endian::Big));
+        assert!(matches!(Endian::from(EndianCfg::Little), Endian::Little));
+        assert!(matches!(Alignment::from(AlignmentCfg::Left), Alignment::Left));
+        assert!(matches!(Alignment::from(AlignmentCfg::Right), Alignment::Right));
+    }
+
+    #[test]
+    fn ut_register_def_kind_mem_type_and_all_formats() {
+        for (code, kind) in [
+            (1u8, Kind::Coil),
+            (2, Kind::DiscreteInput),
+            (3, Kind::InputRegister),
+            (4, Kind::HoldingRegister),
+        ] {
+            assert_eq!(def_with(ValueType::U16, code, Some(0), false).kind(), kind);
+        }
+        assert_eq!(def_with(ValueType::U16, 1, Some(0), false).mem_type(), Type::Coil);
+        assert_eq!(
+            def_with(ValueType::U16, 4, Some(0), false).mem_type(),
+            Type::Register
+        );
+
+        for vt in [
+            ValueType::U8,
+            ValueType::U16,
+            ValueType::U32,
+            ValueType::U64,
+            ValueType::U128,
+            ValueType::I8,
+            ValueType::I16,
+            ValueType::I32,
+            ValueType::I64,
+            ValueType::I128,
+            ValueType::F32,
+            ValueType::F64,
+            ValueType::Ascii,
+        ] {
+            let _ = def_with(vt, 4, Some(0), false).format();
+        }
+    }
+
+    #[test]
+    fn ut_register_def_address_range_and_register() {
+        let fixed = def_with(ValueType::U16, 4, Some(10), false);
+        assert_eq!(fixed.address(), Address::Fixed(10));
+        assert!(fixed.mem_range().is_some());
+        let _ = fixed.register();
+        let _ = fixed.bitfield();
+
+        let virt = def_with(ValueType::U16, 4, None, false);
+        assert_eq!(virt.address(), Address::Virtual);
+        assert!(virt.mem_range().is_none());
+
+        // The `virtual` flag forces Virtual even with a concrete address.
+        assert_eq!(def_with(ValueType::U16, 4, Some(5), true).address(), Address::Virtual);
+    }
+
+    #[test]
+    fn ut_register_def_serde_defaults() {
+        // A minimal definition omitting read_code/resolution/length triggers the default fns.
+        let path = std::env::temp_dir().join("ferrowl_regdef_min.toml");
+        let path = path.to_str().unwrap();
+        std::fs::write(path, "type = \"U16\"\n").unwrap();
+        let def: RegisterDef = Converter::load(path, FileType::Toml).unwrap();
+        assert_eq!(def.read_code, 3);
+        assert_eq!(def.resolution, 1.0);
+        assert_eq!(def.length, 1);
+    }
 }

--- a/ferrowl/src/config/mod.rs
+++ b/ferrowl/src/config/mod.rs
@@ -39,3 +39,49 @@ pub fn load_device(path: &str) -> Result<DeviceConfig, ConfigError> {
 pub fn load_session(path: &str) -> Result<Session, ConfigError> {
     load(path)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_util::convert::{Converter, FileType};
+
+    fn tmp(name: &str) -> String {
+        std::env::temp_dir()
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn ut_load_device_and_session_roundtrip() {
+        let dpath = tmp("ferrowl_cfgmod_device.toml");
+        Converter::save(&DeviceConfig::default(), &dpath, FileType::Toml).unwrap();
+        assert_eq!(load_device(&dpath).unwrap(), DeviceConfig::default());
+
+        let spath = tmp("ferrowl_cfgmod_session.json");
+        Converter::save(&Session::default(), &spath, FileType::Json).unwrap();
+        assert_eq!(load_session(&spath).unwrap(), Session::default());
+    }
+
+    #[test]
+    fn ut_load_unknown_format_errors() {
+        let e = load_session("/tmp/ferrowl_cfg.bin");
+        assert!(matches!(e, Err(ConfigError::UnknownFormat(_))));
+    }
+
+    #[test]
+    fn ut_load_io_error() {
+        let e = load_device("/no/such/ferrowl/device.toml");
+        assert!(matches!(e, Err(ConfigError::Io(_))));
+    }
+
+    #[test]
+    fn ut_config_error_display() {
+        assert!(
+            ConfigError::UnknownFormat("p".into())
+                .to_string()
+                .contains("invalid file")
+        );
+        assert_eq!(ConfigError::Io("boom".into()).to_string(), "boom");
+    }
+}

--- a/ferrowl/src/config/session.rs
+++ b/ferrowl/src/config/session.rs
@@ -165,4 +165,52 @@ mod tests {
             assert_eq!(original, back);
         }
     }
+
+    #[test]
+    fn ut_role_display_and_default() {
+        assert_eq!(Role::Client.to_string(), "Client");
+        assert_eq!(Role::Server.to_string(), "Server");
+        assert_eq!(Role::default(), Role::Server);
+    }
+
+    #[test]
+    fn ut_endpoint_display() {
+        assert_eq!(
+            Endpoint::Tcp {
+                ip: "127.0.0.1".into(),
+                port: 502
+            }
+            .to_string(),
+            "127.0.0.1:502"
+        );
+        // RTU with all optional fields present.
+        assert_eq!(
+            Endpoint::Rtu {
+                path: "/dev/ttyUSB0".into(),
+                baud_rate: 9600,
+                parity: Some("even".into()),
+                data_bits: Some(8),
+                stop_bits: Some(1),
+            }
+            .to_string(),
+            "/dev/ttyUSB0,9600,even,8,1"
+        );
+        // RTU with the optional fields unset renders dashes.
+        assert_eq!(
+            Endpoint::Rtu {
+                path: "/dev/x".into(),
+                baud_rate: 19200,
+                parity: None,
+                data_bits: None,
+                stop_bits: None,
+            }
+            .to_string(),
+            "/dev/x,19200,-,-,-"
+        );
+    }
+
+    #[test]
+    fn ut_default_baud() {
+        assert_eq!(default_baud(), 19200);
+    }
 }

--- a/ferrowl/src/module.rs
+++ b/ferrowl/src/module.rs
@@ -1025,4 +1025,129 @@ mod tests {
         assert_eq!(read, vec![50]);
         assert_eq!(format!("{}", register.decode(&read).unwrap()), "50");
     }
+
+    fn device_with_defs() -> crate::config::DeviceConfig {
+        use crate::config::DeviceConfig;
+        use crate::config::device::{
+            AccessCfg, AlignmentCfg, EndianCfg, NamedValue, ReadRanges, RegisterDef, Scalar,
+            ValueType,
+        };
+        use std::collections::BTreeMap;
+
+        let base = |address: Option<u16>, is_virtual: bool, update, default| RegisterDef {
+            slave_id: 1,
+            read_code: 4,
+            address,
+            is_virtual,
+            access: AccessCfg::ReadWrite,
+            value_type: ValueType::U16,
+            endian: EndianCfg::Big,
+            resolution: 1.0,
+            bitmask: None,
+            length: 1,
+            alignment: AlignmentCfg::Left,
+            values: vec![NamedValue {
+                name: "a".into(),
+                value: Scalar::Int(1),
+            }],
+            update,
+            description: "desc".into(),
+            default,
+        };
+
+        let mut definitions = BTreeMap::new();
+        // Fixed register with a default value (exercises encode + write_unchecked) and a script.
+        definitions.insert(
+            "hold".into(),
+            base(Some(0), false, Some("x = 1".into()), Some(Scalar::Int(7))),
+        );
+        // Virtual register without a default (exercises default_value).
+        definitions.insert("virt".into(), base(None, true, None, None));
+
+        DeviceConfig {
+            version: None,
+            timeout_ms: Some(1000),
+            delay_ms: None,
+            interval_ms: Some(500),
+            log_file: Some(
+                std::env::temp_dir()
+                    .join("ferrowl_module_test.log")
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            read_ranges: ReadRanges {
+                holding: Some("0-10".into()),
+                ..Default::default()
+            },
+            definitions,
+        }
+    }
+
+    #[test]
+    fn ut_module_new_tcp_server_and_sync_accessors() {
+        use super::Module;
+        use crate::config::{Endpoint, ModuleSpec, Role};
+
+        let device = device_with_defs();
+        let spec = ModuleSpec {
+            name: "evse 1".into(),
+            device: String::new(),
+            role: Role::Server,
+            endpoint: Endpoint::Tcp {
+                ip: "127.0.0.1".into(),
+                port: 5020,
+            },
+            timeout_ms: None,
+            delay_ms: None,
+            interval_ms: None,
+        };
+
+        let mut module = Module::new(&spec, &device);
+        assert_eq!(module.registers().len(), 2);
+        let _ = module.memory();
+        let _ = module.log();
+        let _ = module.virtual_store();
+        assert!(!module.lua_running());
+        assert!(!module.is_instance_active());
+
+        // Register-cache mutation helpers.
+        let reg = module.registers()[0].2.clone();
+        module.add_register("new".into(), "d".into(), reg.clone(), vec![]);
+        assert_eq!(module.registers().len(), 3);
+        module.update_register(0, "renamed".into(), "d".into(), reg.clone(), vec![]);
+        module.update_register(99, "oob".into(), "d".into(), reg, vec![]); // out-of-bounds no-op
+        module.remove_register_by_name("new");
+        assert_eq!(module.registers().len(), 2);
+
+        // Log-base reconfiguration: clear, then point at a fresh (unwritable) path.
+        module.set_log_base(None);
+        module.set_log_base(Some("/no/such/ferrowl/dir/base.log"));
+    }
+
+    #[test]
+    fn ut_module_new_rtu_client() {
+        use super::Module;
+        use crate::config::{Endpoint, ModuleSpec, Role};
+
+        let device = device_with_defs();
+        let spec = ModuleSpec {
+            name: "meter".into(),
+            device: String::new(),
+            role: Role::Client,
+            endpoint: Endpoint::Rtu {
+                path: "/dev/ttyUSB0".into(),
+                baud_rate: 9600,
+                parity: Some("none".into()),
+                data_bits: Some(8),
+                stop_bits: Some(1),
+            },
+            timeout_ms: Some(750),
+            delay_ms: Some(10),
+            interval_ms: Some(2000),
+        };
+
+        let module = Module::new(&spec, &device);
+        assert_eq!(module.registers().len(), 2);
+        assert!(!module.is_instance_active());
+    }
 }

--- a/ferrowl/src/view/command.rs
+++ b/ferrowl/src/view/command.rs
@@ -38,3 +38,16 @@ pub fn new_command_line() -> CommandLine {
             .unwrap(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_ui::traits::IsFocus;
+
+    #[test]
+    fn ut_new_command_line_is_unfocused_and_empty() {
+        let cl = new_command_line();
+        assert!(!cl.is_focused());
+        assert_eq!(cl.state.input(), "");
+    }
+}

--- a/ferrowl/src/view/log.rs
+++ b/ferrowl/src/view/log.rs
@@ -124,4 +124,28 @@ mod tests {
         let ms: u64 = 19782 * 86400 * 1000;
         assert_eq!(format_timestamp(ms), "2024-02-29 00:00:00.000");
     }
+
+    #[test]
+    fn ut_log_entry_and_header_traits() {
+        let e = LogEntry {
+            timestamp: "ts".into(),
+            message: "hello".into(),
+        };
+        assert_eq!(e.values(), ["ts".to_string(), "hello".to_string()]);
+        assert_eq!(e.height(), 1);
+        assert_eq!(
+            LogHeader::header(),
+            ["Timestamp".to_string(), "Message".to_string()]
+        );
+        let w = LogHeader::widths();
+        assert_eq!(w[0].min, 23);
+        assert_eq!(w[0].max, 23);
+    }
+
+    #[test]
+    fn ut_new_log_view_is_empty_and_unfocused() {
+        let view = new_log_view();
+        assert!(!view.state.focused());
+        assert!(view.state.values().is_empty());
+    }
 }

--- a/ferrowl/src/view/tabs.rs
+++ b/ferrowl/src/view/tabs.rs
@@ -12,3 +12,17 @@ pub fn render_tabs(names: &[String], active: usize, area: Rect, buf: &mut Buffer
     };
     StatefulWidget::render(&widget, area, buf, &mut state);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ut_render_tabs() {
+        let area = Rect::new(0, 0, 30, 1);
+        let mut buf = Buffer::empty(area);
+        render_tabs(&["alpha".to_string(), "beta".to_string()], 1, area, &mut buf);
+        // Empty tab list must not panic.
+        render_tabs(&[], 0, area, &mut buf);
+    }
+}


### PR DESCRIPTION
These changes add a vast list of additional test cases to improve the total test coverage reported by llvm-cov. It focuses on the library crates and skips large parts of the binary crate since these steps would also require a huge test harness to base the tests on.