### PR TITLE
feat(modbus): replace per-register update scripts with global script …

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The bundled `session.toml` wires up a CSMS plus a Charging Station pair (`csms-d
 | `:wd \| :write-device [PATH]` | Save device configuration |
 | `:log <FILE>\|clear` | Set log output file for the active tab (`:log clear` clears the ring log) |
 | `:lua start\|stop` | Start/Stop lua execution |
+| `:scripts` | Manage Lua scripts (create, edit, toggle, delete) |
 | `:reload` | Reload device configuration |
 | `:compact` | Toggle compact table mode |
 | `:order [col] [asc\|desc]` | Sort table by column |
@@ -329,10 +330,6 @@ type = "U16"
 access = "ReadWrite"
 description = "active power (W)"
 default = 0
-# Lua run every cycle: mirror the setpoint into the power register (server simulation).
-update = """
-C_Register:Set("power", C_Register:Get("setpoint"))
-"""
 
 [definitions.state]
 slave_id = 1
@@ -347,6 +344,14 @@ values = [
     { name = "charging", value = 2 },
     { name = "error", value = -1 },
 ]
+
+# Global Lua scripts, run every simulation cycle while enabled (see :scripts).
+[[scripts]]
+name = "mirror setpoint"
+code = """
+C_Register:Set("power", C_Register:Get("setpoint"))
+"""
+enabled = true
 ```
 
 > [!IMPORTANT]
@@ -369,7 +374,7 @@ values = [
 | `alignment` | `Left` | ASCII alignment: `Left` or `Right`. |
 | `values` | `[]` | Named values for selection-style registers. |
 | `default` | *(none)* | Default value written to memory on startup / configuration load. |
-| `update` | *(none)* | Lua snippet run every simulation cycle. |
+| `update` | *(none)* | *Deprecated.* Legacy per-register Lua snippet; migrated on load into the global `[[scripts]]` list (named after the register) and never written back. |
 | `description` | `""` | Free-text description. |
 
 #### Device-level options
@@ -411,7 +416,7 @@ code = "C_OCPP:Set(\"Power\", C_OCPP:Get(\"Power\") + 100)"
 
 ## Lua Support
 
-As an additional feature, the tool also includes a Lua runtime to execute custom scripts that drive a simulation. For **Modbus** modules these are the per-register `update` snippets (run each cycle), interacting with the registers through `C_Register` and able to print to the module log via `C_Log`. For **OCPP** modules — in both the Charging Station (client) and CSMS (server) roles — scripts are attached to the device config and managed from the *Lua Scripts* dialog (the button under the state table); all enabled scripts run about once per second and interact with the OCPP state and actions through `C_OCPP`, and may print to the module log via `C_Log`. Besides the standard Lua libraries, the exposed modules are `C_Time` and `C_Log` (both), `C_Register` (Modbus only), and `C_OCPP` (OCPP only).
+As an additional feature, the tool also includes a Lua runtime to execute custom scripts that drive a simulation. For **Modbus** modules scripts are attached to the device config as a global, toggleable list managed from the `:scripts` dialog (legacy per-register `update` snippets are migrated into it on load); all enabled scripts run each simulation cycle, interacting with the registers through `C_Register` and able to print to the module log via `C_Log`. For **OCPP** modules — in both the Charging Station (client) and CSMS (server) roles — scripts are attached to the device config and managed from the *Lua Scripts* dialog (the button under the state table); all enabled scripts run about once per second and interact with the OCPP state and actions through `C_OCPP`, and may print to the module log via `C_Log`. Besides the standard Lua libraries, the exposed modules are `C_Time` and `C_Log` (both), `C_Register` (Modbus only), and `C_OCPP` (OCPP only).
 
 ### Module C_Time
 

--- a/ferrowl/src/config/mod.rs
+++ b/ferrowl/src/config/mod.rs
@@ -1,5 +1,7 @@
 //! Device and session configuration loading (TOML/JSON).
 
+pub mod script;
+
 pub mod device {
     pub use crate::module::modbus::config::device::*;
 }
@@ -39,9 +41,12 @@ fn load<T: serde::de::DeserializeOwned>(path: &str) -> Result<T, ConfigError> {
     Converter::load(path, ty).map_err(|e| ConfigError::Io(format!("{:?}", e)))
 }
 
-/// Load a device-type config file.
+/// Load a device-type config file, migrating legacy per-register `update` scripts
+/// into the global script list.
 pub fn load_device(path: &str) -> Result<DeviceConfig, ConfigError> {
-    load(path)
+    let mut device: DeviceConfig = load(path)?;
+    device.migrate_update_scripts();
+    Ok(device)
 }
 
 /// Load an OCPP device-type config file.
@@ -75,6 +80,22 @@ mod tests {
         let spath = tmp("ferrowl_cfgmod_session.json");
         Converter::save(&Session::default(), &spath, FileType::Json).unwrap();
         assert_eq!(load_session(&spath).unwrap(), Session::default());
+    }
+
+    #[test]
+    fn ut_load_device_migrates_update_scripts() {
+        let path = tmp("ferrowl_cfgmod_legacy_update.toml");
+        std::fs::write(
+            &path,
+            "[definitions.reg]\ntype = \"U16\"\nupdate = \"C_Time:Sleep(1)\"\n",
+        )
+        .unwrap();
+        let device = load_device(&path).unwrap();
+        assert!(device.definitions["reg"].update.is_none());
+        assert_eq!(device.scripts.len(), 1);
+        assert_eq!(device.scripts[0].name, "reg");
+        assert_eq!(device.scripts[0].code, "C_Time:Sleep(1)");
+        assert!(device.scripts[0].enabled);
     }
 
     #[test]

--- a/ferrowl/src/config/script.rs
+++ b/ferrowl/src/config/script.rs
@@ -1,0 +1,20 @@
+//! Shared Lua script definition, used by both the OCPP and Modbus device configs and
+//! managed by the [`ScriptDialog`](crate::dialog::scripts::ScriptDialog).
+
+use serde::{Deserialize, Serialize};
+
+/// One named Lua simulation script attached to a device type.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScriptDef {
+    pub name: String,
+    #[serde(default)]
+    pub code: String,
+    /// Whether the script runs in the simulation loop. Defaults to On (a freshly-created script
+    /// and a flag-less file entry are both active).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}

--- a/ferrowl/src/dialog/mod.rs
+++ b/ferrowl/src/dialog/mod.rs
@@ -1,5 +1,7 @@
 //! Modal dialogs: module setup and shared register-edit data types.
 
+pub mod scripts;
+
 pub use crate::module::modbus::dialog::{EditedRegister, parse_raw_value};
 pub use crate::module::modbus::setup_dialog::SetupDialog;
 use ferrowl_ui::widgets::{Validate, ValidateResult};

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -1,4 +1,4 @@
-//! Lua script manager dialog, shared by both OCPP client views. Left: a table of scripts with an
+//! Lua script manager dialog, shared by the OCPP views and the Modbus view. Left: a table of scripts with an
 //! On/Off status over a "New Script" name input; right: a code editor for the selected script.
 //! Edits are live on a working copy; the view reads it back via [`ScriptDialog::resolve`] on close
 //! and reloads the simulation. `t` toggles a script, `d` deletes (with confirmation), `c` toggles
@@ -28,7 +28,7 @@ use ratatui::{
 };
 
 use crate::module::modbus::dialog::ConfirmDeleteDialog;
-use crate::module::ocpp::config::device::ScriptDef;
+use crate::config::script::ScriptDef;
 
 // --- Script table ----------------------------------------------------------
 

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -115,6 +115,7 @@ fn demo_modbus_tab(name: String, role: Role) -> Tab {
         log_file: None,
         read_ranges: Default::default(),
         definitions,
+        scripts: Vec::new(),
     };
     let spec = ModuleSpec {
         name,

--- a/ferrowl/src/migrate.rs
+++ b/ferrowl/src/migrate.rs
@@ -376,7 +376,10 @@ fn convert(legacy: LegacyConfig) -> (DeviceConfig, Vec<String>) {
         log_file: None,
         read_ranges,
         definitions,
+        scripts: Vec::new(),
     };
+    let mut device = device;
+    device.migrate_update_scripts();
 
     (device, warnings)
 }
@@ -634,10 +637,16 @@ mod tests {
         assert_eq!(temp.value_type, ValueType::F32);
         assert_eq!(temp.endian, EndianCfg::Little);
 
-        // on_update → update
+        // on_update → migrated into the global script list, named after the register.
         let label = &device.definitions["status_label"];
-        assert!(label.update.is_some());
+        assert!(label.update.is_none());
         assert_eq!(label.value_type, ValueType::Ascii);
         assert!(label.is_virtual);
+        assert!(
+            device
+                .scripts
+                .iter()
+                .any(|s| s.name == "status_label" && s.enabled)
+        );
     }
 }

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -11,6 +11,8 @@ use ferrowl_store::{CellType, Range};
 use ferrowl_ui::traits::ToLabel;
 use serde::{Deserialize, Serialize};
 
+use crate::config::script::ScriptDef;
+
 /// Fallback timing (ms) when neither the module spec nor the device config sets a value.
 pub const DEFAULT_TIMEOUT_MS: usize = 3000;
 pub const DEFAULT_DELAY_MS: usize = 1000;
@@ -39,6 +41,32 @@ pub struct DeviceConfig {
     #[serde(default, skip_serializing_if = "ReadRanges::is_empty")]
     pub read_ranges: ReadRanges,
     pub definitions: BTreeMap<String, RegisterDef>,
+    /// Global Lua simulation scripts (named, toggleable; run on the sim thread). Managed via
+    /// the `:scripts` dialog; replaces the legacy per-register `update` snippets.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scripts: Vec<ScriptDef>,
+}
+
+impl DeviceConfig {
+    /// Migrate legacy per-register `update` snippets into [`scripts`](Self::scripts): each
+    /// non-empty snippet becomes an enabled script named after its register (skipped when a
+    /// script of that name already exists). The `update` fields are cleared, so a subsequent
+    /// save writes only the global list. Called by `config::load_device`.
+    pub fn migrate_update_scripts(&mut self) {
+        for (name, def) in self.definitions.iter_mut() {
+            let Some(code) = def.update.take() else {
+                continue;
+            };
+            if code.trim().is_empty() || self.scripts.iter().any(|s| s.name == *name) {
+                continue;
+            }
+            self.scripts.push(ScriptDef {
+                name: name.clone(),
+                code,
+                enabled: true,
+            });
+        }
+    }
 }
 
 /// Per-function-code explicit read ranges. Each string is a comma-separated list of inclusive
@@ -133,8 +161,9 @@ pub struct RegisterDef {
     /// Named values for selection-style registers (e.g. enum states).
     #[serde(default)]
     pub values: Vec<NamedValue>,
-    /// Optional Lua snippet run every simulation cycle (see Lua phase).
-    #[serde(default)]
+    /// Legacy per-register Lua snippet. Read-only for backward compatibility: migrated into
+    /// [`DeviceConfig::scripts`] on load and never written back.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update: Option<String>,
     #[serde(default)]
     pub description: String,
@@ -492,7 +521,7 @@ mod tests {
                         value: Scalar::Text("idle".into()),
                     },
                 ],
-                update: Some("C_Register:Set(\"power\", C_Register:GetInt(\"setpoint\"))".into()),
+                update: None,
                 description: String::new(),
                 default: None,
             },
@@ -510,7 +539,33 @@ mod tests {
                 ..Default::default()
             },
             definitions,
+            scripts: vec![ScriptDef {
+                name: "sim".into(),
+                code: "C_Register:Set(\"power\", C_Register:GetInt(\"setpoint\"))".into(),
+                enabled: true,
+            }],
         }
+    }
+
+    #[test]
+    fn ut_migrate_update_scripts() {
+        let mut cfg = sample();
+        cfg.scripts.clear();
+        cfg.definitions.get_mut("state").unwrap().update = Some("C_Time:Sleep(1)".into());
+        cfg.definitions.get_mut("setpoint").unwrap().update = Some("   ".into());
+        cfg.migrate_update_scripts();
+        // Non-empty snippet becomes an enabled script named after its register; the
+        // whitespace-only one is dropped; both update fields are cleared.
+        assert_eq!(cfg.scripts.len(), 1);
+        assert_eq!(cfg.scripts[0].name, "state");
+        assert_eq!(cfg.scripts[0].code, "C_Time:Sleep(1)");
+        assert!(cfg.scripts[0].enabled);
+        assert!(cfg.definitions.values().all(|d| d.update.is_none()));
+        // A name collision with an existing script keeps the existing script.
+        cfg.definitions.get_mut("state").unwrap().update = Some("other".into());
+        cfg.migrate_update_scripts();
+        assert_eq!(cfg.scripts.len(), 1);
+        assert_eq!(cfg.scripts[0].code, "C_Time:Sleep(1)");
     }
 
     fn roundtrip(ty: FileType, ext: &str) {

--- a/ferrowl/src/module/modbus/dialog/input/build.rs
+++ b/ferrowl/src/module/modbus/dialog/input/build.rs
@@ -74,10 +74,6 @@ impl EditInputDialog {
                 "Default value (applied on startup)...",
             ))
             .add_button(widgets::button("ADD PREDEFINED", 1))
-            .update_script(widgets::code(
-                "Lua Update",
-                "-- Lua update script (optional)",
-            ))
             .delete_register_button(widgets::button("DELETE", 1))
             .confirm_button(widgets::button("CONFIRM", 1))
             .error(widgets::error_text())

--- a/ferrowl/src/module/modbus/dialog/input/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/input/mod.rs
@@ -9,9 +9,9 @@ use ferrowl_codec::format::{
 };
 use ferrowl_codec::{Address, Kind, Register, RegisterBuilder, encode};
 use ferrowl_ui::{
-    state::{ButtonState, CodeInputFieldState, InputFieldState, SelectionState},
+    state::{ButtonState, InputFieldState, SelectionState},
     widgets::{
-        Button, CodeInputField, GetValue, InputField, Selection, Text, Validate, ValidateResult,
+        Button, GetValue, InputField, Selection, Text, Validate, ValidateResult,
         Widget,
     },
 };
@@ -75,9 +75,6 @@ pub struct EditInputDialog {
     // Button to add a predefined named value
     #[focus]
     pub add_button: Widget<ButtonState, Button>,
-    // Lua simulation script (optional multiline)
-    #[focus]
-    pub update_script: Widget<CodeInputFieldState, CodeInputField>,
     // Confirm button
     #[focus]
     pub confirm_button: Widget<ButtonState, Button>,
@@ -118,8 +115,6 @@ pub struct EditedRegister {
     pub value: Option<String>,
     /// Updated named-value list from EditSelectionDialog; None means unchanged.
     pub named_values: Option<Vec<crate::config::device::NamedValue>>,
-    /// Lua update script content; None means unchanged (field not shown).
-    pub update: Option<String>,
     /// Default value to store in the device config (applied on startup). None = no default.
     pub default: Option<Scalar>,
 }
@@ -186,16 +181,12 @@ impl EditInputDialog {
         description: &str,
         register: &Register,
         value: &str,
-        update: Option<&str>,
         default: Option<&Scalar>,
     ) -> Self {
         let mut dialog = Self::new();
         dialog.deletable = true;
         set_input(&mut dialog.label, name);
         set_input(&mut dialog.description, description);
-        if let Some(script) = update {
-            dialog.update_script.state.set_content(script);
-        }
         if let Some(def) = default {
             set_input(&mut dialog.default_value, &def.to_string());
         }
@@ -340,13 +331,6 @@ impl EditInputDialog {
         } else {
             None
         };
-        let update_script = self.update_script.state.content().trim().to_string();
-        let update = Some(if update_script.is_empty() {
-            String::new()
-        } else {
-            update_script
-        });
-
         let named_values = if self.pending_named_values.is_empty() {
             None
         } else {
@@ -368,7 +352,6 @@ impl EditInputDialog {
             register,
             value,
             named_values,
-            update,
             default,
         })
     }
@@ -385,10 +368,6 @@ impl EditInputDialog {
 
     pub fn is_delete_register_button_focused(&self) -> bool {
         matches!(self.focus, EditInputDialogFocus::DeleteRegisterButton)
-    }
-
-    pub fn is_update_script_focused(&self) -> bool {
-        matches!(self.focus, EditInputDialogFocus::UpdateScript)
     }
 
     pub fn is_confirm_button_focused(&self) -> bool {
@@ -417,7 +396,6 @@ impl EditInputDialog {
         d.number_bitmask.state = self.number_bitmask.state.clone();
         d.text_alignment.state = self.text_alignment.state.clone();
         d.text_width.state = self.text_width.state.clone();
-        d.update_script.state = self.update_script.state.clone();
 
         // Set up default selection with sentinel and try to match prior text default.
         let mut default_vals = vec![NamedValue {
@@ -484,9 +462,6 @@ impl super::RegisterDialog for EditInputDialog {
     fn handle_space(&mut self) {
         self.handle_space()
     }
-    fn is_update_script_focused(&self) -> bool {
-        self.is_update_script_focused()
-    }
     fn is_confirm_button_focused(&self) -> bool {
         self.is_confirm_button_focused()
     }
@@ -544,7 +519,7 @@ mod apply_tests {
             RegisterFormat::U32((RegisterEndian::Big, Resolution(1.0), BitField::default())),
         );
         let edited =
-            EditInputDialog::from_register("temp", "a sensor", &original, "42", None, None)
+            EditInputDialog::from_register("temp", "a sensor", &original, "42", None)
                 .apply()
                 .expect("valid register should apply");
 
@@ -567,7 +542,7 @@ mod apply_tests {
             1,
             RegisterFormat::U16((RegisterEndian::Little, Resolution(0.5), BitField::default())),
         );
-        let edited = EditInputDialog::from_register("v", "", &original, "3", None, None)
+        let edited = EditInputDialog::from_register("v", "", &original, "3", None)
             .apply()
             .expect("valid register should apply");
 
@@ -589,7 +564,7 @@ mod apply_tests {
                 BitField { mask: 0xFF00 },
             )),
         );
-        let edited = EditInputDialog::from_register("masked", "", &original, "0", None, None)
+        let edited = EditInputDialog::from_register("masked", "", &original, "0", None)
             .apply()
             .expect("valid register should apply");
         assert_eq!(edited.register.format(), original.format());
@@ -604,7 +579,7 @@ mod apply_tests {
             1,
             RegisterFormat::Ascii((TextAlignment::Left, Width(4))),
         );
-        let edited = EditInputDialog::from_register("label", "", &original, "AB", None, None)
+        let edited = EditInputDialog::from_register("label", "", &original, "AB", None)
             .apply()
             .expect("valid register should apply");
         assert_eq!(edited.register.format(), original.format());
@@ -619,7 +594,7 @@ mod apply_tests {
             1,
             RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default())),
         );
-        let edited = EditInputDialog::from_register("c", "", &original, "1", None, None)
+        let edited = EditInputDialog::from_register("c", "", &original, "1", None)
             .apply()
             .expect("valid register should apply");
         assert_eq!(*edited.register.kind(), Kind::Coil);
@@ -665,7 +640,7 @@ mod focus_tests {
             .build()
             .unwrap();
         // `from_register` focuses the value field and sets the cursor at the end of "4".
-        EditInputDialog::from_register("name", "", &register, "4", None, None)
+        EditInputDialog::from_register("name", "", &register, "4", None)
     }
 
     fn coil_dialog() -> EditInputDialog {
@@ -681,7 +656,7 @@ mod focus_tests {
             )))
             .build()
             .unwrap();
-        EditInputDialog::from_register("c", "", &register, "1", None, None)
+        EditInputDialog::from_register("c", "", &register, "1", None)
     }
 
     /// Walk a full forward focus cycle, returning every focus state visited (starting state first).

--- a/ferrowl/src/module/modbus/dialog/input/render.rs
+++ b/ferrowl/src/module/modbus/dialog/input/render.rs
@@ -223,7 +223,7 @@ impl EditInputDialog {
 
         if self.deletable {
             let buttons: [Rect; 2] =
-                Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
+                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .areas(vertical_layout[vertical_index]);
             StatefulWidget::render(
                 &self.confirm_button.widget,

--- a/ferrowl/src/module/modbus/dialog/input/render.rs
+++ b/ferrowl/src/module/modbus/dialog/input/render.rs
@@ -29,7 +29,7 @@ impl EditInputDialog {
 
         let vertical_layout: [Rect; 3] = Layout::vertical([
             Constraint::Min(1),
-            Constraint::Length(48),
+            Constraint::Length(38),
             Constraint::Min(1),
         ])
         .areas(horizontal_layout[1]);
@@ -48,7 +48,7 @@ impl EditInputDialog {
         block.render(dialog_box, buf);
 
         let mut vertical_index = 0;
-        let vertical_layout: [Rect; 14] = Layout::vertical([
+        let vertical_layout: [Rect; 13] = Layout::vertical([
             Constraint::Length(3),
             Constraint::Length(6),
             Constraint::Length(3),
@@ -57,7 +57,6 @@ impl EditInputDialog {
             Constraint::Length(3),
             Constraint::Length(3),
             Constraint::Length(3),
-            Constraint::Length(10),
             Constraint::Length(3),
             Constraint::Length(4),
             Constraint::Length(1),
@@ -222,14 +221,6 @@ impl EditInputDialog {
         );
         vertical_index += 1;
 
-        StatefulWidget::render(
-            &self.update_script.widget,
-            vertical_layout[vertical_index],
-            buf,
-            &mut self.update_script.state,
-        );
-        vertical_index += 1;
-
         if self.deletable {
             let buttons: [Rect; 2] =
                 Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
@@ -356,7 +347,7 @@ mod render_tests {
             )))
             .build()
             .unwrap();
-        let mut dialog = EditInputDialog::from_register("temp", "d", &register, "42", None, None);
+        let mut dialog = EditInputDialog::from_register("temp", "d", &register, "42", None);
         let text = render(&mut dialog);
         assert!(text.contains("Edit"), "missing box title:\n{text}");
         assert!(text.contains("DELETE"), "missing delete button:\n{text}");

--- a/ferrowl/src/module/modbus/dialog/register_dialog.rs
+++ b/ferrowl/src/module/modbus/dialog/register_dialog.rs
@@ -19,7 +19,6 @@ pub trait RegisterDialog: SubDialogs {
     /// Route a key to the focused field (the dialog's `HandleEvents` result is not surfaced here).
     fn handle_events(&mut self, modifiers: KeyModifiers, code: KeyCode);
     fn handle_space(&mut self);
-    fn is_update_script_focused(&self) -> bool;
     fn is_confirm_button_focused(&self) -> bool;
     fn is_delete_register_button_focused(&self) -> bool;
     /// Validate the dialog and produce the edited register (or a user-facing error string).

--- a/ferrowl/src/module/modbus/dialog/selection/build.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/build.rs
@@ -69,10 +69,6 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
             .default_value(widgets::selection("Default", default_values, 0))
             .add_button(widgets::button("ADD", 0))
             .delete_button(widgets::button("DEL", 0))
-            .update_script(widgets::code(
-                "Lua Update",
-                "-- Lua update script (optional)",
-            ))
             .delete_register_button(widgets::button("DELETE", 1))
             .confirm_button(widgets::button("Confirm", 1))
             .error(widgets::error_text())

--- a/ferrowl/src/module/modbus/dialog/selection/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/mod.rs
@@ -14,11 +14,11 @@ use derive_builder::Builder;
 use ferrowl_codec::format::{BitField, Format as RegisterFormat, Resolution, Width};
 use ferrowl_codec::{Address, Register, RegisterBuilder};
 use ferrowl_ui::{
-    state::{ButtonState, CodeInputFieldState, InputFieldState, SelectionState},
+    state::{ButtonState, InputFieldState, SelectionState},
     traits::HandleEvents,
     traits::ToLabel,
     widgets::{
-        Button, CodeInputField, GetValue, InputField, Selection, Text, Validate, ValidateResult,
+        Button, GetValue, InputField, Selection, Text, Validate, ValidateResult,
         Widget,
     },
 };
@@ -130,9 +130,6 @@ where
     // Default value selection (same options as value, plus a leading "no default" sentinel)
     #[focus(when = {!self.value.state.values().is_empty()})]
     pub default_value: Widget<SelectionState<V>, Selection<V>>,
-    // Lua simulation script (optional multiline)
-    #[focus]
-    pub update_script: Widget<CodeInputFieldState, CodeInputField>,
     // Confirm button
     #[focus]
     pub confirm_button: Widget<ButtonState, Button>,
@@ -206,16 +203,12 @@ impl EditSelectionDialog<NamedValue> {
         named_values: Vec<NamedValue>,
         current_value: &str,
         raw_value: &str,
-        update: Option<&str>,
         default: Option<&Scalar>,
     ) -> Self {
         let mut dialog = Self::new(named_values.clone());
         dialog.deletable = true;
         set_input(&mut dialog.label, name);
         set_input(&mut dialog.description, description);
-        if let Some(script) = update {
-            dialog.update_script.state.set_content(script);
-        }
         // Populate default selection: sentinel at index 0, then all named values.
         let mut default_vals = vec![NamedValue {
             name: "(no default)".to_string(),
@@ -355,13 +348,6 @@ impl EditSelectionDialog<NamedValue> {
         } else {
             Some(self.value.state.get_value().value.to_string())
         };
-        let update_script = self.update_script.state.content().trim().to_string();
-        let update = Some(if update_script.is_empty() {
-            String::new()
-        } else {
-            update_script
-        });
-
         let default = {
             let sel = self.default_value.state.selection();
             let vals = self.default_value.state.values();
@@ -378,7 +364,6 @@ impl EditSelectionDialog<NamedValue> {
             register,
             value,
             named_values: Some(named_values),
-            update,
             default,
         })
     }
@@ -396,10 +381,6 @@ impl EditSelectionDialog<NamedValue> {
 
     pub fn is_delete_register_button_focused(&self) -> bool {
         matches!(self.focus, EditSelectionDialogFocus::DeleteRegisterButton)
-    }
-
-    pub fn is_update_script_focused(&self) -> bool {
-        matches!(self.focus, EditSelectionDialogFocus::UpdateScript)
     }
 
     pub fn is_confirm_button_focused(&self) -> bool {
@@ -424,7 +405,6 @@ impl EditSelectionDialog<NamedValue> {
         d.number_bitmask.state = self.number_bitmask.state.clone();
         d.text_alignment.state = self.text_alignment.state.clone();
         d.text_width.state = self.text_width.state.clone();
-        d.update_script.state = self.update_script.state.clone();
         // Convert selected default → text (skip sentinel at index 0).
         let sel = self.default_value.state.selection();
         if sel > 0
@@ -562,7 +542,6 @@ mod apply_tests {
             "1",
             "[0001]",
             None,
-            None,
         )
         .apply()
         .expect("valid dialog should apply");
@@ -588,7 +567,6 @@ mod apply_tests {
             "0",
             "[0000]",
             None,
-            None,
         );
         assert_eq!(dialog.value.state.selection(), 1); // "off" (value 0)
     }
@@ -607,7 +585,6 @@ mod apply_tests {
             named_values(),
             "1",
             "[0001]",
-            None,
             None,
         );
         assert_eq!(dialog.value.state.values().len(), 2);
@@ -654,7 +631,7 @@ mod focus_tests {
             name: "on".into(),
             value: Scalar::Int(1),
         }];
-        EditSelectionDialog::from_register("s", "", &original, values, "1", "[0001]", None, None)
+        EditSelectionDialog::from_register("s", "", &original, values, "1", "[0001]", None)
     }
 
     #[test]
@@ -729,7 +706,6 @@ mod default_and_conversion_tests {
             named_values(),
             "1",
             "[0001]",
-            None,
             Some(&Scalar::Int(1)),
         )
     }
@@ -854,9 +830,6 @@ impl super::RegisterDialog for EditSelectionDialog<NamedValue> {
     }
     fn handle_space(&mut self) {
         self.handle_space()
-    }
-    fn is_update_script_focused(&self) -> bool {
-        self.is_update_script_focused()
     }
     fn is_confirm_button_focused(&self) -> bool {
         self.is_confirm_button_focused()

--- a/ferrowl/src/module/modbus/dialog/selection/render.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/render.rs
@@ -29,7 +29,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
 
         let vertical_layout: [Rect; 3] = Layout::vertical([
             Constraint::Min(1),
-            Constraint::Length(27 + 2 + 2 + 3 + 3 + 3 + 4),
+            Constraint::Length(27 + 2 + 2 + 3 + 3 + 3 + 4 - 10),
             Constraint::Min(1),
         ])
         .areas(horizontal_layout[1]);
@@ -48,7 +48,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
         block.render(dialog_box, buf);
 
         let mut vertical_index = 0;
-        let vertical_layout: [Rect; 13] = Layout::vertical([
+        let vertical_layout: [Rect; 12] = Layout::vertical([
             Constraint::Length(3),
             Constraint::Length(6),
             Constraint::Length(3),
@@ -56,7 +56,6 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
             Constraint::Length(3),
             Constraint::Length(3),
             Constraint::Length(3),
-            Constraint::Length(10),
             Constraint::Length(3),
             Constraint::Length(3),
             Constraint::Length(1),
@@ -246,14 +245,6 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
         }
         vertical_index += 1;
 
-        StatefulWidget::render(
-            &self.update_script.widget,
-            vertical_layout[vertical_index],
-            buf,
-            &mut self.update_script.state,
-        );
-        vertical_index += 1;
-
         if self.deletable {
             let buttons: [Rect; 2] =
                 Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
@@ -391,7 +382,6 @@ mod render_tests {
             }],
             "1",
             "[0001]",
-            None,
             None,
         );
         let text = render(&mut dialog);

--- a/ferrowl/src/module/modbus/dialog/selection/render.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/render.rs
@@ -247,7 +247,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
 
         if self.deletable {
             let buttons: [Rect; 2] =
-                Layout::horizontal([Constraint::Percentage(70), Constraint::Percentage(30)])
+                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .areas(vertical_layout[vertical_index]);
             StatefulWidget::render(
                 &self.confirm_button.widget,

--- a/ferrowl/src/module/modbus/dialog/widgets.rs
+++ b/ferrowl/src/module/modbus/dialog/widgets.rs
@@ -13,18 +13,17 @@ use ferrowl_codec::format::{
     Resolution,
 };
 use ferrowl_codec::{Access, Kind};
-use ferrowl_syntax::Language;
 use ferrowl_ui::state::ButtonState;
 use ferrowl_ui::{
     Border, COLOR_SCHEME,
     state::{
-        CodeInputFieldState, CodeInputFieldStateBuilder, InputFieldState, InputFieldStateBuilder,
+        InputFieldState, InputFieldStateBuilder,
         SelectionState, SelectionStateBuilder,
     },
     style::{ButtonStyle, InputFieldStyle, SelectionStyle, TextStyle},
     traits::ToLabel,
     widgets::{
-        Button, CodeInputField, CodeInputFieldBuilder, InputField, InputFieldBuilder, Selection,
+        Button, InputField, InputFieldBuilder, Selection,
         SelectionBuilder, Text, TextBuilder, Title, Validate, Widget,
     },
 };
@@ -127,28 +126,6 @@ pub(super) fn button(label: &str, horizontal: u16) -> Widget<ButtonState, Button
     ferrowl_ui::widgets::button(label, ButtonStyle::default(), horizontal)
 }
 
-/// An unfocused, bordered, titled multiline code-input field (the Lua update script).
-pub(super) fn code(
-    title: impl Into<Title>,
-    placeholder: &str,
-) -> Widget<CodeInputFieldState, CodeInputField> {
-    Widget {
-        state: CodeInputFieldStateBuilder::default()
-            .focused(false)
-            .disabled(false)
-            .placeholder(Some(placeholder.to_string()))
-            .language(Some(Language::Lua))
-            .build()
-            .expect("static code-input state"),
-        widget: CodeInputFieldBuilder::default()
-            .border(Border::Full(Margin::new(1, 0)))
-            .title(Some(title.into()))
-            .margin(field_margin())
-            .style(InputFieldStyle::default())
-            .build()
-            .expect("static code-input config"),
-    }
-}
 
 /// A bordered, titled static text box showing `content`.
 pub(super) fn text_boxed(

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -28,7 +28,7 @@ use super::log::{FileSink, append, open_sink};
 pub type ModuleMemory = Arc<RwLock<Memory<Key<SlaveKey>>>>;
 pub type ModuleLog = Arc<RwLock<LogRing>>;
 /// Shared store of virtual-register values (no Modbus address), keyed by register name. Shared
-/// with the Lua sim thread so `update` scripts can drive virtual registers and the table shows them.
+/// with the Lua sim thread so scripts can drive virtual registers and the table shows them.
 pub type VirtualStore = Arc<RwLock<HashMap<String, ferrowl_codec::Value>>>;
 
 /// One module instance: a modbus client (reads an external server) or server (simulates a
@@ -43,7 +43,7 @@ pub struct ModbusModule {
     memory: ModuleMemory,
     log: ModuleLog,
     file_sink: FileSink,
-    /// Per-register `update` Lua snippets (register name → code), run on the sim thread.
+    /// Enabled global Lua scripts (name → code), run on the sim thread.
     scripts: Vec<(String, String)>,
     /// Explicit per-function-code read ranges from the device config (empty = auto-merge).
     read_ranges: ReadRanges,
@@ -60,7 +60,7 @@ impl ModbusModule {
     pub fn new(spec: &ModuleSpec, device: &DeviceConfig) -> Self {
         let mut memory = Memory::<Key<SlaveKey>>::default();
         let mut registers: Vec<(String, String, Register, Vec<NamedValue>)> = Vec::new();
-        let mut scripts: Vec<(String, String)> = Vec::new();
+        let scripts = super::registers::collect_scripts(device);
         let mut virtual_init: HashMap<String, ferrowl_codec::Value> = HashMap::new();
 
         for (name, def) in &device.definitions {
@@ -71,11 +71,6 @@ impl ModbusModule {
                 register.clone(),
                 def.values.clone(),
             ));
-            if let Some(code) = &def.update
-                && !code.trim().is_empty()
-            {
-                scripts.push((name.clone(), code.clone()));
-            }
             if let Address::Virtual = register.address() {
                 let init = def
                     .default
@@ -259,7 +254,7 @@ impl ModbusModule {
         self.instance.stop().await
     }
 
-    /// Spawn the Lua simulation thread (no-op if there are no `update` scripts). Any previously
+    /// Spawn the Lua simulation thread (no-op if there are no scripts). Any previously
     /// running thread is stopped first so this is safe to call on restart.
     fn start_sim(&mut self) {
         self.stop_sim();
@@ -286,7 +281,7 @@ impl ModbusModule {
         }
     }
 
-    /// Start the Lua simulation thread (`:lua start`). No-op when there are no `update` scripts.
+    /// Start the Lua simulation thread (`:lua start`). No-op when there are no scripts.
     pub fn start_lua(&mut self) {
         self.start_sim();
     }
@@ -437,6 +432,7 @@ mod tests {
                 ..Default::default()
             },
             definitions,
+            scripts: Vec::new(),
         }
     }
 

--- a/ferrowl/src/module/modbus/registers.rs
+++ b/ferrowl/src/module/modbus/registers.rs
@@ -17,17 +17,13 @@ fn mem_type(register: &Register) -> CellType {
     }
 }
 
-/// (name, script) pairs for every register carrying a non-empty `update` Lua snippet.
+/// (name, code) pairs for every enabled, non-empty global script (run on the sim thread).
 pub(crate) fn collect_scripts(device: &crate::config::DeviceConfig) -> Vec<(String, String)> {
     device
-        .definitions
+        .scripts
         .iter()
-        .filter_map(|(name, def)| {
-            def.update
-                .as_ref()
-                .filter(|s| !s.trim().is_empty())
-                .map(|s| (name.clone(), s.clone()))
-        })
+        .filter(|s| s.enabled && !s.code.trim().is_empty())
+        .map(|s| (s.name.clone(), s.code.clone()))
         .collect()
 }
 

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -10,6 +10,7 @@ use ratatui::Frame;
 use ratatui::layout::Rect;
 
 use crate::config::{DeviceConfig, ModuleSpec};
+use crate::dialog::scripts::ScriptDialog;
 use crate::module::modbus::dialog::{EditInputDialog, EditSelectionDialog};
 use crate::module::modbus::setup_dialog::SetupDialog;
 use crate::module::modbus::table::{Definition, TableView, cmp_definitions};
@@ -31,6 +32,7 @@ pub struct ModbusModuleView {
     sort: Option<(usize, bool)>,
     overlay: Option<ModbusOverlay>,
     setup_overlay: Option<SetupDialog>,
+    scripts_overlay: Option<ScriptDialog>,
     pending: Option<PendingAction>,
     /// Whether this view (its content pane) currently has keyboard focus, set by the owning `Tab`.
     view_focused: bool,
@@ -58,6 +60,7 @@ impl ModbusModuleView {
             sort: None,
             overlay: None,
             setup_overlay: None,
+            scripts_overlay: None,
             pending: None,
             view_focused: false,
         }
@@ -67,14 +70,11 @@ impl ModbusModuleView {
         let Some(def) = self.table.selected().cloned() else {
             return;
         };
-        let (update_script, current_default) = self
+        let current_default = self
             .device
             .definitions
             .get(&def.name)
-            .map(|d| (d.update.as_deref(), d.default.as_ref()))
-            .unzip();
-        let update_script = update_script.flatten();
-        let current_default = current_default.flatten();
+            .and_then(|d| d.default.as_ref());
         let unscaled = def.value.clone().unscaled().to_string();
         if def.named_values.is_empty() {
             self.overlay = Some(ModbusOverlay::Edit(EditInputDialog::from_register(
@@ -82,7 +82,6 @@ impl ModbusModuleView {
                 &def.description,
                 &def.register,
                 &unscaled,
-                update_script,
                 current_default,
             )));
         } else {
@@ -94,7 +93,6 @@ impl ModbusModuleView {
                     def.named_values.clone(),
                     &unscaled,
                     &def.raw_value,
-                    update_script,
                     current_default,
                 ),
             ));
@@ -149,7 +147,6 @@ impl ModbusModuleView {
 
         self.overlay.as_mut().unwrap().clear_name_error();
 
-        let update_script_focused = self.overlay.as_ref().unwrap().is_update_script_focused();
         let confirm_button_focused = self.overlay.as_ref().unwrap().is_confirm_button_focused();
         let delete_button_focused = self
             .overlay
@@ -162,12 +159,7 @@ impl ModbusModuleView {
                 self.overlay = None;
             }
             (KeyModifiers::NONE, KeyCode::Enter) => {
-                if update_script_focused {
-                    self.overlay
-                        .as_mut()
-                        .unwrap()
-                        .handle_events(modifiers, code);
-                } else if delete_button_focused {
+                if delete_button_focused {
                     self.overlay.as_mut().unwrap().open_confirm_delete();
                 } else {
                     self.confirm_overlay();
@@ -261,7 +253,7 @@ impl ModuleView for ModbusModuleView {
     }
 
     fn is_overlay_active(&self) -> bool {
-        self.overlay.is_some() || self.setup_overlay.is_some()
+        self.overlay.is_some() || self.setup_overlay.is_some() || self.scripts_overlay.is_some()
     }
 
     fn render(&mut self, frame: &mut Frame, area: Rect) {
@@ -275,7 +267,10 @@ impl ModuleView for ModbusModuleView {
             Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(area);
 
         self.table.table.state.set_focused(
-            self.view_focused && self.overlay.is_none() && self.setup_overlay.is_none(),
+            self.view_focused
+                && self.overlay.is_none()
+                && self.setup_overlay.is_none()
+                && self.scripts_overlay.is_none(),
         );
         self.table.render(content_area, frame.buffer_mut());
 
@@ -311,7 +306,9 @@ impl ModuleView for ModbusModuleView {
 
     fn render_overlay(&mut self, frame: &mut Frame, _area: Rect) {
         let full_area = frame.area();
-        if let Some(setup) = &mut self.setup_overlay {
+        if let Some(scripts) = &mut self.scripts_overlay {
+            scripts.render(full_area, frame.buffer_mut());
+        } else if let Some(setup) = &mut self.setup_overlay {
             setup.render(full_area, frame.buffer_mut());
         } else if let Some(overlay) = &mut self.overlay {
             overlay.render(full_area, frame.buffer_mut());
@@ -319,6 +316,15 @@ impl ModuleView for ModbusModuleView {
     }
 
     fn handle_events(&mut self, modifiers: KeyModifiers, code: KeyCode) -> EventResult {
+        if let Some(ref mut scripts) = self.scripts_overlay {
+            if scripts.handle_events(modifiers, code) {
+                let dialog = self.scripts_overlay.take().expect("checked above");
+                self.device.scripts = dialog.resolve();
+                self.module
+                    .reload_scripts(super::registers::collect_scripts(&self.device));
+            }
+            return EventResult::Consumed;
+        }
         if let Some(ref mut setup) = self.setup_overlay {
             match (modifiers, code) {
                 (KeyModifiers::NONE, KeyCode::Esc) => {
@@ -483,6 +489,11 @@ impl ModuleView for ModbusModuleView {
             return Box::pin(std::future::ready(CommandResult::Handled(None)));
         }
 
+        if trimmed == "scripts" {
+            self.scripts_overlay = Some(ScriptDialog::new(&self.device.scripts));
+            return Box::pin(std::future::ready(CommandResult::Handled(None)));
+        }
+
         if trimmed == "compact" {
             self.table.set_compact(!self.table.compact);
             return Box::pin(std::future::ready(CommandResult::Handled(None)));
@@ -592,7 +603,7 @@ impl ModuleView for ModbusModuleView {
     }
 }
 
-static MODBUS_COMMANDS: [CommandDescriptor; 12] = [
+static MODBUS_COMMANDS: [CommandDescriptor; 13] = [
     CommandDescriptor {
         name: ":e | :edit",
         description: "edit module setup",
@@ -636,6 +647,10 @@ static MODBUS_COMMANDS: [CommandDescriptor; 12] = [
     CommandDescriptor {
         name: ":lua start|stop|status",
         description: "lua simulation",
+    },
+    CommandDescriptor {
+        name: ":scripts",
+        description: "manage lua scripts",
     },
     CommandDescriptor {
         name: ":order [col] [asc|desc]",
@@ -743,6 +758,7 @@ mod tests {
             log_file: None,
             read_ranges: Default::default(),
             definitions: Default::default(),
+            scripts: Default::default(),
         }
     }
 
@@ -901,6 +917,25 @@ mod tests {
         let result = view.handle_events(KeyModifiers::NONE, KeyCode::Enter);
         assert!(matches!(result, EventResult::Consumed));
         assert!(!view.is_overlay_active());
+    }
+
+    #[test]
+    fn ut_scripts_command_opens_overlay_and_close_applies() {
+        let mut view = new_view();
+        drop(view.handle_command("scripts"));
+        assert!(view.is_overlay_active());
+        // Create a script through the dialog: Tab to the name input (the code editor is
+        // skipped while nothing is selected), type a name, Enter creates it, Esc closes.
+        view.handle_events(KeyModifiers::NONE, KeyCode::Tab);
+        for c in "sim".chars() {
+            view.handle_events(KeyModifiers::NONE, KeyCode::Char(c));
+        }
+        view.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+        view.handle_events(KeyModifiers::NONE, KeyCode::Esc);
+        assert!(!view.is_overlay_active());
+        assert_eq!(view.device.scripts.len(), 1);
+        assert_eq!(view.device.scripts[0].name, "sim");
+        assert!(view.device.scripts[0].enabled);
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -12,9 +12,7 @@ use crate::module::modbus::table::{Definition, TableHeader, column_index};
 use crate::module::view::CommandResult;
 
 use super::super::ModbusModule;
-use super::super::registers::{
-    collect_scripts, register_mem_binding, sync_register_def, write_command,
-};
+use super::super::registers::{register_mem_binding, sync_register_def, write_command};
 use super::ModbusModuleView;
 
 impl ModbusModuleView {
@@ -62,7 +60,7 @@ impl ModbusModuleView {
             length: 1,
             alignment: crate::config::device::AlignmentCfg::default(),
             values: named_values.clone(),
-            update: edited.update.as_ref().filter(|s| !s.is_empty()).cloned(),
+            update: None,
             description: edited.description.clone(),
             default: edited.default.clone(),
         };
@@ -94,16 +92,6 @@ impl ModbusModuleView {
             named_values,
         ));
         self.table.set_definitions(defs);
-
-        if edited
-            .update
-            .as_ref()
-            .map(|s| !s.is_empty())
-            .unwrap_or(false)
-        {
-            let scripts = collect_scripts(&self.device);
-            self.module.reload_scripts(scripts);
-        }
 
         if let Address::Virtual = edited.register.address() {
             let seed = crate::module::modbus::default_value(&edited.register);
@@ -178,13 +166,6 @@ impl ModbusModuleView {
                 if let Some(nv) = &edited.named_values {
                     def.values = nv.clone();
                 }
-                if let Some(script) = &edited.update {
-                    def.update = if script.is_empty() {
-                        None
-                    } else {
-                        Some(script.clone())
-                    };
-                }
                 def.default = edited.default.clone();
             }
             if edited.name != original_name
@@ -205,11 +186,6 @@ impl ModbusModuleView {
         }
 
         self.module.rebuild_operations().await;
-
-        if edited.update.is_some() {
-            let scripts = collect_scripts(&self.device);
-            self.module.reload_scripts(scripts);
-        }
 
         if let Some(v) = preserved_value
             && edited.value.is_none()
@@ -237,9 +213,6 @@ impl ModbusModuleView {
         self.table.select_first();
 
         self.module.rebuild_operations().await;
-
-        let scripts = collect_scripts(&self.device);
-        self.module.reload_scripts(scripts);
     }
 
     pub(super) async fn apply_setup(&mut self, values: SetupValues) {

--- a/ferrowl/src/module/modbus/view/overlay.rs
+++ b/ferrowl/src/module/modbus/view/overlay.rs
@@ -114,10 +114,6 @@ impl ModbusOverlay {
         self.inner_mut().add_dialog_handle_events(modifiers, code)
     }
 
-    pub(super) fn is_update_script_focused(&self) -> bool {
-        self.inner().is_update_script_focused()
-    }
-
     pub(super) fn is_confirm_button_focused(&self) -> bool {
         self.inner().is_confirm_button_focused()
     }

--- a/ferrowl/src/module/ocpp/client/mod.rs
+++ b/ferrowl/src/module/ocpp/client/mod.rs
@@ -5,7 +5,6 @@
 pub mod backend;
 pub mod config;
 pub mod lua_sim;
-pub mod scripts;
 pub mod v1_6;
 pub mod v2_0_1;
 pub mod v2_1;

--- a/ferrowl/src/module/ocpp/client/view/input.rs
+++ b/ferrowl/src/module/ocpp/client/view/input.rs
@@ -7,7 +7,7 @@ use ferrowl_ui::{EventResult, traits::HandleEvents, widgets::GetValue};
 use crate::module::ocpp::action_dialog::{ActionDialog, ActionResult, gen_tx_id, value_to_string};
 use crate::module::ocpp::client::config::{ConfigEditDialog, ConfigKey};
 use crate::module::ocpp::client::lua_sim::ClientFields;
-use crate::module::ocpp::client::scripts::ScriptDialog;
+use crate::dialog::scripts::ScriptDialog;
 use crate::module::ocpp::lock::{HasState, with_state};
 use crate::module::ocpp::scope::Scope;
 

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -45,7 +45,7 @@ use crate::module::ocpp::action_dialog::ActionDialog;
 use crate::module::ocpp::client::backend::{Messages, OcppClient, OcppMessage};
 use crate::module::ocpp::client::config::{ConfigEditDialog, ConfigKey};
 use crate::module::ocpp::client::lua_sim::{ClientFields, OcppSimHandle, ScopedActionQueue};
-use crate::module::ocpp::client::scripts::ScriptDialog;
+use crate::dialog::scripts::ScriptDialog;
 use crate::module::ocpp::config::device::{ConnectorRef, OcppDeviceConfig};
 use crate::module::ocpp::config::session::OcppSpec;
 use crate::module::ocpp::lock::{HasState, with_state, with_state_mut};

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -8,12 +8,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::session::{OcppRole, OcppSpec, OcppVersion};
+pub use crate::config::script::ScriptDef;
 
-/// Default for `ScriptDef::enabled`: a script with no explicit flag is active.
-fn default_true() -> bool {
-    true
-}
+use super::session::{OcppRole, OcppSpec, OcppVersion};
 
 /// A persisted connector entry for a charging-station (client) device type. `evse` is `None` for
 /// OCPP 1.6 (connector-only) and `Some` for 2.0.1; `connector` is the connector id. The CS-level
@@ -49,18 +46,6 @@ pub struct ConfigKeyDef {
     pub value: String,
     #[serde(default)]
     pub readonly: bool,
-}
-
-/// One Lua simulation script attached to an OCPP device type.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ScriptDef {
-    pub name: String,
-    #[serde(default)]
-    pub code: String,
-    /// Whether the script runs in the simulation loop. Defaults to On (a freshly-created script
-    /// and a flag-less file entry are both active).
-    #[serde(default = "default_true")]
-    pub enabled: bool,
 }
 
 /// An OCPP device-type configuration file.

--- a/ferrowl/src/module/ocpp/server/view/input.rs
+++ b/ferrowl/src/module/ocpp/server/view/input.rs
@@ -8,7 +8,7 @@ use ferrowl_ui::widgets::GetValue;
 
 use crate::module::modbus::dialog::ConfirmDeleteDialog;
 use crate::module::ocpp::action_dialog::{ActionDialog, ActionResult, gen_tx_id};
-use crate::module::ocpp::client::scripts::ScriptDialog;
+use crate::dialog::scripts::ScriptDialog;
 use crate::module::ocpp::server::backend::{Scope, with_rfids_mut};
 use crate::module::ocpp::server::detail::{DetailOverlay, DetailRequest};
 

--- a/ferrowl/src/module/ocpp/server/view/mod.rs
+++ b/ferrowl/src/module/ocpp/server/view/mod.rs
@@ -39,7 +39,7 @@ use crate::module::modbus::dialog::ConfirmDeleteDialog;
 use crate::module::ocpp::action_dialog::ActionDialog;
 use crate::module::ocpp::client::backend::OcppMessage;
 use crate::module::ocpp::client::lua_sim::OcppFields;
-use crate::module::ocpp::client::scripts::ScriptDialog;
+use crate::dialog::scripts::ScriptDialog;
 use crate::module::ocpp::config::device::{ConnectorRfids, OcppDeviceConfig};
 use crate::module::ocpp::config::session::{OcppModuleSpec, OcppSpec};
 use crate::module::ocpp::lock::{with_state, with_state_mut};


### PR DESCRIPTION
Per-register update snippets could only be edited inside the register dialog and had no on/off switch; OCPP already had a named, toggleable script list with a manager dialog.

- ScriptDef and ScriptDialog move to shared modules (config::script, dialog::scripts); OCPP call sites only change imports
- DeviceConfig gains a global scripts list; legacy update snippets are migrated on load into enabled scripts named after their register and never written back (field kept deserialize-only)
- new :scripts command opens the manager; closing it applies the list and reloads the sim thread (module machinery unchanged)
- register add/edit dialogs lose the update-script editor and its focus special-casing; dialog height shrinks accordingly
- README: example config, field table, command table, Lua section