### PR TITLE
feat(ui): auto-indent code inputs on Enter

### DIFF
--- a/ferrowl-syntax/src/format/lua.rs
+++ b/ferrowl-syntax/src/format/lua.rs
@@ -8,16 +8,16 @@
 use crate::lang::lua::highlight_line;
 use crate::{LineState, LuaCarry, SyntaxKind};
 
-fn is_opener(text: &str, kind: SyntaxKind) -> bool {
+pub(crate) fn is_opener(text: &str, kind: SyntaxKind) -> bool {
     matches!(text, "function" | "do" | "then" | "repeat")
         || (kind == SyntaxKind::Punct && matches!(text, "{" | "("))
 }
 
-fn is_closer(text: &str, kind: SyntaxKind) -> bool {
+pub(crate) fn is_closer(text: &str, kind: SyntaxKind) -> bool {
     matches!(text, "end" | "until") || (kind == SyntaxKind::Punct && matches!(text, "}" | ")"))
 }
 
-fn is_else(text: &str) -> bool {
+pub(crate) fn is_else(text: &str) -> bool {
     matches!(text, "else" | "elseif")
 }
 

--- a/ferrowl-syntax/src/format/mod.rs
+++ b/ferrowl-syntax/src/format/mod.rs
@@ -3,7 +3,7 @@
 //! on `None` — this module never mangles content it can't fully understand.
 
 mod json;
-mod lua;
+pub(crate) mod lua;
 
 use crate::Language;
 

--- a/ferrowl-syntax/src/indent.rs
+++ b/ferrowl-syntax/src/indent.rs
@@ -1,0 +1,107 @@
+//! Indent hint for editors: given the text left of the cursor when Enter is pressed,
+//! how many levels deeper (or shallower) should the new line start relative to that
+//! line's own leading whitespace? Token-scanned with the language lexers, so block
+//! keywords or brackets inside strings/comments never count — mirroring the depth
+//! rules of the [`format`](crate::format) re-indenters.
+
+use crate::format::lua::{is_closer, is_else, is_opener};
+use crate::{Language, LineState, SyntaxKind, highlight_line};
+
+/// Net block-depth change `line` contributes to the line that follows it, in levels
+/// (callers multiply by their indent width). Leading closers don't count: they dedent
+/// the line itself, not the next one. A leading `else` counts as one level (its body is
+/// deeper than the `else` line); `elseif` opens via its own trailing `then`.
+pub fn indent_delta(lang: Language, line: &str) -> i32 {
+    let (spans, _) = highlight_line(lang, line, LineState::default());
+    let chars: Vec<char> = line.chars().collect();
+    let mut delta = 0i32;
+    let mut leading = true;
+    for (start, end, kind) in spans {
+        let text: String = chars[start..end].iter().collect();
+        let (opener, closer) = classify(lang, &text, kind);
+        if leading {
+            if closer {
+                continue;
+            }
+            if lang == Language::Lua && is_else(&text) {
+                leading = false;
+                if text == "else" {
+                    delta += 1;
+                }
+                continue;
+            }
+            leading = false;
+        }
+        if opener {
+            delta += 1;
+        } else if closer {
+            delta -= 1;
+        }
+    }
+    delta
+}
+
+fn classify(lang: Language, text: &str, kind: SyntaxKind) -> (bool, bool) {
+    match lang {
+        Language::Lua => (is_opener(text, kind), is_closer(text, kind)),
+        Language::Json => (
+            kind == SyntaxKind::Punct && matches!(text, "{" | "["),
+            kind == SyntaxKind::Punct && matches!(text, "}" | "]"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ut_lua_openers_indent_next_line() {
+        assert_eq!(indent_delta(Language::Lua, "function foo()"), 1);
+        assert_eq!(indent_delta(Language::Lua, "if x then"), 1);
+        assert_eq!(indent_delta(Language::Lua, "for i=1,10 do"), 1);
+        assert_eq!(indent_delta(Language::Lua, "repeat"), 1);
+        assert_eq!(indent_delta(Language::Lua, "local t = {"), 1);
+    }
+
+    #[test]
+    fn ut_lua_balanced_and_plain_lines_are_flat() {
+        assert_eq!(indent_delta(Language::Lua, "print(x)"), 0);
+        assert_eq!(indent_delta(Language::Lua, "if x then y() end"), 0);
+        assert_eq!(indent_delta(Language::Lua, ""), 0);
+    }
+
+    #[test]
+    fn ut_lua_leading_closer_does_not_dedent_next_line() {
+        assert_eq!(indent_delta(Language::Lua, "end"), 0);
+        assert_eq!(indent_delta(Language::Lua, "until done"), 0);
+        assert_eq!(indent_delta(Language::Lua, "}"), 0);
+    }
+
+    #[test]
+    fn ut_lua_else_and_elseif_indent_their_body() {
+        assert_eq!(indent_delta(Language::Lua, "else"), 1);
+        assert_eq!(indent_delta(Language::Lua, "elseif y then"), 1);
+    }
+
+    #[test]
+    fn ut_lua_mid_line_closer_dedents_next_line() {
+        assert_eq!(indent_delta(Language::Lua, "x() end"), -1);
+    }
+
+    #[test]
+    fn ut_lua_keywords_in_strings_do_not_count() {
+        assert_eq!(indent_delta(Language::Lua, "local s = \"function do then\""), 0);
+        assert_eq!(indent_delta(Language::Lua, "-- if x then"), 0);
+    }
+
+    #[test]
+    fn ut_json_braces_and_brackets() {
+        assert_eq!(indent_delta(Language::Json, "{"), 1);
+        assert_eq!(indent_delta(Language::Json, "\"a\": ["), 1);
+        assert_eq!(indent_delta(Language::Json, "\"a\": 1,"), 0);
+        assert_eq!(indent_delta(Language::Json, "},"), 0);
+        assert_eq!(indent_delta(Language::Json, "\"a\": { \"b\": ["), 2);
+        assert_eq!(indent_delta(Language::Json, "\"s\": \"{[\","), 0);
+    }
+}

--- a/ferrowl-syntax/src/lib.rs
+++ b/ferrowl-syntax/src/lib.rs
@@ -6,9 +6,11 @@
 //! TUI editor widget) own the mapping from [`SyntaxKind`] to actual colors/styles.
 
 mod format;
+mod indent;
 mod lang;
 
 pub use format::format;
+pub use indent::indent_delta;
 pub use lang::Language;
 
 /// Classification of a highlighted span.

--- a/ferrowl-ui/src/state/code_input_field.rs
+++ b/ferrowl-ui/src/state/code_input_field.rs
@@ -151,10 +151,21 @@ impl HandleEvents for CodeInputFieldState {
                 let chars: Vec<char> = line.chars().collect();
                 let before: String = chars[..self.cursor_col].iter().collect();
                 let after: String = chars[self.cursor_col..].iter().collect();
+                // Auto-indent: inherit the split line's leading whitespace, one level
+                // deeper/shallower per its net block balance (format-on-blur trues it up).
+                let indent = match self.language {
+                    Some(lang) => {
+                        let lead = before.chars().take_while(|c| *c == ' ').count() as i32;
+                        let delta = ferrowl_syntax::indent_delta(lang, &before);
+                        (lead + 4 * delta).max(0) as usize
+                    }
+                    None => 0,
+                };
                 self.lines[self.active_line] = before;
                 self.active_line += 1;
-                self.lines.insert(self.active_line, after);
-                self.cursor_col = 0;
+                self.lines
+                    .insert(self.active_line, format!("{}{}", " ".repeat(indent), after));
+                self.cursor_col = indent;
                 EventResult::Consumed
             }
             (KeyModifiers::NONE, KeyCode::Backspace) if !self.disabled => {
@@ -553,6 +564,65 @@ mod tests {
         s.set_content(r#"{"b":1,"a":2}"#);
         s.set_focused(true);
         assert_eq!(s.content(), r#"{"b":1,"a":2}"#);
+    }
+
+    #[test]
+    fn enter_auto_indents_after_lua_opener() {
+        let mut s = CodeInputFieldStateBuilder::default()
+            .language(Some(ferrowl_syntax::Language::Lua))
+            .build()
+            .unwrap();
+        s.set_content("function foo()");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "function foo()\n    ");
+        assert_eq!(s.cursor_col(), 4);
+    }
+
+    #[test]
+    fn enter_inherits_indent_on_plain_line() {
+        let mut s = CodeInputFieldStateBuilder::default()
+            .language(Some(ferrowl_syntax::Language::Lua))
+            .build()
+            .unwrap();
+        s.set_content("function foo()\n    print(1)");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "function foo()\n    print(1)\n    ");
+        assert_eq!(s.cursor_col(), 4);
+    }
+
+    #[test]
+    fn enter_does_not_indent_after_closing_line() {
+        let mut s = CodeInputFieldStateBuilder::default()
+            .language(Some(ferrowl_syntax::Language::Lua))
+            .build()
+            .unwrap();
+        s.set_content("end");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "end\n");
+        assert_eq!(s.cursor_col(), 0);
+    }
+
+    #[test]
+    fn enter_auto_indents_json_and_carries_tail() {
+        let mut s = CodeInputFieldStateBuilder::default()
+            .language(Some(ferrowl_syntax::Language::Json))
+            .build()
+            .unwrap();
+        // Cursor between `{` and `}`: the tail moves to the new, indented line.
+        s.set_content("{}");
+        s.set_cursor_col(1);
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "{\n    }");
+        assert_eq!(s.cursor_col(), 4);
+    }
+
+    #[test]
+    fn enter_without_language_does_not_indent() {
+        let mut s = state();
+        s.set_content("    x {");
+        press(&mut s, KeyModifiers::NONE, KeyCode::Enter);
+        assert_eq!(s.content(), "    x {\n");
+        assert_eq!(s.cursor_col(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Tab switches focus, so every new line started at column 0 and had to be indented by hand (double-space chord or format-on-blur after).

- ferrowl-syntax: indent_delta(lang, line) computes a line's net block balance via the lexers, reusing the re-indenter's opener/closer/else rules so strings and comments never count
- Enter inherits the split line's leading whitespace +/- 4 spaces per level; leading closers don't dedent the next line; language-less fields are unchanged