### PR TITLE
Feature/modbus change highlight

### DIFF
--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -7,7 +7,7 @@ use crate::{
 use derive_builder::Builder;
 use ferrowl_codec::{Register, Value};
 use ferrowl_ui::{
-    Border,
+    Border, COLOR_SCHEME,
     state::{TableState, TableStateBuilder},
     style::TableStyleBuilder,
     widgets::{Header, Table, TableBuilder, TableEntry, Widget, Width},
@@ -16,11 +16,20 @@ use ferrowl_ui_derive::{Focus, focusable};
 use ratatui::{
     buffer::Buffer,
     layout::{Margin, Rect},
+    style::Style,
     widgets::StatefulWidget,
 };
 use std::fmt::Debug;
+use std::time::{Duration, Instant};
 
 pub const COLUMN_COUNT: usize = 11;
+
+/// How long the Value/Raw Value cells stay highlighted after a register change.
+pub const CHANGE_HIGHLIGHT: Duration = Duration::from_secs(2);
+
+/// Column indices of the live-value cells highlighted on change.
+const VALUE_COL: usize = 9;
+const RAW_VALUE_COL: usize = 10;
 
 /// Resolve a user-supplied column name to its index in [`TableHeader::header`].
 /// Matching is case-insensitive and ignores spaces, so `slaveid`, `slave id`, and
@@ -105,6 +114,9 @@ pub struct Definition {
     pub named_values: Vec<NamedValue>,
     pub value: Value,
     pub raw_value: String,
+    /// When the decoded value last changed; drives the change highlight (see
+    /// [`CHANGE_HIGHLIGHT`]). `None` until the first observed change.
+    pub changed_at: Option<Instant>,
 }
 
 impl Definition {
@@ -121,7 +133,14 @@ impl Definition {
             named_values,
             value: Value::Ascii(String::new()),
             raw_value: String::new(),
+            changed_at: None,
         }
+    }
+
+    /// Whether the row is inside its post-change highlight window.
+    fn highlight_active(&self) -> bool {
+        self.changed_at
+            .is_some_and(|at| at.elapsed() < CHANGE_HIGHLIGHT)
     }
 }
 
@@ -171,6 +190,16 @@ impl TableEntry<COLUMN_COUNT> for Definition {
 
     fn height(&self) -> u16 {
         3
+    }
+
+    fn cell_styles(&self) -> [Option<Style>; COLUMN_COUNT] {
+        let mut styles = [None; COLUMN_COUNT];
+        if self.highlight_active() {
+            let hi = Some(Style::default().fg(COLOR_SCHEME.hi));
+            styles[VALUE_COL] = hi;
+            styles[RAW_VALUE_COL] = hi;
+        }
+        styles
     }
 }
 
@@ -252,5 +281,56 @@ impl TableView {
     /// Select the first register row (or clear the selection when the table is empty).
     pub fn select_first(&mut self) {
         self.table.state.move_to_top();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
+
+    fn definition() -> Definition {
+        let register = RegisterBuilder::default()
+            .slave_id(1u8)
+            .access(Access::ReadWrite)
+            .kind(Kind::HoldingRegister)
+            .address(Address::Fixed(0))
+            .format(Format::U16((
+                Endian::Big,
+                Resolution(1.0),
+                BitField::default(),
+            )))
+            .build()
+            .unwrap();
+        Definition::new("reg".to_string(), "d".to_string(), register, vec![])
+    }
+
+    #[test]
+    fn ut_no_change_has_no_cell_styles() {
+        let d = definition();
+        assert!(d.cell_styles().iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn ut_recent_change_highlights_value_cells_only() {
+        let mut d = definition();
+        d.changed_at = Some(Instant::now());
+        let styles = d.cell_styles();
+        for (i, style) in styles.iter().enumerate() {
+            if i == VALUE_COL || i == RAW_VALUE_COL {
+                assert!(style.is_some(), "column {i} must be highlighted");
+            } else {
+                assert!(style.is_none(), "column {i} must stay unstyled");
+            }
+        }
+    }
+
+    #[test]
+    fn ut_highlight_expires_after_window() {
+        let mut d = definition();
+        d.changed_at = Instant::now().checked_sub(CHANGE_HIGHLIGHT + Duration::from_secs(1));
+        assert!(d.changed_at.is_some(), "back-dating must succeed");
+        assert!(d.cell_styles().iter().all(Option::is_none));
     }
 }

--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -24,12 +24,8 @@ use std::time::{Duration, Instant};
 
 pub const COLUMN_COUNT: usize = 11;
 
-/// How long the Value/Raw Value cells stay highlighted after a register change.
+/// How long a row stays highlighted after a register change.
 pub const CHANGE_HIGHLIGHT: Duration = Duration::from_secs(2);
-
-/// Column indices of the live-value cells highlighted on change.
-const VALUE_COL: usize = 9;
-const RAW_VALUE_COL: usize = 10;
 
 /// Resolve a user-supplied column name to its index in [`TableHeader::header`].
 /// Matching is case-insensitive and ignores spaces, so `slaveid`, `slave id`, and
@@ -193,13 +189,11 @@ impl TableEntry<COLUMN_COUNT> for Definition {
     }
 
     fn cell_styles(&self) -> [Option<Style>; COLUMN_COUNT] {
-        let mut styles = [None; COLUMN_COUNT];
         if self.highlight_active() {
-            let hi = Some(Style::default().fg(COLOR_SCHEME.hi));
-            styles[VALUE_COL] = hi;
-            styles[RAW_VALUE_COL] = hi;
+            [Some(Style::default().fg(COLOR_SCHEME.hi)); COLUMN_COUNT]
+        } else {
+            [None; COLUMN_COUNT]
         }
-        styles
     }
 }
 
@@ -313,17 +307,10 @@ mod tests {
     }
 
     #[test]
-    fn ut_recent_change_highlights_value_cells_only() {
+    fn ut_recent_change_highlights_full_row() {
         let mut d = definition();
         d.changed_at = Some(Instant::now());
-        let styles = d.cell_styles();
-        for (i, style) in styles.iter().enumerate() {
-            if i == VALUE_COL || i == RAW_VALUE_COL {
-                assert!(style.is_some(), "column {i} must be highlighted");
-            } else {
-                assert!(style.is_none(), "column {i} must stay unstyled");
-            }
-        }
+        assert!(d.cell_styles().iter().all(Option::is_some));
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -648,6 +648,7 @@ fn decode_definition(
     memory: &Memory<Key<SlaveKey>>,
     virtual_values: &HashMap<String, Value>,
 ) -> Definition {
+    let prev_raw = std::mem::take(&mut d.raw_value);
     match d.register.address() {
         Address::Fixed(addr) => {
             let width = d.register.format().width();
@@ -680,6 +681,11 @@ fn decode_definition(
                 d.raw_value.clear();
             }
         },
+    }
+    // The first fill-in (empty previous raw) is not a change; later differing
+    // decodes stamp the highlight window (see `Definition::cell_styles`).
+    if !prev_raw.is_empty() && d.raw_value != prev_raw {
+        d.changed_at = Some(std::time::Instant::now());
     }
     d
 }
@@ -843,6 +849,41 @@ mod tests {
         let decoded = decode_definition(def, &memory, &empty_vs);
         assert!(matches!(decoded.value, Value::Ascii(ref s) if s.is_empty()));
         assert!(decoded.raw_value.is_empty());
+    }
+
+    #[test]
+    fn ut_decode_definition_first_fill_is_not_a_change() {
+        let def = fixed_def();
+        let memory = Memory::<Key<SlaveKey>>::default();
+        let empty_vs: HashMap<String, Value> = HashMap::new();
+        let decoded = decode_definition(def, &memory, &empty_vs);
+        assert!(decoded.changed_at.is_none());
+        // A second identical decode is not a change either.
+        let decoded = decode_definition(decoded, &memory, &empty_vs);
+        assert!(decoded.changed_at.is_none());
+    }
+
+    #[test]
+    fn ut_decode_definition_value_change_stamps_changed_at() {
+        let mut memory = Memory::<Key<SlaveKey>>::default();
+        let key = Key {
+            id: SlaveKey {
+                slave_id: 1,
+                kind: Kind::HoldingRegister,
+            },
+        };
+        memory.add_ranges(
+            key.clone(),
+            &CellKind::ReadWrite(ferrowl_store::CellType::Register),
+            std::slice::from_ref(&Range::new(0, 1)),
+        );
+        memory.write_unchecked(key.clone(), &Range::new(0, 1), &[1u16]);
+        let empty_vs: HashMap<String, Value> = HashMap::new();
+        let decoded = decode_definition(fixed_def(), &memory, &empty_vs);
+        assert!(decoded.changed_at.is_none(), "first fill must not stamp");
+        memory.write_unchecked(key, &Range::new(0, 1), &[2u16]);
+        let decoded = decode_definition(decoded, &memory, &empty_vs);
+        assert!(decoded.changed_at.is_some(), "changed value must stamp");
     }
 
     // --- view construction & key handling -----------------------------------


### PR DESCRIPTION
With these changes, registers will light up (highlighted) for a moment whenever the value is updated. This way it's possible to see any changes done to the server instance or any changes read by the client instance at a glimpse. 