### PR TITLE
refactor(lua)!: collapse register API to Get/Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ description = "active power (W)"
 default = 0
 # Lua run every cycle: mirror the setpoint into the power register (server simulation).
 update = """
-C_Register:Set("power", C_Register:GetInt("setpoint"))
+C_Register:Set("power", C_Register:Get("setpoint"))
 """
 
 [definitions.state]
@@ -309,44 +309,15 @@ Return: Time in milliseconds since startup.
 ### Module C_Register
 
 ```
-Method:   C_Register:GetString(name)
+Method:   C_Register:Get(name)
 
 Arguments:
                Name: name
                Type: String
         Description: Name of the register as defined in the configuration.
 
-Return: String value of the register
-```
-```
-Method:   C_Register:GetInt(name)
-
-Arguments:
-               Name: name
-               Type: String
-        Description: Name of the register as defined in the configuration.
-
-Return: Integer value of the register
-```
-```
-Method:   C_Register:GetFloat(name)
-
-Arguments:
-               Name: name
-               Type: String
-        Description: Name of the register as defined in the configuration.
-
-Return: Floating point value of the register
-```
-```
-Method:   C_Register:GetBool(name)
-
-Arguments:
-               Name: name
-               Type: String
-        Description: Name of the register as defined in the configuration.
-
-Return: Boolean value of the register
+Return: Value of the register, typed to match it: a number for integer and
+        floating-point registers, a string for strings and a boolean for booleans.
 ```
 ```
 Method:   C_Register:Set(name, value)

--- a/ferrowl-lua/src/module/mod.rs
+++ b/ferrowl-lua/src/module/mod.rs
@@ -10,11 +10,39 @@ pub use statics::Statics as StaticsModule;
 pub use time::Time as TimeModule;
 
 /// A dynamically typed value passed between Lua and the host.
+#[derive(Clone)]
 pub enum ValueType {
     Int(i128),
     Float(f64),
     String(String),
     Bool(bool),
+}
+
+impl mlua::IntoLua for ValueType {
+    fn into_lua(self, lua: &mlua::Lua) -> mlua::Result<mlua::Value> {
+        match self {
+            ValueType::Int(v) => v.into_lua(lua),
+            ValueType::Float(v) => v.into_lua(lua),
+            ValueType::String(v) => v.into_lua(lua),
+            ValueType::Bool(v) => v.into_lua(lua),
+        }
+    }
+}
+
+impl mlua::FromLua for ValueType {
+    fn from_lua(value: mlua::Value, _lua: &mlua::Lua) -> mlua::Result<Self> {
+        match value {
+            mlua::Value::Integer(v) => Ok(ValueType::Int(v as i128)),
+            mlua::Value::Number(v) => Ok(ValueType::Float(v)),
+            mlua::Value::String(v) => Ok(ValueType::String(v.to_str()?.to_owned())),
+            mlua::Value::Boolean(v) => Ok(ValueType::Bool(v)),
+            other => Err(mlua::Error::FromLuaConversionError {
+                from: other.type_name(),
+                to: "ValueType".to_string(),
+                message: Some("expected number, string or boolean".to_string()),
+            }),
+        }
+    }
 }
 
 /// A host module that can be registered in a Lua context.

--- a/ferrowl-lua/src/module/register/mod.rs
+++ b/ferrowl-lua/src/module/register/mod.rs
@@ -4,12 +4,12 @@ use crate::module::{Module, ValueType};
 use mlua::{Result, UserData};
 use traits::{Read, Write};
 
-/// Lua module `C_Register`: gives scripts typed read/write access to named
-/// registers through a host-provided [`Read`]/[`Write`] handle.
+/// Lua module `C_Register`: gives scripts read/write access to named registers
+/// through a host-provided [`Read`]/[`Write`] handle.
 ///
-/// Exposed Lua methods: `GetInt`, `GetFloat`, `GetString`, `GetBool`
-/// (each takes a register name and errors on type mismatch) and
-/// `Set(name, value)`.
+/// Exposed Lua methods: `Get(name)` — returns a number for integer/float
+/// registers, a string for strings and a boolean for booleans — and
+/// `Set(name, value)`, which accepts any of those Lua types.
 pub struct Register<T>
 where
     T: Write + Read + 'static,
@@ -41,10 +41,7 @@ where
     T: Write + Read + 'static,
 {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method("GetInt", Self::get_int);
-        methods.add_method("GetFloat", Self::get_float);
-        methods.add_method("GetString", Self::get_string);
-        methods.add_method("GetBool", Self::get_bool);
+        methods.add_method("Get", Self::get);
         methods.add_method("Set", Self::set);
     }
 }
@@ -53,39 +50,14 @@ impl<T> Register<T>
 where
     T: Write + Read + 'static,
 {
-    fn get_int(_: &mlua::Lua, this: &Register<T>, name: String) -> Result<i128> {
-        match this.handle.read(name) {
-            Ok(ValueType::Int(v)) => Ok(v),
-            Err(e) => Err(e),
-            Ok(_) => Err(mlua::Error::UserDataTypeMismatch),
-        }
+    /// `Get(name)` — reads the register and returns its value as the matching
+    /// Lua type (number / string / boolean).
+    fn get(_: &mlua::Lua, this: &Register<T>, name: String) -> Result<ValueType> {
+        this.handle.read(name)
     }
 
-    fn get_float(_: &mlua::Lua, this: &Register<T>, name: String) -> Result<f64> {
-        match this.handle.read(name) {
-            Ok(ValueType::Float(v)) => Ok(v),
-            Err(e) => Err(e),
-            Ok(_) => Err(mlua::Error::UserDataTypeMismatch),
-        }
-    }
-
-    fn get_string(_: &mlua::Lua, this: &Register<T>, name: String) -> Result<String> {
-        match this.handle.read(name) {
-            Ok(ValueType::String(v)) => Ok(v),
-            Err(e) => Err(e),
-            Ok(_) => Err(mlua::Error::UserDataTypeMismatch),
-        }
-    }
-
-    fn get_bool(_: &mlua::Lua, this: &Register<T>, name: String) -> Result<bool> {
-        match this.handle.read(name) {
-            Ok(ValueType::Bool(v)) => Ok(v),
-            Err(e) => Err(e),
-            Ok(_) => Err(mlua::Error::UserDataTypeMismatch),
-        }
-    }
-
-    fn set(_: &mlua::Lua, this: &Register<T>, (name, value): (String, String)) -> Result<()> {
+    /// `Set(name, value)` — writes a typed Lua value to the register.
+    fn set(_: &mlua::Lua, this: &Register<T>, (name, value): (String, ValueType)) -> Result<()> {
         this.handle.write(name, value)
     }
 }

--- a/ferrowl-lua/src/module/register/traits.rs
+++ b/ferrowl-lua/src/module/register/traits.rs
@@ -3,9 +3,9 @@
 use crate::module::register::ValueType;
 use mlua::Result;
 
-/// Writes a string value to the register named `name`.
+/// Writes a typed value to the register named `name`.
 pub trait Write {
-    fn write(&self, name: String, value: String) -> Result<()>;
+    fn write(&self, name: String, value: ValueType) -> Result<()>;
 }
 
 /// Reads the current value of the register named `name`.

--- a/ferrowl-lua/src/module/statics.rs
+++ b/ferrowl-lua/src/module/statics.rs
@@ -6,8 +6,9 @@ use mlua::{Result, UserData};
 /// Lua module `C_Statics`: read-only key/value store of host-provided
 /// constants.
 ///
-/// Exposed Lua methods: `GetInt`, `GetFloat`, `GetString`, `GetBool` — each
-/// takes a key and errors if the key is missing or holds a different type.
+/// Exposed Lua method: `Get(name)` — returns the stored constant as the
+/// matching Lua type (number / string / boolean), erroring if the key is
+/// missing.
 #[allow(dead_code)]
 #[derive(Default)]
 pub struct Statics {
@@ -22,10 +23,7 @@ impl Module for Statics {
 
 impl UserData for Statics {
     fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method("GetInt", Self::get_int);
-        methods.add_method("GetFloat", Self::get_float);
-        methods.add_method("GetString", Self::get_string);
-        methods.add_method("GetBool", Self::get_bool);
+        methods.add_method("Get", Self::get);
     }
 }
 
@@ -40,35 +38,12 @@ impl Statics {
         self.data.insert(key, value)
     }
 
-    fn get_int(_: &mlua::Lua, this: &Statics, name: String) -> Result<i128> {
-        if let Some(ValueType::Int(i)) = this.data.get(&name) {
-            Ok(*i)
-        } else {
-            Err(mlua::Error::UserDataTypeMismatch)
-        }
-    }
-
-    fn get_float(_: &mlua::Lua, this: &Statics, name: String) -> Result<f64> {
-        if let Some(ValueType::Float(f)) = this.data.get(&name) {
-            Ok(*f)
-        } else {
-            Err(mlua::Error::UserDataTypeMismatch)
-        }
-    }
-
-    fn get_string(_: &mlua::Lua, this: &Statics, name: String) -> Result<String> {
-        if let Some(ValueType::String(s)) = this.data.get(&name) {
-            Ok(s.to_owned())
-        } else {
-            Err(mlua::Error::UserDataTypeMismatch)
-        }
-    }
-
-    fn get_bool(_: &mlua::Lua, this: &Statics, name: String) -> Result<bool> {
-        if let Some(ValueType::Bool(b)) = this.data.get(&name) {
-            Ok(*b)
-        } else {
-            Err(mlua::Error::UserDataTypeMismatch)
-        }
+    /// `Get(name)` — returns the stored constant as the matching Lua type,
+    /// erroring if the key is unknown.
+    fn get(_: &mlua::Lua, this: &Statics, name: String) -> Result<ValueType> {
+        this.data
+            .get(&name)
+            .cloned()
+            .ok_or_else(|| mlua::Error::RuntimeError(format!("unknown static '{name}'")))
     }
 }

--- a/ferrowl-lua/tests/modules.rs
+++ b/ferrowl-lua/tests/modules.rs
@@ -30,7 +30,7 @@ impl Read for Handle {
 }
 
 impl Write for Handle {
-    fn write(&self, _name: String, _value: String) -> Result<()> {
+    fn write(&self, _name: String, _value: ValueType) -> Result<()> {
         Ok(())
     }
 }
@@ -51,33 +51,25 @@ const TIME_SCRIPT: &str = r#"
 "#;
 
 const STATICS_SCRIPT: &str = r#"
-    assert(C_Statics:GetInt("i") == 42)
-    assert(C_Statics:GetFloat("f") == 1.5)
-    assert(C_Statics:GetString("s") == "hi")
-    assert(C_Statics:GetBool("b") == true)
-    -- Missing/typed-wrong keys error out.
-    assert(not pcall(function() return C_Statics:GetInt("missing") end))
-    assert(not pcall(function() return C_Statics:GetFloat("i") end))
-    assert(not pcall(function() return C_Statics:GetString("i") end))
-    assert(not pcall(function() return C_Statics:GetBool("i") end))
+    assert(C_Statics:Get("i") == 42)
+    assert(C_Statics:Get("f") == 1.5)
+    assert(C_Statics:Get("s") == "hi")
+    assert(C_Statics:Get("b") == true)
+    -- Missing keys error out.
+    assert(not pcall(function() return C_Statics:Get("missing") end))
 "#;
 
 const REGISTER_SCRIPT: &str = r#"
-    assert(C_Register:GetInt("i") == 7)
-    assert(C_Register:GetFloat("f") == 1.5)
-    assert(C_Register:GetString("s") == "hi")
-    assert(C_Register:GetBool("b") == true)
-    C_Register:Set("x", "99")
+    assert(C_Register:Get("i") == 7)
+    assert(C_Register:Get("f") == 1.5)
+    assert(C_Register:Get("s") == "hi")
+    assert(C_Register:Get("b") == true)
+    -- Set accepts any Lua value type.
+    C_Register:Set("x", 99)
+    C_Register:Set("s2", "hello")
+    C_Register:Set("b2", true)
     -- Host read error propagates.
-    assert(not pcall(function() return C_Register:GetInt("err") end))
-    assert(not pcall(function() return C_Register:GetFloat("err") end))
-    assert(not pcall(function() return C_Register:GetString("err") end))
-    assert(not pcall(function() return C_Register:GetBool("err") end))
-    -- Wrong-type reads error.
-    assert(not pcall(function() return C_Register:GetInt("f") end))
-    assert(not pcall(function() return C_Register:GetFloat("i") end))
-    assert(not pcall(function() return C_Register:GetString("i") end))
-    assert(not pcall(function() return C_Register:GetBool("i") end))
+    assert(not pcall(function() return C_Register:Get("err") end))
 "#;
 
 fn build_context() -> Context<String> {
@@ -139,7 +131,7 @@ fn ut_statics_from_constructor() {
     data.insert("k".to_string(), ValueType::Int(1));
     let mut ctx = ContextBuilder::<String>::default()
         .with_module(StaticsModule::from(data))
-        .with_script("s".to_string(), r#"assert(C_Statics:GetInt("k") == 1)"#)
+        .with_script("s".to_string(), r#"assert(C_Statics:Get("k") == 1)"#)
         .build()
         .unwrap();
     ctx.call(&"s".to_string()).unwrap();

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -1,5 +1,5 @@
 //! Per-module Lua simulation: a `RegisterBridge` exposes the module's `Memory` to Lua as the
-//! `C_Register` global (`Get*`/`Set(name, value)`), and `run_sim` drives every register's
+//! `C_Register` global (`Get(name)`/`Set(name, value)`), and `run_sim` drives every register's
 //! `update` script on a dedicated thread (because `mlua::Lua` is `!Send`).
 
 use std::collections::HashMap;
@@ -80,7 +80,15 @@ impl Read for RegisterBridge {
 }
 
 impl Write for RegisterBridge {
-    fn write(&self, name: String, value: String) -> Result<()> {
+    fn write(&self, name: String, value: ValueType) -> Result<()> {
+        // The register codec (`encode`/`str_to_value`) is string-based and shared with the
+        // `:set` user-input path, so render the typed value to its canonical string once here.
+        let value = match value {
+            ValueType::Int(v) => v.to_string(),
+            ValueType::Float(v) => v.to_string(),
+            ValueType::String(s) => s,
+            ValueType::Bool(b) => (b as u8).to_string(),
+        };
         let register = self.register(&name)?;
         let addr = match register.address() {
             Address::Fixed(addr) => *addr,
@@ -304,7 +312,7 @@ mod tests {
         // Reading before any write errors; after a write the value round-trips via the store.
         assert!(bridge.read("calc".to_string()).is_err());
         bridge
-            .write("calc".to_string(), "7".to_string())
+            .write("calc".to_string(), ValueType::Int(7))
             .expect("virtual write");
         match bridge.read("calc".to_string()).expect("virtual read") {
             ValueType::Int(v) => assert_eq!(v, 7),
@@ -323,7 +331,7 @@ mod tests {
     fn ut_bridge_write_then_read() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), evse_registers());
         bridge
-            .write("setpoint".to_string(), "100".to_string())
+            .write("setpoint".to_string(), ValueType::Int(100))
             .expect("write");
         match bridge.read("setpoint".to_string()).expect("read") {
             ValueType::Int(v) => assert_eq!(v, 100),
@@ -335,7 +343,7 @@ mod tests {
     fn ut_bridge_unknown_register_errors() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), evse_registers());
         assert!(bridge.read("nope".to_string()).is_err());
-        assert!(bridge.write("nope".to_string(), "1".to_string()).is_err());
+        assert!(bridge.write("nope".to_string(), ValueType::Int(1)).is_err());
     }
 
     // Mirrors `run_sim`'s body once: a `power` update copying `setpoint` reflects after a cycle.
@@ -344,7 +352,7 @@ mod tests {
         let memory = evse_memory();
         let bridge = RegisterBridge::new(memory.clone(), vstore(), evse_registers());
         bridge
-            .write("setpoint".to_string(), "42".to_string())
+            .write("setpoint".to_string(), ValueType::Int(42))
             .expect("seed setpoint");
 
         let mut context = ContextBuilder::<String>::default()
@@ -353,7 +361,7 @@ mod tests {
             .with_module(TimeModule::default())
             .with_script(
                 "power".to_string(),
-                "C_Register:Set(\"power\", C_Register:GetInt(\"setpoint\"))",
+                "C_Register:Set(\"power\", C_Register:Get(\"setpoint\"))",
             )
             .build()
             .expect("build context");


### PR DESCRIPTION
Typed getters (GetInt/GetFloat/GetString/GetBool) forced scripts to know each register's type and erred on a wrong guess. Replace with a single Get(name) returning the matching Lua type and a Set(name, value) taking a typed value. Value flows as ValueType end-to-end via mlua IntoLua/FromLua, so the binding layer no longer coerces strings; the host renders to string only for the existing codec (still backs :set). C_Statics collapses the same getters into Get, staying read-only.

> [!WARNING]
> Update scripts using C_Register:GetInt/GetFloat/ GetString/GetBool or C_Statics:Get* must switch to :Get(name).