### PR TITLE
feat(dialog): add typed validators for label, address, and bitmask fields

### DIFF
--- a/ferrowl-ui/src/widgets/input_field.rs
+++ b/ferrowl-ui/src/widgets/input_field.rs
@@ -188,9 +188,15 @@ where
 
         // Create block if border is required
         let border_style = if state.focused() && !state.disabled() {
-            self.style.focused
+            match valid {
+                ValidateResult::Success | ValidateResult::None => self.style.focused,
+                ValidateResult::Error(_) => self.style.error,
+            }
         } else {
-            self.style.general
+            match valid {
+                ValidateResult::Success | ValidateResult::None => self.style.general,
+                ValidateResult::Error(_) => self.style.error,
+            }
         };
         let area = crate::widgets::render_border(
             area,

--- a/ferrowl-ui/tests/render.rs
+++ b/ferrowl-ui/tests/render.rs
@@ -142,6 +142,20 @@ fn input_field_render_variants() {
     let mut b = buffer(24, 3);
     StatefulWidget::render(&f, Rect::new(0, 0, 24, 3), &mut b, &mut st);
 
+    // Unfocused + error input -> unfocused error-style border branch.
+    let f = InputFieldBuilder::<i32>::default()
+        .border(full_border())
+        .title(Some("n".into()))
+        .build()
+        .unwrap();
+    let mut st = InputFieldStateBuilder::default()
+        .focused(false)
+        .input("not-a-number".to_string())
+        .build()
+        .unwrap();
+    let mut b = buffer(24, 3);
+    StatefulWidget::render(&f, Rect::new(0, 0, 24, 3), &mut b, &mut st);
+
     // Disabled (no cursor) and the plain `Widget` impl (builds default state).
     let f = InputFieldBuilder::<String>::default().build().unwrap();
     let mut st = InputFieldStateBuilder::default().disabled(true).build().unwrap();

--- a/ferrowl/src/dialog/edit/input.rs
+++ b/ferrowl/src/dialog/edit/input.rs
@@ -1,6 +1,7 @@
 //! Free-text register edit dialog: every register property as an input field.
 
 use crate::config::device::{NamedValue, Scalar};
+use crate::dialog::NonEmpty;
 use crate::dialog::edit::{
     AccessOption, Alignment, Endian, Format, KindOption, ValueType, parse_address,
 };
@@ -37,7 +38,7 @@ use std::fmt::Debug;
 pub struct EditInputDialog {
     // Label for the register
     #[focus]
-    pub label: Widget<InputFieldState, InputField<String>>,
+    pub label: Widget<InputFieldState, InputField<NonEmpty>>,
     // Description for the register
     #[focus]
     pub description: Widget<InputFieldState, InputField<String>>,
@@ -46,7 +47,7 @@ pub struct EditInputDialog {
     pub slave_id: Widget<InputFieldState, InputField<u8>>,
     // Address of the start register
     #[focus]
-    pub address: Widget<InputFieldState, InputField<String>>,
+    pub address: Widget<InputFieldState, InputField<crate::dialog::Address>>,
     // Register kind selection (HoldingRegister, Coil, etc.)
     #[focus]
     pub kind: Widget<SelectionState<KindOption>, Selection<KindOption>>,
@@ -69,7 +70,7 @@ pub struct EditInputDialog {
     pub number_resolution: Widget<InputFieldState, InputField<f64>>,
     // Bit-field mask input (integer formats only)
     #[focus(when = { !self.is_boolean_kind() && self.value_type.get_value() == ValueType::Number && is_integer_format(&self.number_format.get_value().0) })]
-    pub number_bitmask: Widget<InputFieldState, InputField<String>>,
+    pub number_bitmask: Widget<InputFieldState, InputField<crate::dialog::Bitmask>>,
     // Text alignment selection
     #[focus(when = { !self.is_boolean_kind() && self.value_type.get_value() == ValueType::Text })]
     pub text_alignment: Widget<SelectionState<Alignment>, Selection<Alignment>>,

--- a/ferrowl/src/dialog/edit/selection.rs
+++ b/ferrowl/src/dialog/edit/selection.rs
@@ -62,7 +62,7 @@ where
 {
     // Label for the register
     #[focus]
-    pub label: Widget<InputFieldState, InputField<String>>,
+    pub label: Widget<InputFieldState, InputField<crate::dialog::NonEmpty>>,
     // Description for the register
     #[focus]
     pub description: Widget<InputFieldState, InputField<String>>,
@@ -71,7 +71,7 @@ where
     pub slave_id: Widget<InputFieldState, InputField<u8>>,
     // Address of the start register
     #[focus]
-    pub address: Widget<InputFieldState, InputField<String>>,
+    pub address: Widget<InputFieldState, InputField<crate::dialog::Address>>,
     // Register kind selection (HoldingRegister, Coil, etc.)
     #[focus]
     pub kind: Widget<SelectionState<KindOption>, Selection<KindOption>>,
@@ -92,7 +92,7 @@ where
     pub number_resolution: Widget<InputFieldState, InputField<f64>>,
     // Bit-field mask input (integer formats only)
     #[focus(when = {self.value_type.get_value() == ValueType::Number && is_integer_format(&self.number_format.get_value().0)})]
-    pub number_bitmask: Widget<InputFieldState, InputField<String>>,
+    pub number_bitmask: Widget<InputFieldState, InputField<crate::dialog::Bitmask>>,
     // Text alignment selection
     #[focus(when = {self.value_type.get_value() == ValueType::Text})]
     pub text_alignment: Widget<SelectionState<Alignment>, Selection<Alignment>>,

--- a/ferrowl/src/dialog/mod.rs
+++ b/ferrowl/src/dialog/mod.rs
@@ -4,4 +4,150 @@ mod edit;
 mod setup;
 
 pub use edit::{EditInputDialog, EditSelectionDialog, EditedRegister, SubDialogs, parse_raw_value};
+use ferrowl_ui::widgets::{Validate, ValidateResult};
 pub use setup::{SetupDialog, SetupValues};
+
+#[derive(Clone, Debug)]
+pub struct NonEmpty();
+
+impl Validate for NonEmpty {
+    fn validate(input: &str) -> ValidateResult {
+        if input.is_empty() {
+            ValidateResult::Error("Non-empty input required".to_string())
+        } else {
+            String::validate(input)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Address();
+
+impl Validate for Address {
+    fn validate(input: &str) -> ValidateResult {
+        if input == "virtual" {
+            ValidateResult::Success
+        } else if let ValidateResult::Error(e) = i16::validate(input) {
+            ValidateResult::Error(format!("{e}"))
+        } else {
+            ValidateResult::None
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Bitmask();
+
+impl Validate for Bitmask {
+    fn validate(input: &str) -> ValidateResult {
+        if input.is_empty() {
+            ValidateResult::None
+        } else if let Some(hex) = input
+            .strip_prefix("0x")
+            .or_else(|| input.strip_prefix("0X"))
+        {
+            if let Err(e) =
+                u128::from_str_radix(hex, 16).map_err(|_| "must be a hex (0x…) or decimal number")
+            {
+                ValidateResult::Error(format!("{e}"))
+            } else {
+                ValidateResult::None
+            }
+        } else {
+            if let Err(e) = input
+                .parse::<u128>()
+                .map_err(|_| "must be a hex (0x…) or decimal number")
+            {
+                ValidateResult::Error(format!("{e}"))
+            } else {
+                ValidateResult::None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_ui::widgets::ValidateResult;
+
+    // ---- NonEmpty ----
+
+    #[test]
+    fn non_empty_rejects_empty() {
+        assert!(matches!(NonEmpty::validate(""), ValidateResult::Error(_)));
+    }
+
+    #[test]
+    fn non_empty_accepts_text() {
+        assert!(matches!(NonEmpty::validate("hello"), ValidateResult::None));
+        assert!(matches!(NonEmpty::validate(" "), ValidateResult::None));
+    }
+
+    // ---- Address ----
+
+    #[test]
+    fn address_virtual_keyword() {
+        assert!(matches!(Address::validate("virtual"), ValidateResult::Success));
+    }
+
+    #[test]
+    fn address_valid_i16() {
+        assert!(matches!(Address::validate("0"), ValidateResult::None));
+        assert!(matches!(Address::validate("32767"), ValidateResult::None));
+        assert!(matches!(Address::validate("-32768"), ValidateResult::None));
+        assert!(matches!(Address::validate("100"), ValidateResult::None));
+    }
+
+    #[test]
+    fn address_overflow_i16() {
+        assert!(matches!(Address::validate("32768"), ValidateResult::Error(_)));
+        assert!(matches!(Address::validate("-32769"), ValidateResult::Error(_)));
+        assert!(matches!(Address::validate("99999"), ValidateResult::Error(_)));
+    }
+
+    #[test]
+    fn address_non_numeric() {
+        assert!(matches!(Address::validate("abc"), ValidateResult::Error(_)));
+        assert!(matches!(Address::validate(""), ValidateResult::Error(_)));
+    }
+
+    // ---- Bitmask ----
+
+    #[test]
+    fn bitmask_empty_is_none() {
+        assert!(matches!(Bitmask::validate(""), ValidateResult::None));
+    }
+
+    #[test]
+    fn bitmask_valid_hex_lowercase_prefix() {
+        assert!(matches!(Bitmask::validate("0xFF"), ValidateResult::None));
+        assert!(matches!(Bitmask::validate("0x0"), ValidateResult::None));
+        assert!(matches!(Bitmask::validate("0xDEADBEEF"), ValidateResult::None));
+    }
+
+    #[test]
+    fn bitmask_valid_hex_uppercase_prefix() {
+        assert!(matches!(Bitmask::validate("0XFF"), ValidateResult::None));
+        assert!(matches!(Bitmask::validate("0X0"), ValidateResult::None));
+    }
+
+    #[test]
+    fn bitmask_invalid_hex() {
+        assert!(matches!(Bitmask::validate("0xGG"), ValidateResult::Error(_)));
+        assert!(matches!(Bitmask::validate("0x"), ValidateResult::Error(_)));
+    }
+
+    #[test]
+    fn bitmask_valid_decimal() {
+        assert!(matches!(Bitmask::validate("0"), ValidateResult::None));
+        assert!(matches!(Bitmask::validate("255"), ValidateResult::None));
+        assert!(matches!(Bitmask::validate("340282366920938463463374607431768211455"), ValidateResult::None)); // u128::MAX
+    }
+
+    #[test]
+    fn bitmask_invalid_decimal() {
+        assert!(matches!(Bitmask::validate("abc"), ValidateResult::Error(_)));
+        assert!(matches!(Bitmask::validate("-1"), ValidateResult::Error(_)));
+    }
+}


### PR DESCRIPTION
Bare `String` fields accepted any input silently; invalid addresses and bitmasks only failed at save/parse time with no user feedback. `NonEmpty`, `Address`, and `Bitmask` validators surface errors inline via the input field's error border style.

input_field.rs border logic now applies error style regardless of focus state so invalid input stays visible when a field loses focus.