### PR TITLE
refactor(store): return Result from Memory read/write with typed errors

### DIFF
--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -38,7 +38,7 @@ where
             };
             let guard = memory.read().await;
             match guard.read(key, &CellType::Coil, &Range::new(addr as usize, cnt as usize)) {
-                Some(v) => {
+                Ok(v) => {
                     if verbose {
                         log.invoke(format!(
                             "ReadCoils request for slave ID {} and range [{}, {}) successful.",
@@ -50,10 +50,10 @@ where
                     }
                     Ok(Response::ReadCoils(v.into_iter().map(|b| b != 0).collect()))
                 }
-                None => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "ReadCoils request for slave ID {} and range [{}, {}) failed.",
+                            "ReadCoils request for slave ID {} and range [{}, {}) failed: {e}.",
                             slave,
                             addr,
                             addr + cnt
@@ -77,7 +77,7 @@ where
             };
             let guard = memory.read().await;
             match guard.read(key, &CellType::Coil, &Range::new(addr as usize, cnt as usize)) {
-                Some(v) => {
+                Ok(v) => {
                     if verbose {
                         log.invoke(format!(
                             "ReadDiscreteInputs request for slave ID {} and range [{}, {}) successful.",
@@ -91,10 +91,10 @@ where
                         v.into_iter().map(|b| b != 0).collect(),
                     ))
                 }
-                None => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "ReadDiscreteInputs request for slave ID {} and range [{}, {}) failed.",
+                            "ReadDiscreteInputs request for slave ID {} and range [{}, {}) failed: {e}.",
                             slave,
                             addr,
                             addr + cnt
@@ -122,7 +122,7 @@ where
                 &CellType::Register,
                 &Range::new(addr as usize, cnt as usize),
             ) {
-                Some(v) => {
+                Ok(v) => {
                     if verbose {
                         log.invoke(format!(
                             "ReadInputRegisters request for slave ID {} and range [{}, {}) successful.",
@@ -134,10 +134,10 @@ where
                     }
                     Ok(Response::ReadInputRegisters(v))
                 }
-                None => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "ReadInputRegisters request for slave ID {} and range [{}, {}) failed.",
+                            "ReadInputRegisters request for slave ID {} and range [{}, {}) failed: {e}.",
                             slave,
                             addr,
                             addr + cnt
@@ -165,7 +165,7 @@ where
                 &CellType::Register,
                 &Range::new(addr as usize, cnt as usize),
             ) {
-                Some(v) => {
+                Ok(v) => {
                     if verbose {
                         log.invoke(format!(
                             "ReadHoldingRegisters request for slave ID {} and range [{}, {}) successful.",
@@ -177,10 +177,10 @@ where
                     }
                     Ok(Response::ReadHoldingRegisters(v))
                 }
-                None => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "ReadHoldingRegisters request for slave ID {} and range [{}, {}) failed.",
+                            "ReadHoldingRegisters request for slave ID {} and range [{}, {}) failed: {e}.",
                             slave,
                             addr,
                             addr + cnt
@@ -210,7 +210,7 @@ where
                 &Range::new(addr as usize, values.len()),
                 &values,
             ) {
-                true => {
+                Ok(()) => {
                     if verbose {
                         log.invoke(format!(
                             "WriteMultipleRegisters request for slave ID {}, range [{}, {}), and values {:?} successful.",
@@ -223,10 +223,10 @@ where
                     }
                     Ok(Response::WriteMultipleRegisters(addr, values.len() as u16))
                 }
-                false => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "WriteMultipleRegisters request for slave ID {}, range [{}, {}), and values {:?} failed.",
+                            "WriteMultipleRegisters request for slave ID {}, range [{}, {}), and values {:?} failed: {e}.",
                             slave,
                             addr,
                             addr as usize + values.len(),
@@ -254,7 +254,7 @@ where
                 &Range::new(addr as usize, 1),
                 &[value],
             ) {
-                true => {
+                Ok(()) => {
                     if verbose {
                         log.invoke(format!(
                             "WriteSingleRegister request for slave ID {}, address {}, and value {} successful.",
@@ -264,10 +264,10 @@ where
                     }
                     Ok(Response::WriteSingleRegister(addr, value))
                 }
-                false => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "WriteSingleRegister request for slave ID {}, address {}, and value {} failed.",
+                            "WriteSingleRegister request for slave ID {}, address {}, and value {} failed: {e}.",
                             slave, addr, value
                         ))
                         .await;
@@ -291,7 +291,7 @@ where
             let mut guard = memory.write().await;
             let values: Vec<u16> = values.iter().map(|v| *v as u16).collect();
             match guard.write(key, &CellType::Coil, &Range::new(addr as usize, values.len()), &values) {
-                true => {
+                Ok(()) => {
                     if verbose {
                         log.invoke(format!(
                             "WriteMultipleCoils request for slave ID {}, range [{}, {}), and values {:?} successful.",
@@ -304,10 +304,10 @@ where
                     }
                     Ok(Response::WriteMultipleCoils(addr, values.len() as u16))
                 }
-                false => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "WriteMultipleCoils request for slave ID {}, range [{}, {}), and values {:?} failed.",
+                            "WriteMultipleCoils request for slave ID {}, range [{}, {}), and values {:?} failed: {e}.",
                             slave,
                             addr,
                             addr as usize + values.len(),
@@ -331,7 +331,7 @@ where
             let mut guard = memory.write().await;
             let val = value as u16;
             match guard.write(key, &CellType::Coil, &Range::new(addr as usize, 1), &[val]) {
-                true => {
+                Ok(()) => {
                     if verbose {
                         log.invoke(format!(
                             "WriteSingleCoil request for slave ID {}, address {}, and value {} successful.",
@@ -341,10 +341,10 @@ where
                     }
                     Ok(Response::WriteSingleCoil(addr, value))
                 }
-                false => {
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "WriteSingleCoil request for slave ID {}, address {}, and value {} failed.",
+                            "WriteSingleCoil request for slave ID {}, address {}, and value {} failed: {e}.",
                             slave, addr, value
                         ))
                         .await;
@@ -379,20 +379,28 @@ where
                 id: T::from_slave_fn(slave, FunctionCode::ReadWriteMultipleRegisters),
             };
             let mut guard = memory.write().await;
-            let readable = guard.readable(
+            if let Err(e) = guard.readable(
                 &key,
                 &CellType::Register,
                 &Range::new(read_addr as usize, cnt as usize),
-            );
-            let writable = guard.writable(
+            ) {
+                if verbose {
+                    log.invoke(format!(
+                        "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed: {e}.",
+                        slave, read_addr, cnt, write_addr, values
+                    ))
+                    .await;
+                }
+                return Err(ExceptionCode::IllegalDataAddress);
+            }
+            if let Err(e) = guard.writable(
                 &key,
                 &CellType::Register,
                 &Range::new(write_addr as usize, values.len()),
-            );
-            if !readable || !writable {
+            ) {
                 if verbose {
                     log.invoke(format!(
-                        "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed.",
+                        "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed: {e}.",
                         slave, read_addr, cnt, write_addr, values
                     ))
                     .await;
@@ -404,11 +412,11 @@ where
                 &CellType::Register,
                 &Range::new(read_addr as usize, cnt as usize),
             ) {
-                Some(v) => v,
-                None => {
+                Ok(v) => v,
+                Err(e) => {
                     if verbose {
                         log.invoke(format!(
-                            "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed.",
+                            "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed: {e}.",
                             slave, read_addr, cnt, write_addr, values
                         ))
                         .await;
@@ -416,7 +424,7 @@ where
                     return Err(ExceptionCode::IllegalFunction);
                 }
             };
-            if !guard.write(
+            if let Err(e) = guard.write(
                 key,
                 &CellType::Register,
                 &Range::new(write_addr as usize, values.len()),
@@ -424,7 +432,7 @@ where
             ) {
                 if verbose {
                     log.invoke(format!(
-                        "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed.",
+                        "ReadWriteMultipleRegisrters request for slave ID {}, read address {}, count {}, write address {}, and values {:?} failed: {e}.",
                         slave, read_addr, cnt, write_addr, values
                     ))
                     .await;
@@ -483,7 +491,7 @@ mod tests {
             &[Range::new(0, 4)],
         );
         if !seed.is_empty() {
-            mem.write(key, &CellType::Register, &Range::new(0, seed.len()), seed);
+            mem.write(key, &CellType::Register, &Range::new(0, seed.len()), seed).unwrap();
         }
         Arc::new(RwLock::new(mem))
     }
@@ -591,7 +599,7 @@ mod tests {
         let mut mem = Memory::<Key<SlaveKey>>::default();
         mem.add_ranges(key.clone(), &MemKind::ReadWrite(ty), &[Range::new(0, len)]);
         if !seed.is_empty() {
-            mem.write(key, &ty, &Range::new(0, seed.len()), seed);
+            mem.write(key, &ty, &Range::new(0, seed.len()), seed).unwrap();
         }
         Arc::new(RwLock::new(mem))
     }

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -46,13 +46,13 @@ fn config(port: u16) -> tcp::Config {
 fn server_mem() -> Mem {
     let mut mem = Memory::<Key<SlaveKey>>::default();
     mem.add_ranges(key(RegKind::Coil), &MemKind::ReadWrite(CellType::Coil), &[Range::new(0, 8)]);
-    mem.write(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4), &[1, 0, 1, 0]);
+    mem.write(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4), &[1, 0, 1, 0]).unwrap();
     mem.add_ranges(
         key(RegKind::DiscreteInput),
         &MemKind::ReadWrite(CellType::Coil),
         &[Range::new(0, 4)],
     );
-    mem.write(key(RegKind::DiscreteInput), &CellType::Coil, &Range::new(0, 4), &[0, 1, 1, 0]);
+    mem.write(key(RegKind::DiscreteInput), &CellType::Coil, &Range::new(0, 4), &[0, 1, 1, 0]).unwrap();
     mem.add_ranges(
         key(RegKind::InputRegister),
         &MemKind::ReadWrite(CellType::Register),
@@ -63,7 +63,7 @@ fn server_mem() -> Mem {
         &CellType::Register,
         &Range::new(0, 4),
         &[100, 200, 300, 400],
-    );
+    ).unwrap();
     mem.add_ranges(
         key(RegKind::HoldingRegister),
         &MemKind::ReadWrite(CellType::Register),
@@ -74,7 +74,7 @@ fn server_mem() -> Mem {
         &CellType::Register,
         &Range::new(0, 4),
         &[10, 20, 30, 40],
-    );
+    ).unwrap();
     Arc::new(RwLock::new(mem))
 }
 
@@ -148,20 +148,20 @@ async fn tcp_client_polls_server_and_executes_commands() {
     {
         let g = cli_mem.read().await;
         assert_eq!(
-            g.read(key(RegKind::HoldingRegister), &CellType::Register, &Range::new(0, 4)),
-            Some(vec![10, 20, 30, 40])
+            g.read(key(RegKind::HoldingRegister), &CellType::Register, &Range::new(0, 4)).unwrap(),
+            vec![10, 20, 30, 40]
         );
         assert_eq!(
-            g.read(key(RegKind::InputRegister), &CellType::Register, &Range::new(0, 4)),
-            Some(vec![100, 200, 300, 400])
+            g.read(key(RegKind::InputRegister), &CellType::Register, &Range::new(0, 4)).unwrap(),
+            vec![100, 200, 300, 400]
         );
         assert_eq!(
-            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4)),
-            Some(vec![1, 0, 1, 0])
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4)).unwrap(),
+            vec![1, 0, 1, 0]
         );
         assert_eq!(
-            g.read(key(RegKind::DiscreteInput), &CellType::Coil, &Range::new(0, 4)),
-            Some(vec![0, 1, 1, 0])
+            g.read(key(RegKind::DiscreteInput), &CellType::Coil, &Range::new(0, 4)).unwrap(),
+            vec![0, 1, 1, 0]
         );
     }
 
@@ -175,12 +175,12 @@ async fn tcp_client_polls_server_and_executes_commands() {
     {
         let g = srv_mem.read().await;
         assert_eq!(
-            g.read(key(RegKind::HoldingRegister), &CellType::Register, &Range::new(0, 3)),
-            Some(vec![99, 5, 6])
+            g.read(key(RegKind::HoldingRegister), &CellType::Register, &Range::new(0, 3)).unwrap(),
+            vec![99, 5, 6]
         );
         assert_eq!(
-            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(5, 3)),
-            Some(vec![1, 1, 0])
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(5, 3)).unwrap(),
+            vec![1, 1, 0]
         );
     }
 

--- a/ferrowl-store/src/lib.rs
+++ b/ferrowl-store/src/lib.rs
@@ -12,6 +12,6 @@ mod cell;
 
 pub mod slice;
 
-pub use memory::Memory;
+pub use memory::{Memory, MemoryError};
 pub use range::Range;
 pub use cell::{CellKind, CellType, Cell, ValueRange};

--- a/ferrowl-store/src/memory.rs
+++ b/ferrowl-store/src/memory.rs
@@ -4,7 +4,34 @@ use crate::range::Range;
 use crate::slice::Slice;
 use crate::cell::{CellKind, CellType, Cell};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
+
+/// Why a [`Memory`] read or write operation failed.
+#[derive(Debug, PartialEq)]
+pub enum MemoryError {
+    /// The device key has no registered memory regions.
+    UnknownKey,
+    /// The requested address range is not registered or not readable as the given cell type.
+    AddressNotReadable,
+    /// The requested address range is not registered or not writable as the given cell type.
+    AddressNotWritable,
+    /// The number of supplied values does not match the range length.
+    LengthMismatch { expected: usize, got: usize },
+}
+
+impl fmt::Display for MemoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MemoryError::UnknownKey => write!(f, "key not registered"),
+            MemoryError::AddressNotReadable => write!(f, "address not readable"),
+            MemoryError::AddressNotWritable => write!(f, "address not writable"),
+            MemoryError::LengthMismatch { expected, got } => {
+                write!(f, "length mismatch: expected {expected}, got {got}")
+            }
+        }
+    }
+}
 
 /// Register storage for multiple devices, keyed by `K` (e.g. a unit/slave id).
 ///
@@ -100,24 +127,23 @@ where
 
     /// Writes `values` to device `id` starting at `range.start`.
     ///
-    /// Fails (returns `false`) if the value count does not match the range
-    /// length, or if any addressed cell is not writable as type `ty`.
-    pub fn write(&mut self, id: K, ty: &CellType, range: &Range, values: &[u16]) -> bool {
-        if range.length() != values.len() || !self.writable(&id, ty, range) {
-            return false;
+    /// Returns [`MemoryError::LengthMismatch`] if the value count does not match the range length,
+    /// [`MemoryError::UnknownKey`] if `id` has no registered regions, and
+    /// [`MemoryError::AddressNotWritable`] if any addressed cell is not writable as type `ty`.
+    pub fn write(&mut self, id: K, ty: &CellType, range: &Range, values: &[u16]) -> Result<(), MemoryError> {
+        if range.length() != values.len() {
+            return Err(MemoryError::LengthMismatch { expected: range.length(), got: values.len() });
         }
-        match self.slices.get_mut(&id) {
-            Some(map) => {
-                let mut idx = 0;
-                walk_slices_mut(map, range, |slice, seg| {
-                    let count = seg.length();
-                    slice.write(&seg, &values[idx..(idx + count)]);
-                    idx += count;
-                    true
-                })
-            }
-            _ => false,
-        }
+        self.writable(&id, ty, range)?;
+        let map = self.slices.get_mut(&id).unwrap();
+        let mut idx = 0;
+        walk_slices_mut(map, range, |slice, seg| {
+            let count = seg.length();
+            slice.write(&seg, &values[idx..(idx + count)]);
+            idx += count;
+            true
+        });
+        Ok(())
     }
 
     /// Write values regardless of cell kind — bypasses the `writable` check and forces writes to
@@ -140,35 +166,37 @@ where
         }
     }
 
-    /// Returns `true` if every cell in `range` exists and accepts writes of type `ty`.
-    pub fn writable(&mut self, id: &K, ty: &CellType, range: &Range) -> bool {
+    /// Returns `Ok(())` if every cell in `range` exists and accepts writes of type `ty`,
+    /// otherwise returns [`MemoryError::UnknownKey`] or [`MemoryError::AddressNotWritable`].
+    pub fn writable(&mut self, id: &K, ty: &CellType, range: &Range) -> Result<(), MemoryError> {
         match self.slices.get(id) {
-            Some(map) => walk_slices(map, range, |slice, seg| slice.writable(ty, &seg)),
-            _ => false,
+            Some(map) => {
+                if walk_slices(map, range, |slice, seg| slice.writable(ty, &seg)) {
+                    Ok(())
+                } else {
+                    Err(MemoryError::AddressNotWritable)
+                }
+            }
+            None => Err(MemoryError::UnknownKey),
         }
     }
 
     /// Reads the values in `range` from device `id`.
     ///
-    /// Returns `None` if any addressed cell is missing or not readable as
-    /// type `ty`.
-    pub fn read(&self, id: K, ty: &CellType, range: &Range) -> Option<Vec<u16>> {
-        if !self.readable(&id, ty, range) {
-            return None;
-        }
-        match self.slices.get(&id) {
-            Some(map) => {
-                let mut output: Vec<u16> = Vec::with_capacity(range.length());
-                let covered = walk_slices(map, range, |slice, seg| {
-                    if let Some(mut v) = slice.read(&seg) {
-                        output.append(&mut v);
-                    }
-                    true
-                });
-                if covered { Some(output) } else { None }
+    /// Returns [`MemoryError::UnknownKey`] if `id` has no registered regions and
+    /// [`MemoryError::AddressNotReadable`] if any addressed cell is missing or not
+    /// readable as type `ty`.
+    pub fn read(&self, id: K, ty: &CellType, range: &Range) -> Result<Vec<u16>, MemoryError> {
+        self.readable(&id, ty, range)?;
+        let map = self.slices.get(&id).unwrap();
+        let mut output: Vec<u16> = Vec::with_capacity(range.length());
+        walk_slices(map, range, |slice, seg| {
+            if let Some(mut v) = slice.read(&seg) {
+                output.append(&mut v);
             }
-            _ => None,
-        }
+            true
+        });
+        Ok(output)
     }
 
     /// Reads values regardless of cell kind — returns the stored value of
@@ -189,11 +217,18 @@ where
         }
     }
 
-    /// Returns `true` if every cell in `range` exists and is readable as type `ty`.
-    pub fn readable(&self, id: &K, ty: &CellType, range: &Range) -> bool {
+    /// Returns `Ok(())` if every cell in `range` exists and is readable as type `ty`,
+    /// otherwise returns [`MemoryError::UnknownKey`] or [`MemoryError::AddressNotReadable`].
+    pub fn readable(&self, id: &K, ty: &CellType, range: &Range) -> Result<(), MemoryError> {
         match self.slices.get(id) {
-            Some(map) => walk_slices(map, range, |slice, seg| slice.readable(ty, &seg)),
-            _ => false,
+            Some(map) => {
+                if walk_slices(map, range, |slice, seg| slice.readable(ty, &seg)) {
+                    Ok(())
+                } else {
+                    Err(MemoryError::AddressNotReadable)
+                }
+            }
+            None => Err(MemoryError::UnknownKey),
         }
     }
 }
@@ -246,7 +281,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{CellKind, Memory, CellType, Cell, range::Range};
+    use crate::{CellKind, Memory, MemoryError, CellType, Cell, range::Range};
 
     #[test]
     fn ut_memory() {
@@ -319,10 +354,10 @@ mod tests {
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]);
 
         let values: Vec<u16> = vec![10, 20, 30, 40, 50];
-        assert!(memory.write(1u8, &CellType::Coil, &Range::new(0, 5), &values));
+        assert!(memory.write(1u8, &CellType::Coil, &Range::new(0, 5), &values).is_ok());
 
         let result = memory.read(1u8, &CellType::Coil, &Range::new(0, 5));
-        assert_eq!(result, Some(values));
+        assert_eq!(result.unwrap(), values);
     }
 
     #[test]
@@ -331,10 +366,10 @@ mod tests {
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Register), &[Range::new(0, 10)]);
 
         let values: Vec<u16> = vec![1, 2, 3];
-        assert!(memory.write(1u8, &CellType::Register, &Range::new(3, 3), &values));
+        assert!(memory.write(1u8, &CellType::Register, &Range::new(3, 3), &values).is_ok());
 
         let result = memory.read(1u8, &CellType::Register, &Range::new(3, 3));
-        assert_eq!(result, Some(values));
+        assert_eq!(result.unwrap(), values);
     }
 
     #[test]
@@ -343,7 +378,10 @@ mod tests {
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]);
 
         let values: Vec<u16> = vec![1, 2, 3]; // length 3, range length 5
-        assert!(!memory.write(1u8, &CellType::Coil, &Range::new(0, 5), &values));
+        assert_eq!(
+            memory.write(1u8, &CellType::Coil, &Range::new(0, 5), &values),
+            Err(MemoryError::LengthMismatch { expected: 5, got: 3 })
+        );
     }
 
     #[test]
@@ -352,7 +390,10 @@ mod tests {
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]);
 
         let values: Vec<u16> = vec![1, 2, 3, 4, 5];
-        assert!(!memory.write(99u8, &CellType::Coil, &Range::new(0, 5), &values));
+        assert_eq!(
+            memory.write(99u8, &CellType::Coil, &Range::new(0, 5), &values),
+            Err(MemoryError::UnknownKey)
+        );
     }
 
     #[test]
@@ -360,7 +401,10 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]);
 
-        assert!(memory.read(99u8, &CellType::Coil, &Range::new(0, 5)).is_none());
+        assert_eq!(
+            memory.read(99u8, &CellType::Coil, &Range::new(0, 5)),
+            Err(MemoryError::UnknownKey)
+        );
     }
 
     #[test]
@@ -368,7 +412,10 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]);
 
-        assert!(!memory.writable(&1u8, &CellType::Register, &Range::new(0, 5)));
+        assert_eq!(
+            memory.writable(&1u8, &CellType::Register, &Range::new(0, 5)),
+            Err(MemoryError::AddressNotWritable)
+        );
     }
 
     #[test]
@@ -376,7 +423,10 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Register), &[Range::new(0, 5)]);
 
-        assert!(!memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert_eq!(
+            memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)),
+            Err(MemoryError::AddressNotReadable)
+        );
     }
 
     #[test]
@@ -384,7 +434,10 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]);
 
-        assert!(!memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert_eq!(
+            memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)),
+            Err(MemoryError::AddressNotWritable)
+        );
     }
 
     #[test]
@@ -392,7 +445,10 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]);
 
-        assert!(!memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert_eq!(
+            memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)),
+            Err(MemoryError::AddressNotReadable)
+        );
     }
 
     #[test]
@@ -409,8 +465,8 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Read(CellType::Register), &[Range::new(0, 5)]);
         assert!(memory.add_ranges(1u8, &CellKind::Write(CellType::Register), &[Range::new(0, 5)]));
-        assert!(memory.readable(&1u8, &CellType::Register, &Range::new(0, 5)));
-        assert!(memory.writable(&1u8, &CellType::Register, &Range::new(0, 5)));
+        assert!(memory.readable(&1u8, &CellType::Register, &Range::new(0, 5)).is_ok());
+        assert!(memory.writable(&1u8, &CellType::Register, &Range::new(0, 5)).is_ok());
     }
 
     #[test]
@@ -419,8 +475,8 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]);
         assert!(memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]));
-        assert!(memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)));
-        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert!(memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_ok());
+        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_ok());
     }
 
     #[test]
@@ -429,8 +485,8 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]);
         assert!(memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]));
-        assert!(!memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)));
-        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert!(memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_err());
+        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_ok());
     }
 
     #[test]
@@ -438,8 +494,8 @@ mod tests {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]);
         assert!(memory.add_ranges(1u8, &CellKind::ReadWrite(CellType::Coil), &[Range::new(0, 5)]));
-        assert!(memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)));
-        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)));
+        assert!(memory.readable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_ok());
+        assert!(memory.writable(&1u8, &CellType::Coil, &Range::new(0, 5)).is_ok());
     }
 
     #[test]
@@ -472,7 +528,7 @@ mod tests {
 
         // Checked write fails on read-only cells; unchecked forces it.
         let values: Vec<u16> = vec![5, 6, 7, 8, 9];
-        assert!(!memory.write(1u8, &CellType::Register, &Range::new(0, 5), &values));
+        assert!(memory.write(1u8, &CellType::Register, &Range::new(0, 5), &values).is_err());
         assert!(memory.write_unchecked(1u8, &Range::new(0, 5), &values));
         assert_eq!(memory.read_unchecked(1u8, &Range::new(0, 5)), Some(values));
 
@@ -492,17 +548,17 @@ mod tests {
         assert_eq!(memory.slices.get(&1u8).unwrap().len(), 2);
 
         let values: Vec<u16> = (1..=10).collect();
-        assert!(memory.write(1u8, &CellType::Register, &Range::new(0, 10), &values));
+        assert!(memory.write(1u8, &CellType::Register, &Range::new(0, 10), &values).is_ok());
         assert_eq!(
-            memory.read(1u8, &CellType::Register, &Range::new(0, 10)),
-            Some(values)
+            memory.read(1u8, &CellType::Register, &Range::new(0, 10)).unwrap(),
+            values
         );
 
         // A range living only in the second slice: the first slice is skipped.
-        assert!(memory.write(1u8, &CellType::Register, &Range::new(7, 3), &[70, 80, 90]));
+        assert!(memory.write(1u8, &CellType::Register, &Range::new(7, 3), &[70, 80, 90]).is_ok());
         assert_eq!(
-            memory.read(1u8, &CellType::Register, &Range::new(7, 3)),
-            Some(vec![70, 80, 90])
+            memory.read(1u8, &CellType::Register, &Range::new(7, 3)).unwrap(),
+            vec![70, 80, 90]
         );
     }
 }

--- a/ferrowl/src/module.rs
+++ b/ferrowl/src/module.rs
@@ -1011,7 +1011,7 @@ mod tests {
                 &CellType::Register,
                 &Range::new(0, raw.len()),
                 &raw
-            ),
+            ).is_ok(),
             "write should succeed for a Combined register cell"
         );
 


### PR DESCRIPTION
`Memory::read`, `write`, `readable`, and `writable` returned `Option`/`bool` with no failure reason. Callers could only log "failed" with no context.

New `MemoryError` enum (`UnknownKey`, `AddressNotReadable`, `AddressNotWritable`, `LengthMismatch`) lets server_core log the actual cause, e.g. "failed: key not registered" or "failed: length mismatch: expected 4, got 3".