### PR TITLE
feat(ocpp): prefill JSON-only actions with example payloads

### DIFF
--- a/ferrowl/src/module/ocpp/client/v1_6/version.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/version.rs
@@ -134,6 +134,10 @@ impl ClientVersion for V1_6 {
         crate::module::ocpp::spec::v1_6::json_actions()
     }
 
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v1_6::json_template(name)
+    }
+
     fn scope_of(s: &CsState, idx: usize) -> Scope {
         Scope::connector(s.connectors[idx].connector_id)
     }

--- a/ferrowl/src/module/ocpp/client/v2_0_1/version.rs
+++ b/ferrowl/src/module/ocpp/client/v2_0_1/version.rs
@@ -56,6 +56,10 @@ impl ClientVersion for V2_0_1 {
         crate::module::ocpp::spec::v2_0_1::json_actions()
     }
 
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v2_0_1::json_template(name)
+    }
+
     fn scope_of(s: &CsState, idx: usize) -> Scope {
         common::scope_of(s, idx)
     }

--- a/ferrowl/src/module/ocpp/client/v2_1/version.rs
+++ b/ferrowl/src/module/ocpp/client/v2_1/version.rs
@@ -58,6 +58,10 @@ impl ClientVersion for V2_1 {
         crate::module::ocpp::spec::v2_1::json_actions()
     }
 
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v2_1::json_template(name)
+    }
+
     fn scope_of(s: &CsState, idx: usize) -> Scope {
         common::scope_of(s, idx)
     }

--- a/ferrowl/src/module/ocpp/client/view/input.rs
+++ b/ferrowl/src/module/ocpp/client/view/input.rs
@@ -324,8 +324,10 @@ impl<V: ClientVersion> ClientView<V> {
                             V::json_actions().contains(&name.as_str()),
                             "{name} has no spec and is not a registered JSON action"
                         );
-                        let template = V::default_action(&name)
-                            .and_then(|a| V::encode_action(&a).ok())
+                        let template = V::json_template(&name)
+                            .or_else(|| {
+                                V::default_action(&name).and_then(|a| V::encode_action(&a).ok())
+                            })
                             .map(|v| serde_json::to_string_pretty(&v).unwrap_or_default())
                             .unwrap_or_else(|| "{}".to_string());
                         Box::new(ActionDialog::json_only(name, &template))

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -135,6 +135,10 @@ pub trait ClientVersion: Version + Sized + 'static {
     /// Dialog-reachable actions that intentionally use the raw JSON editor (no typed form yet).
     fn json_actions() -> &'static [&'static str];
 
+    /// A handcrafted example payload prefilling the raw JSON editor for a [`Self::json_actions`]
+    /// entry (falls back to the serde-`Default` skeleton when `None`).
+    fn json_template(name: &str) -> Option<serde_json::Value>;
+
     /// The scope of the connector at list index `idx` (1.6 `Scope::connector`, 2.0.1 `Scope::evse`).
     fn scope_of(s: &Self::Cs, idx: usize) -> Scope;
 

--- a/ferrowl/src/module/ocpp/server/v1_6/mod.rs
+++ b/ferrowl/src/module/ocpp/server/v1_6/mod.rs
@@ -95,6 +95,10 @@ impl ServerVersion for V1_6 {
     fn json_actions() -> &'static [&'static str] {
         crate::module::ocpp::spec::v1_6::json_actions()
     }
+
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v1_6::json_template(name)
+    }
 }
 
 #[cfg(test)]

--- a/ferrowl/src/module/ocpp/server/v2_0_1/mod.rs
+++ b/ferrowl/src/module/ocpp/server/v2_0_1/mod.rs
@@ -68,6 +68,10 @@ impl ServerVersion for V2_0_1 {
     fn json_actions() -> &'static [&'static str] {
         crate::module::ocpp::spec::v2_0_1::json_actions()
     }
+
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v2_0_1::json_template(name)
+    }
 }
 
 #[cfg(test)]

--- a/ferrowl/src/module/ocpp/server/v2_1/mod.rs
+++ b/ferrowl/src/module/ocpp/server/v2_1/mod.rs
@@ -68,4 +68,8 @@ impl ServerVersion for V2_1 {
     fn json_actions() -> &'static [&'static str] {
         crate::module::ocpp::spec::v2_1::json_actions()
     }
+
+    fn json_template(name: &str) -> Option<serde_json::Value> {
+        crate::module::ocpp::spec::v2_1::json_template(name)
+    }
 }

--- a/ferrowl/src/module/ocpp/server/view/input.rs
+++ b/ferrowl/src/module/ocpp/server/view/input.rs
@@ -256,8 +256,10 @@ where
                             V::json_actions().contains(&name.as_str()),
                             "{name} has no spec and is not a registered JSON action"
                         );
-                        let template = V::default_action(&name)
-                            .and_then(|a| V::encode_action(&a).ok())
+                        let template = V::json_template(&name)
+                            .or_else(|| {
+                                V::default_action(&name).and_then(|a| V::encode_action(&a).ok())
+                            })
                             .map(|v| serde_json::to_string_pretty(&v).unwrap_or_default())
                             .unwrap_or_else(|| "{}".to_string());
                         ActionDialog::json_only(name.clone(), &template)

--- a/ferrowl/src/module/ocpp/server/view/mod.rs
+++ b/ferrowl/src/module/ocpp/server/view/mod.rs
@@ -164,6 +164,10 @@ pub trait ServerVersion: Version + Sized + 'static {
     /// Dialog-reachable actions that intentionally use the raw JSON editor (no typed form yet).
     fn json_actions() -> &'static [&'static str];
 
+    /// A handcrafted example payload prefilling the raw JSON editor for a [`Self::json_actions`]
+    /// entry (falls back to the serde-`Default` skeleton when `None`).
+    fn json_template(name: &str) -> Option<serde_json::Value>;
+
     /// Inject the target scope's connector/EVSE id into a (Lua-built) payload that does not already
     /// carry it, so e.g. `con:SetChargingProfile()` defaults to the selected connector. No-op for
     /// the CS-level scope or a non-object payload.

--- a/ferrowl/src/module/ocpp/spec/v1_6.rs
+++ b/ferrowl/src/module/ocpp/spec/v1_6.rs
@@ -103,6 +103,16 @@ pub fn json_actions() -> &'static [&'static str] {
     &["GetConfiguration"]
 }
 
+/// A decode-valid example payload for a [`json_actions`] entry (see
+/// [`super::v2_0_1::json_template`]). `GetConfiguration` never opens a form today, but the
+/// template keeps the version-agnostic wiring total.
+pub fn json_template(name: &str) -> Option<Value> {
+    match name {
+        "GetConfiguration" => Some(json!({ "key": ["HeartbeatInterval"] })),
+        _ => None,
+    }
+}
+
 /// The flat action spec for `name`, or `None` (JSON editor) for complex/unsupported actions.
 pub fn action_spec(name: &str) -> Option<ActionSpec> {
     use PropKind::*;
@@ -425,8 +435,21 @@ pub fn action_spec(name: &str) -> Option<ActionSpec> {
 
 #[cfg(test)]
 mod tests {
-    use super::{action_spec, json_actions};
+    use super::{action_spec, json_actions, json_template};
     use ferrowl_ocpp::{V1_6, Version};
+
+    /// Every JSON-only action ships a handcrafted template that decodes and validates.
+    #[test]
+    fn ut_json_templates_cover_all_json_actions_and_decode() {
+        for name in json_actions() {
+            let template =
+                json_template(name).unwrap_or_else(|| panic!("{name} has no JSON template"));
+            let action = V1_6::decode_call(name, template)
+                .unwrap_or_else(|e| panic!("{name} template does not decode: {e}"));
+            V1_6::validate(&action)
+                .unwrap_or_else(|e| panic!("{name} template fails validation: {e}"));
+        }
+    }
 
     /// CS actions a charging station builds from state (sent without a dialog); excluded from
     /// dialog completeness. Mirrors the client view's `STATE_DRIVEN`.

--- a/ferrowl/src/module/ocpp/spec/v2_0_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_0_1.rs
@@ -423,6 +423,112 @@ pub fn json_actions() -> &'static [&'static str] {
     ]
 }
 
+/// A decode-valid example payload for a [`json_actions`] entry, prefilling the raw JSON editor.
+/// Unlike the serde-`Default` skeleton (which omits every optional and renders required lists as
+/// `[]`), these spell out one representative element per list so the shape is editable in place.
+pub fn json_template(name: &str) -> Option<Value> {
+    const TS: &str = "2026-01-01T00:00:00Z";
+    Some(match name {
+        "SetNetworkProfile" => json!({
+            "configurationSlot": 1,
+            "connectionData": {
+                "ocppVersion": "OCPP20",
+                "ocppTransport": "JSON",
+                "ocppCsmsUrl": "wss://csms.example.com/ocpp",
+                "messageTimeout": 30,
+                "securityProfile": 1,
+                "ocppInterface": "Wired0",
+            },
+        }),
+        "SetVariableMonitoring" => json!({
+            "setMonitoringData": [{
+                "component": { "name": "EVSE", "evse": { "id": 1 } },
+                "variable": { "name": "Power.Active.Import" },
+                "type": "UpperThreshold",
+                "severity": 5,
+                "value": 11000,
+            }],
+        }),
+        "NotifyEVChargingNeeds" => json!({
+            "evseId": 1,
+            "chargingNeeds": {
+                "requestedEnergyTransfer": "AC_three_phase",
+                "acChargingParameters": {
+                    "energyAmount": 20000,
+                    "evMinCurrent": 6,
+                    "evMaxCurrent": 32,
+                    "evMaxVoltage": 400,
+                },
+            },
+        }),
+        "NotifyEVChargingSchedule" => json!({
+            "evseId": 1,
+            "timeBase": TS,
+            "chargingSchedule": {
+                "id": 1,
+                "chargingRateUnit": "A",
+                "chargingSchedulePeriod": [{ "startPeriod": 0, "limit": 16 }],
+            },
+        }),
+        "NotifyMonitoringReport" => json!({
+            "requestId": 1,
+            "seqNo": 0,
+            "generatedAt": TS,
+            "monitor": [{
+                "component": { "name": "EVSE", "evse": { "id": 1 } },
+                "variable": { "name": "Power.Active.Import" },
+                "variableMonitoring": [{
+                    "id": 1,
+                    "severity": 5,
+                    "transaction": false,
+                    "type": "UpperThreshold",
+                    "value": 11000,
+                }],
+            }],
+        }),
+        "NotifyReport" => json!({
+            "requestId": 1,
+            "seqNo": 0,
+            "generatedAt": TS,
+            "reportData": [{
+                "component": { "name": "ChargingStation" },
+                "variable": { "name": "Model" },
+                "variableAttribute": [{
+                    "type": "Actual",
+                    "value": "Example",
+                    "mutability": "ReadOnly",
+                }],
+            }],
+        }),
+        "ReportChargingProfiles" => json!({
+            "requestId": 1,
+            "evseId": 1,
+            "chargingLimitSource": "CSO",
+            "chargingProfile": [{
+                "id": 1,
+                "stackLevel": 0,
+                "chargingProfilePurpose": "TxDefaultProfile",
+                "chargingProfileKind": "Absolute",
+                "chargingSchedule": [{
+                    "id": 1,
+                    "chargingRateUnit": "A",
+                    "chargingSchedulePeriod": [{ "startPeriod": 0, "limit": 16 }],
+                }],
+            }],
+        }),
+        "TransactionEvent" => json!({
+            "eventType": "Started",
+            "timestamp": TS,
+            "triggerReason": "Authorized",
+            "seqNo": 0,
+            "transactionInfo": { "transactionId": "tx-1", "chargingState": "Charging" },
+            "evse": { "id": 1, "connectorId": 1 },
+            "idToken": { "idToken": "TAG-1", "type": "ISO14443" },
+        }),
+        _ => return None,
+    })
+}
+
 /// The action spec for `name`, or `None` for actions handled by the raw JSON editor
 /// ([`json_actions`]).
 pub fn action_spec(name: &str) -> Option<ActionSpec> {
@@ -1412,9 +1518,22 @@ pub fn action_spec(name: &str) -> Option<ActionSpec> {
 
 #[cfg(test)]
 mod tests {
-    use super::{action_spec, json_actions};
+    use super::{action_spec, json_actions, json_template};
     use crate::module::ocpp::action_dialog::ActionDialog;
     use ferrowl_ocpp::{V2_0_1, Version};
+
+    /// Every JSON-only action ships a handcrafted template that decodes and validates.
+    #[test]
+    fn ut_json_templates_cover_all_json_actions_and_decode() {
+        for name in json_actions() {
+            let template =
+                json_template(name).unwrap_or_else(|| panic!("{name} has no JSON template"));
+            let action = V2_0_1::decode_call(name, template)
+                .unwrap_or_else(|e| panic!("{name} template does not decode: {e}"));
+            V2_0_1::validate(&action)
+                .unwrap_or_else(|e| panic!("{name} template fails validation: {e}"));
+        }
+    }
 
     /// CS actions a charging station builds from state (sent without a dialog); mirrors the client
     /// view's `STATE_DRIVEN`.

--- a/ferrowl/src/module/ocpp/spec/v2_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_1.rs
@@ -135,6 +135,94 @@ pub fn json_actions() -> &'static [&'static str] {
     })
 }
 
+/// A decode-valid example payload for a [`json_actions`] entry (see
+/// [`super::v2_0_1::json_template`]). 2.1-only actions are spelled out below; the shared
+/// JSON-only actions reuse 2.0.1's templates (2.1 payloads are supersets — additions are
+/// optional, so the 2.0.1 shapes still decode).
+pub fn json_template(name: &str) -> Option<Value> {
+    Some(match name {
+        "BatterySwap" => json!({
+            "eventType": "BatteryIn",
+            "requestId": 1,
+            "idToken": { "idToken": "TAG-1", "type": "ISO14443" },
+            "batteryData": [{
+                "evseId": 1,
+                "serialNumber": "BAT-001",
+                "soC": 80,
+                "soH": 95,
+            }],
+        }),
+        "GetCertificateChainStatus" => json!({
+            "certificateStatusRequests": [{
+                "source": "OCSP",
+                "urls": ["https://ocsp.example.com"],
+                "certificateHashData": {
+                    "hashAlgorithm": "SHA256",
+                    "issuerNameHash": "a1b2c3",
+                    "issuerKeyHash": "d4e5f6",
+                    "serialNumber": "1234",
+                },
+            }],
+        }),
+        "OpenPeriodicEventStream" => json!({
+            "constantStreamData": {
+                "id": 1,
+                "variableMonitoringId": 1,
+                "params": { "interval": 60, "values": 10 },
+            },
+        }),
+        "ReportDERControl" => json!({
+            "requestId": 1,
+            "curve": [{
+                "id": "curve-1",
+                "curveType": "FreqWatt",
+                "isDefault": false,
+                "isSuperseded": false,
+                "curve": {
+                    "priority": 0,
+                    "yUnit": "PctMaxW",
+                    "curveData": [{ "x": 50, "y": 100 }],
+                },
+            }],
+        }),
+        "AdjustPeriodicEventStream" => json!({
+            "id": 1,
+            "params": { "interval": 60, "values": 10 },
+        }),
+        "ChangeTransactionTariff" => json!({
+            "transactionId": "tx-1",
+            "tariff": { "tariffId": "tariff-1", "currency": "EUR" },
+        }),
+        "SetDefaultTariff" => json!({
+            "evseId": 1,
+            "tariff": { "tariffId": "tariff-1", "currency": "EUR" },
+        }),
+        "UpdateDynamicSchedule" => json!({
+            "chargingProfileId": 1,
+            "scheduleUpdate": { "limit": 16 },
+        }),
+        // Shared with 2.0.1, but 2.1's VariableMonitoringType requires eventNotificationType.
+        "NotifyMonitoringReport" => json!({
+            "requestId": 1,
+            "seqNo": 0,
+            "generatedAt": "2026-01-01T00:00:00Z",
+            "monitor": [{
+                "component": { "name": "EVSE", "evse": { "id": 1 } },
+                "variable": { "name": "Power.Active.Import" },
+                "variableMonitoring": [{
+                    "id": 1,
+                    "severity": 5,
+                    "transaction": false,
+                    "type": "UpperThreshold",
+                    "value": 11000,
+                    "eventNotificationType": "PreconfiguredMonitor",
+                }],
+            }],
+        }),
+        _ => return super::v2_0_1::json_template(name),
+    })
+}
+
 /// The action spec for `name`. 2.1-only actions are classified below; everything else (the 64
 /// shared actions) delegates to 2.0.1's specs unchanged.
 pub fn action_spec(name: &str) -> Option<ActionSpec> {
@@ -460,9 +548,23 @@ pub fn action_spec(name: &str) -> Option<ActionSpec> {
 
 #[cfg(test)]
 mod tests {
-    use super::{action_spec, json_actions};
+    use super::{action_spec, json_actions, json_template};
     use crate::module::ocpp::action_dialog::ActionDialog;
     use ferrowl_ocpp::{V2_1, Version};
+
+    /// Every JSON-only action (2.1-only and inherited) ships a template that decodes and
+    /// validates against the 2.1 types — this also proves the reused 2.0.1 templates still fit.
+    #[test]
+    fn ut_json_templates_cover_all_json_actions_and_decode() {
+        for name in json_actions() {
+            let template =
+                json_template(name).unwrap_or_else(|| panic!("{name} has no JSON template"));
+            let action = V2_1::decode_call(name, template)
+                .unwrap_or_else(|e| panic!("{name} template does not decode: {e}"));
+            V2_1::validate(&action)
+                .unwrap_or_else(|e| panic!("{name} template fails validation: {e}"));
+        }
+    }
 
     /// CS actions a charging station builds from state (sent without a dialog); mirrors the client
     /// view's `STATE_DRIVEN` (same set as 2.0.1 — 2.1 adds no new state-driven action).


### PR DESCRIPTION
Spec-less actions prefilled the editor from the serde-Default skeleton: optionals omitted, required lists rendered as [], leaving the element shape to be known by heart.

- json_template(name) per spec module returns a handcrafted, decode-valid payload with one representative element per list
- v2.1 spells out its eight new actions, overrides NotifyMonitoringReport (2.1 requires eventNotificationType) and reuses 2.0.1's templates for the shared set
- new json_template method on both view Version traits; dialog-open sites prefer template, then Default skeleton, then {}
- per-version test: every json_actions() entry decodes and validates