### PR TITLE
feat(tui): bundled Lua script templates, template browser, script rename

### DIFF
--- a/docs/specs/scripting/requirements.md
+++ b/docs/specs/scripting/requirements.md
@@ -186,6 +186,20 @@ the client is connected or the server is bound.
 
 ---
 
+## Script templates
+
+**SC-R-036** — The binary shall carry a fixed library of Lua script templates,
+compiled in at build time. Each template shall have a name, a one-line
+description, a Lua code body, and the set of script contexts (Modbus, OCPP client,
+OCPP server, session) it applies to. A template shall not be a script: it becomes
+one only by being copied into a script list, and nothing shall load template code
+from disk at run time (SC-R-023 stands).
+
+**SC-R-037** — Every template's code body shall be loadable by the Lua runtime — a
+template that fails to compile shall be a build/test failure, not a run-time one.
+
+---
+
 ## State access semantics
 
 **SC-R-027** — A value read from a register or an OCPP state field shall be

--- a/docs/specs/tui/api-contract.md
+++ b/docs/specs/tui/api-contract.md
@@ -197,14 +197,32 @@ Insert/Visual mode `?` is literal text.
 
 | Key | Context | Action |
 |---|---|---|
-| `Tab` / `Shift+Tab` | dialog | Cycle focus (script table → name input → code editor → interval → log); the code editor is skipped while no script is selected |
+| `Tab` / `Shift+Tab` | dialog | Cycle focus (script table → name input → Templates button → code editor → interval → log); the code editor is skipped while no script is selected |
 | `Esc` | dialog | Open close-confirm |
 | `t` | script table focused | Toggle the selected script's enabled flag |
 | `d` | script table focused | Delete the selected script (opens confirm) |
 | `c` | script table focused | Toggle compact rows |
 | `e` | script table focused | Execute the selected script once (current editor content, enabled or not) |
+| `Enter` | script table focused | Open the rename prompt for the selected script |
 | `Enter` | name input focused | Create a new script with the typed name |
+| `Enter` / `Space` | Templates button focused | Open the template-browser overlay |
 | `?` | code editor, Normal mode | Open the Lua-bindings help overlay |
+
+### 4.10 Template-browser overlay (Templates button in the script-manager dialog)
+
+| Key | Context | Action |
+|---|---|---|
+| `j` / `k` / `Up` / `Down` | template list | Move the selection; the preview follows |
+| `Tab` / `Shift+Tab` | overlay | Cycle focus between the template list and the (read-only) preview |
+| `Enter` | overlay | Insert the selected template as a new enabled script and close the overlay |
+| `Esc` / `q` | overlay | Close, changing nothing |
+
+### 4.11 Script rename prompt (`Enter` on the script table)
+
+| Key | Context | Action |
+|---|---|---|
+| `Enter` | prompt | Commit the new name; an empty or duplicate name is refused and the prompt stays open |
+| `Esc` | prompt | Cancel, leaving the name unchanged |
 
 ## 5. Code editor — modes and commands
 

--- a/docs/specs/tui/edge-cases.md
+++ b/docs/specs/tui/edge-cases.md
@@ -46,6 +46,12 @@ it is not mistaken for an oversight and silently "fixed".
 | `:` or `?` pressed while a view overlay is open | Not treated as global; the key is delivered to the overlay (so `?` types into a Lua editor, `:` into a text field) |
 | A key with no binding in the current dialog/field | Left unhandled; the generic dialog defaults (`Enter`/`Esc`/`Tab`) apply only if no widget consumed it, otherwise nothing happens |
 | Suggestion popup closed, `Up`/`Down`/`Enter`/`Tab`/`Esc` pressed | Passed through to the surrounding dialog rather than consumed by the popup |
+| Inserting a template whose name is already used in the script list | Inserted as `<name>-2` (then `-3`, …); never refused |
+| Preview pane of the template browser | A disabled code editor: vim motions and visual-yank work, edits do not |
+| Renaming a script to an empty or duplicate name | Refused silently; the prompt stays open (same rule as creating a script) |
+| Renaming a script to its own current name | Accepted; a no-op |
+| `Esc` while the rename prompt is open | Cancels the prompt; it does not reach the dialog's close-confirm |
+| A rename is an edit | Like any script edit, it restarts the sim thread when the dialog closes (SC-R-024): the Lua context is keyed by script name |
 
 ## 4. Code editor
 

--- a/docs/specs/tui/requirements.md
+++ b/docs/specs/tui/requirements.md
@@ -180,6 +180,33 @@ and the run's `print`/`C_Log` output and any error shall appear in the dialog's 
 pane. The execution semantics are specified by SC-R-035 in
 [`../scripting/requirements.md`](../scripting/requirements.md).
 
+**UI-R-052** — The script-manager dialog shall carry a *Templates* button in its
+focus cycle, positioned after the new-script name input. `Enter` or `Space` on the
+focused button shall open the template-browser overlay.
+
+**UI-R-053** — The template-browser overlay shall list only the templates
+applicable to the dialog's script context (SC-R-036 in
+[`../scripting/requirements.md`](../scripting/requirements.md)), each with its name
+and description, alongside a read-only preview of the selected template's Lua code
+with syntax highlighting. `Esc` or `q` shall close the overlay without changing the
+script list. While the overlay is open it shall take precedence over all other
+dialog keys.
+
+**UI-R-054** — Confirming a template in the overlay shall append it to the dialog's
+working script list as a new enabled script whose code is a copy of the template
+body, select that script, close the overlay, and leave the dialog open. The new
+script shall take the template's name; if that name is already taken in the list, it
+shall take the first free `<name>-<n>` (n from 2 upwards) — insertion shall never be
+refused for a name collision.
+
+**UI-R-055** — In the script-manager dialog, while the script table is focused,
+`Enter` on a selected script shall open a rename prompt pre-filled with that
+script's current name. Confirming with `Enter` shall rename the script; `Esc` shall
+dismiss the prompt leaving the name unchanged. A name that is empty (after trimming)
+or already used by another script in the list shall be refused and the prompt shall
+stay open. With no script selected, `Enter` shall be a no-op. Renaming shall change
+only the script's name — its code and enabled flag shall be preserved.
+
 ## Code editor (vim-modal)
 
 **UI-R-027** — The multi-line code editor shall support two operating profiles:

--- a/ferrowl/src/dialog/mod.rs
+++ b/ferrowl/src/dialog/mod.rs
@@ -3,8 +3,10 @@
 pub mod close_confirm;
 pub mod lua_help;
 pub mod path_suggest;
+pub mod rename;
 mod script_manager;
 pub mod scripts;
+pub mod template_browser;
 
 pub use crate::module::modbus::dialog::{EditedRegister, parse_raw_value};
 pub use crate::module::modbus::setup_dialog::SetupDialog;

--- a/ferrowl/src/dialog/rename.rs
+++ b/ferrowl/src/dialog/rename.rs
@@ -1,0 +1,251 @@
+//! Rename prompt of the script dialog (UI-R-055): a small popup, pre-filled with the selected
+//! script's current name. `Enter` commits, `Esc` cancels; the host refuses an empty or duplicate
+//! name and leaves the prompt open.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use ferrowl_ui::{
+    Border, COLOR_SCHEME,
+    state::{InputFieldState, InputFieldStateBuilder},
+    style::{InputFieldStyleBuilder, TextStyle},
+    traits::{HandleEvents, SetFocus},
+    widgets::{InputField, InputFieldBuilder, Text, TextBuilder, Widget},
+};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, HorizontalAlignment, Layout, Margin, Rect},
+    widgets::{Block, Clear, StatefulWidget, Widget as UiWidget},
+};
+
+use crate::view::border_style;
+
+/// Outcome of feeding a key into a [`RenamePrompt`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenameEvent {
+    /// Key eaten, the prompt stays open.
+    Consumed,
+    /// `Esc`: drop the prompt, leave the name unchanged.
+    Cancel,
+    /// `Enter`: the host should try to apply this (trimmed) name.
+    Commit(String),
+}
+
+/// Outcome of [`route_rename`]: what the host dialog should do about an open rename prompt.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenameOutcome {
+    /// No prompt was open; the caller should route the key itself.
+    NotActive,
+    /// The prompt captured the key (cancelling itself if applicable).
+    Consumed,
+    /// The user confirmed a name. The prompt is **not** cleared: the host clears it only if the
+    /// rename was accepted, so a refused name leaves the prompt open (UI-R-055).
+    Commit(String),
+}
+
+/// The rename popup: one pre-filled input field plus a keybind hint.
+pub struct RenamePrompt {
+    input: Widget<InputFieldState, InputField<String>>,
+    keybinds: Widget<String, Text>,
+}
+
+impl RenamePrompt {
+    /// Open the prompt on `current` — the field starts pre-filled, cursor at the end, so `Enter`
+    /// alone is a no-op rename rather than an empty one.
+    pub fn new(current: &str) -> Self {
+        let mut input = Widget {
+            state: InputFieldStateBuilder::default()
+                .focused(true)
+                .disabled(false)
+                .placeholder(Some("Script name".to_string()))
+                .build()
+                .unwrap(),
+            widget: InputFieldBuilder::default()
+                .border(Border::Full(Margin::new(1, 0)))
+                .title(Some(("New name", HorizontalAlignment::Left).into()))
+                .style(
+                    InputFieldStyleBuilder::default()
+                        .border(border_style())
+                        .build()
+                        .unwrap(),
+                )
+                .margin(Margin {
+                    vertical: 0,
+                    horizontal: 0,
+                })
+                .build()
+                .unwrap(),
+        };
+        input.state.set_input(current.to_string());
+        input.state.set_cursor(current.chars().count());
+        input.state.set_focused(true);
+
+        Self {
+            input,
+            keybinds: Widget {
+                state: "<Enter>: rename | <Esc>: cancel".to_string(),
+                widget: TextBuilder::default()
+                    .margin(Margin {
+                        vertical: 0,
+                        horizontal: 1,
+                    })
+                    .horizontal_alignment(HorizontalAlignment::Center)
+                    .style(TextStyle::default())
+                    .build()
+                    .unwrap(),
+            },
+        }
+    }
+
+    /// Feed one key while the prompt is open.
+    pub fn handle_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> RenameEvent {
+        match (modifiers, code) {
+            (KeyModifiers::NONE, KeyCode::Esc) => RenameEvent::Cancel,
+            (KeyModifiers::NONE, KeyCode::Enter) => {
+                RenameEvent::Commit(self.input.state.input().trim().to_string())
+            }
+            _ => {
+                let _ = self.input.state.handle_events(modifiers, code);
+                RenameEvent::Consumed
+            }
+        }
+    }
+
+    pub fn render(&mut self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let [_, hc, _] = Layout::horizontal([
+            Constraint::Min(1),
+            Constraint::Length(46),
+            Constraint::Min(1),
+        ])
+        .areas(area);
+        // 2 border + 2 margin + 3 input + 1 keybinds = 8
+        let [_, popup, _] = Layout::vertical([
+            Constraint::Min(1),
+            Constraint::Length(8),
+            Constraint::Min(1),
+        ])
+        .areas(hc);
+
+        let block = Block::bordered()
+            .style(
+                ratatui::prelude::Style::default()
+                    .fg(COLOR_SCHEME.hi)
+                    .bg(COLOR_SCHEME.bg),
+            )
+            .title_alignment(HorizontalAlignment::Center)
+            .title(" Rename Script ");
+        let inner = block.inner(popup).inner(Margin::new(2, 1));
+        UiWidget::render(&Clear, popup, buf);
+        block.render(popup, buf);
+
+        let [input_area, keybinds_area] =
+            Layout::vertical([Constraint::Length(3), Constraint::Length(1)]).areas(inner);
+
+        StatefulWidget::render(&self.input.widget, input_area, buf, &mut self.input.state);
+        StatefulWidget::render(
+            &self.keybinds.widget,
+            keybinds_area,
+            buf,
+            &mut self.keybinds.state,
+        );
+    }
+}
+
+/// Feed one key through `rename`, if the rename prompt is open. Clears `*rename` on cancel; on
+/// commit the prompt is left in place for the host to keep or clear depending on whether the new
+/// name was accepted.
+pub fn route_rename(
+    rename: &mut Option<RenamePrompt>,
+    modifiers: KeyModifiers,
+    code: KeyCode,
+) -> RenameOutcome {
+    let Some(prompt) = rename.as_mut() else {
+        return RenameOutcome::NotActive;
+    };
+    match prompt.handle_key(modifiers, code) {
+        RenameEvent::Consumed => RenameOutcome::Consumed,
+        RenameEvent::Cancel => {
+            *rename = None;
+            RenameOutcome::Consumed
+        }
+        RenameEvent::Commit(name) => RenameOutcome::Commit(name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// UI-R-055 — the prompt opens pre-filled with the current name.
+    #[test]
+    fn ut_prompt_is_prefilled() {
+        let prompt = RenamePrompt::new("boot");
+        assert_eq!(prompt.input.state.input(), "boot");
+    }
+
+    /// UI-R-055 — `Enter` commits the trimmed field content, `Esc` cancels.
+    #[test]
+    fn ut_enter_commits_trimmed_and_esc_cancels() {
+        let mut prompt = RenamePrompt::new("boot");
+        assert_eq!(
+            prompt.handle_key(KeyModifiers::NONE, KeyCode::Enter),
+            RenameEvent::Commit("boot".to_string())
+        );
+        assert_eq!(
+            prompt.handle_key(KeyModifiers::NONE, KeyCode::Esc),
+            RenameEvent::Cancel
+        );
+    }
+
+    #[test]
+    fn ut_typing_edits_the_field() {
+        let mut prompt = RenamePrompt::new("a");
+        assert_eq!(
+            prompt.handle_key(KeyModifiers::NONE, KeyCode::Char('b')),
+            RenameEvent::Consumed
+        );
+        assert_eq!(
+            prompt.handle_key(KeyModifiers::NONE, KeyCode::Enter),
+            RenameEvent::Commit("ab".to_string())
+        );
+    }
+
+    /// UI-R-055 — `Esc` clears the prompt; a commit leaves it in place for the host to judge.
+    #[test]
+    fn ut_route_cancel_clears_commit_keeps() {
+        let mut rename = Some(RenamePrompt::new("a"));
+        assert_eq!(
+            route_rename(&mut rename, KeyModifiers::NONE, KeyCode::Enter),
+            RenameOutcome::Commit("a".to_string())
+        );
+        assert!(
+            rename.is_some(),
+            "a commit must not clear the prompt itself"
+        );
+
+        assert_eq!(
+            route_rename(&mut rename, KeyModifiers::NONE, KeyCode::Esc),
+            RenameOutcome::Consumed
+        );
+        assert!(rename.is_none());
+    }
+
+    #[test]
+    fn ut_route_not_active_when_none() {
+        let mut rename: Option<RenamePrompt> = None;
+        assert_eq!(
+            route_rename(&mut rename, KeyModifiers::NONE, KeyCode::Enter),
+            RenameOutcome::NotActive
+        );
+    }
+
+    #[test]
+    fn ut_render_does_not_panic() {
+        let mut prompt = RenamePrompt::new("boot");
+        let area = Rect::new(0, 0, 80, 24);
+        let mut buf = Buffer::empty(area);
+        prompt.render(area, &mut buf);
+    }
+}

--- a/ferrowl/src/dialog/script_manager.rs
+++ b/ferrowl/src/dialog/script_manager.rs
@@ -12,13 +12,13 @@ use ferrowl_syntax::Language;
 use ferrowl_ui::{
     Border,
     state::{
-        CodeInputFieldState, CodeInputFieldStateBuilder, InputFieldState, InputFieldStateBuilder,
-        TableState, TableStateBuilder,
+        ButtonState, ButtonStateBuilder, CodeInputFieldState, CodeInputFieldStateBuilder,
+        InputFieldState, InputFieldStateBuilder, TableState, TableStateBuilder,
     },
-    style::{InputFieldStyleBuilder, TableStyleBuilder},
+    style::{ButtonStyle, InputFieldStyleBuilder, TableStyleBuilder},
     widgets::{
-        CodeInputField, CodeInputFieldBuilder, InputField, InputFieldBuilder, Table, TableBuilder,
-        Widget,
+        Button, ButtonBuilder, CodeInputField, CodeInputFieldBuilder, InputField,
+        InputFieldBuilder, Table, TableBuilder, Widget,
     },
 };
 use ferrowl_ui_derive::TableEntry;
@@ -28,6 +28,7 @@ use ratatui::{
 };
 
 use crate::config::script::ScriptDef;
+use crate::script_template::ScriptTemplate;
 
 #[derive(Clone, Debug, Default, TableEntry)]
 #[table_entry(header = ScriptHeader)]
@@ -103,6 +104,44 @@ impl ScriptManagerRef<'_> {
         self.sync_code_from_selection();
     }
 
+    /// Append a bundled template as a new enabled script and select it (UI-R-054). The code is
+    /// **copied** — the inserted script has no link back to the template. A name already taken is
+    /// suffixed rather than refused, so picking the same template twice always produces a script.
+    pub fn insert_template(&mut self, template: &ScriptTemplate) {
+        self.scripts.push(ScriptDef {
+            name: unique_name(self.scripts, template.name),
+            code: template.code.to_string(),
+            enabled: true,
+        });
+        self.refresh_rows();
+        self.table.state.move_to_bottom();
+        self.sync_code_from_selection();
+    }
+
+    /// Rename the selected script (UI-R-055). Returns `false` — refusing — for an empty name or one
+    /// another script already holds; renaming a script to its own current name is accepted as a
+    /// no-op. Code and enabled flag are untouched either way.
+    pub fn rename_selected(&mut self, new_name: &str) -> bool {
+        let Some(i) = self.selected() else {
+            return false;
+        };
+        let name = new_name.trim();
+        if name.is_empty() {
+            return false;
+        }
+        if self
+            .scripts
+            .iter()
+            .enumerate()
+            .any(|(j, s)| j != i && s.name == name)
+        {
+            return false;
+        }
+        self.scripts[i].name = name.to_string();
+        self.refresh_rows();
+        true
+    }
+
     pub fn toggle_compact(&mut self) {
         *self.compact = !*self.compact;
         self.table.widget.set_row_margin(Margin {
@@ -128,6 +167,18 @@ impl ScriptManagerRef<'_> {
     }
 }
 
+/// `base` if free, else the first free `base-2`, `base-3`, … (UI-R-054).
+fn unique_name(scripts: &[ScriptDef], base: &str) -> String {
+    let taken = |name: &str| scripts.iter().any(|s| s.name == name);
+    if !taken(base) {
+        return base.to_string();
+    }
+    (2..)
+        .map(|n| format!("{base}-{n}"))
+        .find(|name| !taken(name))
+        .expect("an unbounded suffix search always terminates")
+}
+
 pub(crate) fn rows(scripts: &[ScriptDef]) -> Vec<ScriptRow> {
     scripts
         .iter()
@@ -144,7 +195,7 @@ pub(crate) fn script_table(rows: Vec<ScriptRow>) -> ScriptTable {
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(
-                "Scripts (e: run, t: toggle, d: delete, c: compact)".into(),
+                "Scripts (Enter: rename, e: run, t: toggle, d: delete, c: compact)".into(),
             ))
             .style(TableStyleBuilder::default().build().unwrap())
             .row_margin(Margin {
@@ -177,6 +228,28 @@ pub(crate) fn name_input(border: Style) -> Widget<InputFieldState, InputField<St
                 vertical: 0,
                 horizontal: 0,
             })
+            .build()
+            .unwrap(),
+    }
+}
+
+/// The *Templates* button (UI-R-052): opens the template browser from the script dialog.
+pub(crate) fn templates_button() -> Widget<ButtonState, Button> {
+    Widget {
+        state: ButtonStateBuilder::default()
+            .focused(false)
+            .label("TEMPLATES".to_string())
+            .disabled(false)
+            .build()
+            .unwrap(),
+        widget: ButtonBuilder::default()
+            .border_margin(Margin::new(1, 0))
+            .margin(Margin {
+                vertical: 0,
+                horizontal: 0,
+            })
+            .style(ButtonStyle::default())
+            .horizontal_alignment(HorizontalAlignment::Center)
             .build()
             .unwrap(),
     }
@@ -288,6 +361,52 @@ mod tests {
 
         mgr.delete_selected();
         assert!(mgr.scripts.is_empty());
+    }
+
+    /// UI-R-054 — the suffix search skips every taken name, not just the base.
+    #[test]
+    fn ut_unique_name_suffixes_past_taken_names() {
+        let scripts = vec![
+            ScriptDef {
+                name: "ramp".into(),
+                code: String::new(),
+                enabled: true,
+            },
+            ScriptDef {
+                name: "ramp-2".into(),
+                code: String::new(),
+                enabled: true,
+            },
+        ];
+        assert_eq!(unique_name(&scripts, "ramp"), "ramp-3");
+        assert_eq!(unique_name(&scripts, "sine"), "sine");
+    }
+
+    /// UI-R-055 — renaming to the script's own name is accepted (a no-op), not refused as a
+    /// duplicate of itself.
+    #[test]
+    fn ut_rename_to_own_name_is_accepted() {
+        let mut scripts = vec![ScriptDef {
+            name: "boot".into(),
+            code: "x".into(),
+            enabled: true,
+        }];
+        let mut table = script_table(rows(&scripts));
+        let mut name_input = name_input(Style::default());
+        let mut code = code_editor(Style::default());
+        let mut compact = false;
+        let mut mgr = manager_fixture(
+            &mut scripts,
+            &mut table,
+            &mut name_input,
+            &mut code,
+            &mut compact,
+        );
+
+        assert!(mgr.rename_selected("boot"));
+        assert!(!mgr.rename_selected("   "), "blank name is refused");
+        assert_eq!(mgr.scripts[0].name, "boot");
+        assert_eq!(mgr.scripts[0].code, "x");
     }
 
     #[test]

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -3,24 +3,27 @@
 //! input) on the left, the code editor for the selected script on the right, and a read-only tail
 //! of the owner's script log at the bottom.
 //!
-//! One flat Tab order: Interval → script table → name input → code editor → log → Interval
-//! (`Shift+Tab` reversed; the code editor is skipped while no script is selected). `t` toggles a
-//! script, `d` deletes (with confirmation), `c` toggles compact rows, `e` runs the selected script
-//! once (see [`ScriptDialog::take_run_request`]), Enter in the name input
-//! creates a new (enabled) script. Edits are live on a working copy, applied when the dialog
-//! closes via [`ScriptDialog::resolve`]. `Esc` opens a close confirmation popup (Enter/Space
-//! confirms, Esc dismisses it); `?` from the code editor's Normal mode opens the Lua bindings
-//! overlay, routed to the right reference page by `context`.
+//! One flat Tab order: Interval → script table → name input → Templates button → code editor → log
+//! → Interval (`Shift+Tab` reversed; the code editor is skipped while no script is selected). `t`
+//! toggles a script, `d` deletes (with confirmation), `c` toggles compact rows, `e` runs the
+//! selected script once (see [`ScriptDialog::take_run_request`]), `Enter` on the table renames the
+//! selected script (UI-R-055), Enter in the name input creates a new (enabled) script, and the
+//! Templates button opens the bundled-template browser (UI-R-052). Edits are live on a working
+//! copy, applied when the dialog closes via [`ScriptDialog::resolve`]. `Esc` opens a close
+//! confirmation popup (Enter/Space confirms, Esc dismisses it); `?` from the code editor's Normal
+//! mode opens the Lua bindings overlay, routed to the right reference page by `context`.
 
 use std::time::Duration;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use ferrowl_ui::{
     Border, COLOR_SCHEME,
-    state::{CodeInputFieldState, InputFieldState, InputFieldStateBuilder, VimMode},
+    state::{ButtonState, CodeInputFieldState, InputFieldState, InputFieldStateBuilder, VimMode},
     style::InputFieldStyleBuilder,
     traits::{HandleEvents, SetFocus},
-    widgets::{CodeInputField, InputField, InputFieldBuilder, Validate, ValidateResult, Widget},
+    widgets::{
+        Button, CodeInputField, InputField, InputFieldBuilder, Validate, ValidateResult, Widget,
+    },
 };
 use ferrowl_ui_derive::{Focus, focusable};
 use ratatui::{
@@ -32,7 +35,11 @@ use ratatui::{
 use crate::config::script::ScriptDef;
 use crate::dialog::close_confirm::{CloseConfirmDialog, CloseConfirmOutcome, route_close_confirm};
 use crate::dialog::lua_help::{LuaHelpOutcome, LuaHelpOverlay, ScriptContext, route_lua_help};
+use crate::dialog::rename::{RenameOutcome, RenamePrompt, route_rename};
 use crate::dialog::script_manager::{self, ScriptManagerRef, ScriptTable};
+use crate::dialog::template_browser::{
+    TemplateBrowser, TemplateBrowserOutcome, route_template_browser,
+};
 use crate::module::modbus::dialog::{
     ConfirmDeleteDialog, DeleteConfirmOutcome, route_delete_confirm,
 };
@@ -63,8 +70,8 @@ impl Validate for Interval {
 /// The script manager dialog. Works on a private copy of the scripts/interval; the caller applies
 /// the result via [`ScriptDialog::resolve`] on close.
 ///
-/// Tab order (declaration order below): interval → script table → name input → code editor
-/// (skipped while no script is selected) → log.
+/// Tab order (declaration order below): interval → script table → name input → Templates button →
+/// code editor (skipped while no script is selected) → log.
 #[focusable]
 #[derive(Focus)]
 pub struct ScriptDialog {
@@ -78,11 +85,17 @@ pub struct ScriptDialog {
     table: ScriptTable,
     #[focus]
     name_input: Widget<InputFieldState, InputField<String>>,
+    #[focus]
+    templates_button: Widget<ButtonState, Button>,
     #[focus(when = self.selected().is_some())]
     code: Widget<CodeInputFieldState, CodeInputField>,
     #[focus]
     log: LogView,
     confirm: Option<ConfirmDeleteDialog>,
+    /// The template browser opened by the Templates button (UI-R-052).
+    template_browser: Option<TemplateBrowser>,
+    /// The rename prompt opened by `Enter` on the script table (UI-R-055).
+    rename: Option<RenamePrompt>,
     /// Set by `e` on the script table: the selected script, to be executed once by the owner
     /// (which holds the Lua modules the dialog knows nothing about). Pulled out with
     /// [`ScriptDialog::take_run_request`] after each key.
@@ -104,11 +117,14 @@ impl ScriptDialog {
             initial_interval: interval,
             table: script_manager::script_table(script_manager::rows(&scripts)),
             name_input: script_manager::name_input(border_style()),
+            templates_button: script_manager::templates_button(),
             code: script_manager::code_editor(border_style()),
             log: new_log_view(),
             focus: ScriptDialogFocus::Interval,
             view_focused: true,
             confirm: None,
+            template_browser: None,
+            rename: None,
             pending_run: None,
             compact: false,
             close_confirm: None,
@@ -191,6 +207,13 @@ impl ScriptDialog {
         self.pending_run = self.selected().map(|i| self.scripts[i].clone());
     }
 
+    /// Open the rename prompt on the selected script (UI-R-055). No selection: nothing to rename.
+    fn request_rename(&mut self) {
+        if let Some(i) = self.selected() {
+            self.rename = Some(RenamePrompt::new(&self.scripts[i].name));
+        }
+    }
+
     /// Take the script queued by `e`, if any. The owner calls this after every key and executes
     /// the script once against its own Lua modules (SC-R-035).
     pub fn take_run_request(&mut self) -> Option<ScriptDef> {
@@ -204,6 +227,30 @@ impl ScriptDialog {
         match route_lua_help(&mut self.lua_help, modifiers, code) {
             LuaHelpOutcome::NotActive => {}
             LuaHelpOutcome::Consumed => return false,
+        }
+
+        // The template browser takes precedence over the dialog's own keys while open (UI-R-053).
+        match route_template_browser(&mut self.template_browser, modifiers, code) {
+            TemplateBrowserOutcome::NotActive => {}
+            TemplateBrowserOutcome::Consumed => return false,
+            TemplateBrowserOutcome::Insert(template) => {
+                self.manager().insert_template(template);
+                return false;
+            }
+        }
+
+        // The rename prompt takes precedence too — notably over `Esc`, which cancels the prompt
+        // rather than opening the dialog's close-confirm (UI-R-055).
+        match route_rename(&mut self.rename, modifiers, code) {
+            RenameOutcome::NotActive => {}
+            RenameOutcome::Consumed => return false,
+            RenameOutcome::Commit(name) => {
+                // A refused (empty/duplicate) name leaves the prompt open to be corrected.
+                if self.manager().rename_selected(&name) {
+                    self.rename = None;
+                }
+                return false;
+            }
         }
 
         // The close-confirm popup takes precedence once open.
@@ -257,6 +304,7 @@ impl ScriptDialog {
                     let _ = self.interval.state.handle_events(modifiers, code);
                 }
                 ScriptDialogFocus::Table => match (modifiers, code) {
+                    (KeyModifiers::NONE, KeyCode::Enter) => self.request_rename(),
                     (KeyModifiers::NONE, KeyCode::Char('e')) => self.request_run(),
                     (KeyModifiers::NONE, KeyCode::Char('t')) => self.toggle_selected(),
                     (KeyModifiers::NONE, KeyCode::Char('c')) => self.toggle_compact(),
@@ -276,6 +324,13 @@ impl ScriptDialog {
                         let _ = self.name_input.state.handle_events(modifiers, code);
                     }
                 },
+                ScriptDialogFocus::TemplatesButton => {
+                    if let (KeyModifiers::NONE, KeyCode::Enter | KeyCode::Char(' ')) =
+                        (modifiers, code)
+                    {
+                        self.template_browser = Some(TemplateBrowser::new(self.context));
+                    }
+                }
                 // Code-focus keys were already offered to the editor above; anything
                 // reaching this arm was left unhandled by it.
                 ScriptDialogFocus::Code => {}
@@ -330,9 +385,10 @@ impl ScriptDialog {
         // editor right.
         let [left, right] =
             Layout::horizontal([Constraint::Max(50), Constraint::Min(1)]).areas(scripts_area);
-        let [interval_area, list_area, input_area] = Layout::vertical([
+        let [interval_area, list_area, input_area, button_area] = Layout::vertical([
             Constraint::Length(3),
             Constraint::Min(1),
+            Constraint::Length(3),
             Constraint::Length(3),
         ])
         .areas(left);
@@ -346,6 +402,9 @@ impl ScriptDialog {
         self.name_input
             .state
             .set_focused(self.focus == ScriptDialogFocus::NameInput);
+        self.templates_button
+            .state
+            .set_focused(self.focus == ScriptDialogFocus::TemplatesButton);
         self.code
             .state
             .set_focused(self.focus == ScriptDialogFocus::Code);
@@ -366,11 +425,25 @@ impl ScriptDialog {
             buf,
             &mut self.name_input.state,
         );
+        StatefulWidget::render(
+            &self.templates_button.widget,
+            button_area,
+            buf,
+            &mut self.templates_button.state,
+        );
         StatefulWidget::render(&self.code.widget, right, buf, &mut self.code.state);
         StatefulWidget::render(&self.log.widget, log_area, buf, &mut self.log.state);
 
         if let Some(confirm) = self.confirm.as_mut() {
             confirm.render(vc, buf);
+        }
+
+        if let Some(browser) = self.template_browser.as_mut() {
+            browser.render(area, buf);
+        }
+
+        if let Some(rename) = self.rename.as_mut() {
+            rename.render(area, buf);
         }
 
         if let Some(help) = self.lua_help.as_mut() {
@@ -530,6 +603,7 @@ mod tests {
         let expected = [
             ScriptDialogFocus::Table,
             ScriptDialogFocus::NameInput,
+            ScriptDialogFocus::TemplatesButton,
             ScriptDialogFocus::Code,
             ScriptDialogFocus::Log,
             ScriptDialogFocus::Interval,
@@ -546,6 +620,7 @@ mod tests {
         let expected = [
             ScriptDialogFocus::Log,
             ScriptDialogFocus::Code,
+            ScriptDialogFocus::TemplatesButton,
             ScriptDialogFocus::NameInput,
             ScriptDialogFocus::Table,
             ScriptDialogFocus::Interval,
@@ -562,10 +637,11 @@ mod tests {
         let mut d = ScriptDialog::new(&[], Duration::from_secs(1), ScriptContext::Modbus);
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // code skipped -> log
         assert_eq!(d.focus, ScriptDialogFocus::Log);
-        d.handle_events(KeyModifiers::SHIFT, KeyCode::BackTab); // code skipped -> name input
-        assert_eq!(d.focus, ScriptDialogFocus::NameInput);
+        d.handle_events(KeyModifiers::SHIFT, KeyCode::BackTab); // code skipped -> templates button
+        assert_eq!(d.focus, ScriptDialogFocus::TemplatesButton);
     }
 
     #[test]
@@ -617,6 +693,7 @@ mod tests {
         // Edit in the code editor, then come back to the table without leaving the dialog: the
         // run must see the edited buffer, not the code the script was created with.
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code editor
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('i')); // vim insert
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('x'));
@@ -737,6 +814,7 @@ mod tests {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
         assert_eq!(d.focus, ScriptDialogFocus::Code);
         assert_eq!(d.code.state.vim_mode(), VimMode::Normal);
@@ -749,6 +827,7 @@ mod tests {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
         assert_eq!(d.focus, ScriptDialogFocus::Code);
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('i'));
@@ -773,6 +852,7 @@ mod tests {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
         assert_eq!(d.focus, ScriptDialogFocus::Code);
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('i'));
@@ -786,6 +866,7 @@ mod tests {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
         assert_eq!(d.focus, ScriptDialogFocus::Code);
         assert_eq!(d.code.state.vim_mode(), VimMode::Normal);
@@ -814,6 +895,7 @@ mod tests {
 
         // From Code Insert mode: `?` is text.
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
         assert_eq!(d.focus, ScriptDialogFocus::Code);
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('i'));
@@ -834,11 +916,175 @@ mod tests {
             let mut d = dialog();
             d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
             d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+            d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
             d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> code
             d.handle_events(KeyModifiers::NONE, KeyCode::Char('?'));
             assert!(d.lua_help.is_some());
             assert!(!d.handle_events(KeyModifiers::NONE, close_key));
             assert!(d.lua_help.is_none());
         }
+    }
+
+    // --- templates ------------------------------------------------------
+
+    /// Tab to the Templates button (interval → table → name input → button).
+    fn focus_templates_button(d: &mut ScriptDialog) {
+        while d.focus != ScriptDialogFocus::TemplatesButton {
+            d.handle_events(KeyModifiers::NONE, KeyCode::Tab);
+        }
+    }
+
+    /// UI-R-052 — the Templates button sits in the focus cycle after the name input, and
+    /// `Enter`/`Space` on it opens the template browser.
+    #[test]
+    fn ut_templates_button_in_focus_cycle_and_opens_browser() {
+        for open_key in [KeyCode::Enter, KeyCode::Char(' ')] {
+            let mut d = dialog();
+            d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
+            d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> name input
+            d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> templates button
+            assert_eq!(d.focus, ScriptDialogFocus::TemplatesButton);
+
+            assert!(d.template_browser.is_none());
+            assert!(!d.handle_events(KeyModifiers::NONE, open_key));
+            assert!(d.template_browser.is_some(), "{open_key:?} must open it");
+        }
+    }
+
+    /// UI-R-053 — while the browser is open it takes every key: `Esc` closes it instead of opening
+    /// the dialog's close-confirm.
+    #[test]
+    fn ut_open_browser_takes_precedence_over_dialog_keys() {
+        let mut d = dialog();
+        focus_templates_button(&mut d);
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+
+        assert!(!d.handle_events(KeyModifiers::NONE, KeyCode::Esc));
+        assert!(d.template_browser.is_none(), "Esc closes the browser");
+        assert!(d.close_confirm.is_none(), "and not the dialog");
+    }
+
+    /// UI-R-054 — confirming a template appends it as a new enabled script, selects it, and leaves
+    /// the dialog open with the browser closed.
+    #[test]
+    fn ut_insert_template_appends_enabled_script() {
+        let mut d = dialog();
+        focus_templates_button(&mut d);
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter); // open browser
+        assert!(!d.handle_events(KeyModifiers::NONE, KeyCode::Enter)); // insert first template
+        assert!(d.template_browser.is_none());
+
+        let template = crate::script_template::templates(ScriptContext::Modbus)[0];
+        assert_eq!(d.selected(), Some(1), "the new script is selected");
+        let (scripts, _) = d.resolve();
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[1].name, template.name);
+        assert_eq!(scripts[1].code, template.code);
+        assert!(scripts[1].enabled);
+    }
+
+    /// UI-R-054 — inserting the same template twice suffixes the second rather than refusing it.
+    #[test]
+    fn ut_insert_duplicate_template_auto_suffixes() {
+        let mut d = dialog();
+        for _ in 0..2 {
+            focus_templates_button(&mut d);
+            d.handle_events(KeyModifiers::NONE, KeyCode::Enter); // open browser
+            d.handle_events(KeyModifiers::NONE, KeyCode::Enter); // insert
+        }
+        let template = crate::script_template::templates(ScriptContext::Modbus)[0];
+        let (scripts, _) = d.resolve();
+        assert_eq!(scripts.len(), 3);
+        assert_eq!(scripts[1].name, template.name);
+        assert_eq!(scripts[2].name, format!("{}-2", template.name));
+    }
+
+    // --- rename ---------------------------------------------------------
+
+    /// UI-R-055 — `Enter` on the script table opens a rename prompt pre-filled with the current
+    /// name; committing renames the script, preserving its code and enabled flag.
+    #[test]
+    fn ut_enter_on_table_renames_selected_script() {
+        let mut d = ScriptDialog::new(
+            &[ScriptDef {
+                name: "boot".into(),
+                code: "print('hi')".into(),
+                enabled: false,
+            }],
+            Duration::from_secs(1),
+            ScriptContext::Modbus,
+        );
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
+        assert!(!d.handle_events(KeyModifiers::NONE, KeyCode::Enter));
+        assert!(d.rename.is_some());
+
+        for c in ['-', '2'] {
+            d.handle_events(KeyModifiers::NONE, KeyCode::Char(c));
+        }
+        assert!(!d.handle_events(KeyModifiers::NONE, KeyCode::Enter));
+        assert!(d.rename.is_none(), "an accepted name closes the prompt");
+
+        let (scripts, _) = d.resolve();
+        assert_eq!(scripts[0].name, "boot-2");
+        assert_eq!(scripts[0].code, "print('hi')");
+        assert!(!scripts[0].enabled);
+    }
+
+    /// UI-R-055 — an empty or duplicate name is refused and the prompt stays open.
+    #[test]
+    fn ut_rename_refuses_empty_and_duplicate() {
+        let mut d = ScriptDialog::new(
+            &[
+                ScriptDef {
+                    name: "boot".into(),
+                    code: String::new(),
+                    enabled: true,
+                },
+                ScriptDef {
+                    name: "other".into(),
+                    code: String::new(),
+                    enabled: true,
+                },
+            ],
+            Duration::from_secs(1),
+            ScriptContext::Modbus,
+        );
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table (row 0: boot)
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter); // open the prompt
+
+        // Clear the field, then commit an empty name.
+        for _ in 0..4 {
+            d.handle_events(KeyModifiers::NONE, KeyCode::Backspace);
+        }
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+        assert!(d.rename.is_some(), "empty name must be refused");
+
+        // Type the other script's name: also refused.
+        for c in "other".chars() {
+            d.handle_events(KeyModifiers::NONE, KeyCode::Char(c));
+        }
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+        assert!(d.rename.is_some(), "duplicate name must be refused");
+
+        assert_eq!(d.scripts[0].name, "boot", "the name is unchanged");
+    }
+
+    /// UI-R-055 — `Esc` dismisses the prompt, leaving the name unchanged; with no script selected
+    /// `Enter` on the table is a no-op.
+    #[test]
+    fn ut_rename_esc_cancels_and_empty_table_is_noop() {
+        let mut d = dialog();
+        d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
+        d.handle_events(KeyModifiers::NONE, KeyCode::Enter);
+        d.handle_events(KeyModifiers::NONE, KeyCode::Char('x'));
+        assert!(!d.handle_events(KeyModifiers::NONE, KeyCode::Esc));
+        assert!(d.rename.is_none());
+        assert!(d.close_confirm.is_none(), "Esc belonged to the prompt");
+        assert_eq!(d.scripts[0].name, "boot");
+
+        let mut empty = ScriptDialog::new(&[], Duration::from_secs(1), ScriptContext::Modbus);
+        empty.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table (empty)
+        assert!(!empty.handle_events(KeyModifiers::NONE, KeyCode::Enter));
+        assert!(empty.rename.is_none());
     }
 }

--- a/ferrowl/src/dialog/template_browser.rs
+++ b/ferrowl/src/dialog/template_browser.rs
@@ -1,0 +1,385 @@
+//! The template-browser overlay of the script dialog (UI-R-053): the templates bundled for the
+//! dialog's script context on the left, a read-only preview of the selected one's Lua code on the
+//! right. `Enter` inserts the selection into the dialog's script list; `Esc`/`q` closes it.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use ferrowl_syntax::Language;
+use ferrowl_ui::{
+    Border, COLOR_SCHEME,
+    state::{CodeInputFieldState, CodeInputFieldStateBuilder, TableState, TableStateBuilder},
+    style::{InputFieldStyleBuilder, TableStyleBuilder},
+    traits::{HandleEvents, SetFocus},
+    widgets::{CodeInputField, CodeInputFieldBuilder, Table, TableBuilder, Widget},
+};
+use ferrowl_ui_derive::TableEntry;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, HorizontalAlignment, Layout, Margin, Rect},
+    widgets::{Block, Clear, StatefulWidget, Widget as UiWidget},
+};
+
+use crate::dialog::lua_help::ScriptContext;
+use crate::script_template::{ScriptTemplate, templates};
+use crate::view::border_style;
+
+#[derive(Clone, Debug, Default, TableEntry)]
+#[table_entry(header = TemplateHeader)]
+pub(crate) struct TemplateRow {
+    #[column(name = "Template", min = 12, max = 24)]
+    name: String,
+    #[column(name = "Description", min = 20, max = 60)]
+    description: String,
+}
+
+type TemplateTable = Widget<TableState<TemplateRow, 2>, Table<TemplateRow, TemplateHeader, 2>>;
+
+/// Which pane of the overlay has focus. The preview is focusable so a long template can be scrolled
+/// with the editor's own motions; it stays disabled, so it can never be edited.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BrowserFocus {
+    List,
+    Preview,
+}
+
+/// What the host dialog should do after feeding a key to an open browser.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TemplateBrowserEvent {
+    /// Key eaten, the overlay stays open.
+    Consumed,
+    /// `Esc`/`q`: drop the overlay, change nothing.
+    Close,
+    /// `Enter`: insert this template, then drop the overlay.
+    Insert(&'static ScriptTemplate),
+}
+
+/// Outcome of [`route_template_browser`], mirroring [`route_lua_help`](super::lua_help::route_lua_help).
+#[derive(Debug, PartialEq, Eq)]
+pub enum TemplateBrowserOutcome {
+    /// No overlay was open; the caller should route the key itself.
+    NotActive,
+    /// The overlay captured the key (closing itself if applicable).
+    Consumed,
+    /// The user picked a template; the caller should insert it. The overlay is already cleared.
+    Insert(&'static ScriptTemplate),
+}
+
+pub struct TemplateBrowser {
+    templates: Vec<&'static ScriptTemplate>,
+    table: TemplateTable,
+    preview: Widget<CodeInputFieldState, CodeInputField>,
+    focus: BrowserFocus,
+}
+
+impl TemplateBrowser {
+    /// Build the browser for `ctx`, listing only that context's templates (UI-R-053).
+    pub fn new(ctx: ScriptContext) -> Self {
+        let templates = templates(ctx);
+        let mut browser = Self {
+            table: template_table(rows(&templates)),
+            preview: preview_editor(),
+            templates,
+            focus: BrowserFocus::List,
+        };
+        browser.sync_preview();
+        browser
+    }
+
+    fn selected(&self) -> Option<&'static ScriptTemplate> {
+        let index = self.table.state.table_state().selected()?;
+        self.templates.get(index).copied()
+    }
+
+    /// Load the selected template's code into the (read-only) preview.
+    fn sync_preview(&mut self) {
+        let code = self.selected().map(|t| t.code).unwrap_or_default();
+        self.preview.state.set_content(code);
+    }
+
+    /// Feed one key while the overlay is open.
+    pub fn handle_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> TemplateBrowserEvent {
+        match (modifiers, code) {
+            (KeyModifiers::NONE, KeyCode::Esc) => return TemplateBrowserEvent::Close,
+            (KeyModifiers::NONE, KeyCode::Enter) => {
+                if let Some(template) = self.selected() {
+                    return TemplateBrowserEvent::Insert(template);
+                }
+                return TemplateBrowserEvent::Consumed;
+            }
+            (KeyModifiers::NONE, KeyCode::Tab)
+            | (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::BackTab) => {
+                self.focus = match self.focus {
+                    BrowserFocus::List => BrowserFocus::Preview,
+                    BrowserFocus::Preview => BrowserFocus::List,
+                };
+                return TemplateBrowserEvent::Consumed;
+            }
+            _ => {}
+        }
+
+        match self.focus {
+            BrowserFocus::List => {
+                // `q` closes only from the list: in the preview it is a (harmless) editor motion
+                // key, and the editor is where a stray `q` is most likely to be typed.
+                if let (KeyModifiers::NONE, KeyCode::Char('q')) = (modifiers, code) {
+                    return TemplateBrowserEvent::Close;
+                }
+                let _ = self.table.state.handle_events(modifiers, code);
+                self.sync_preview();
+            }
+            BrowserFocus::Preview => {
+                // The preview is a disabled editor: motions work, edits are refused (UI-R-036).
+                let _ = self.preview.state.handle_events(modifiers, code);
+            }
+        }
+        TemplateBrowserEvent::Consumed
+    }
+
+    /// Render the overlay as a centered popup over `area`.
+    pub fn render(&mut self, area: Rect, buf: &mut Buffer) {
+        let [_, hc, _] = Layout::horizontal([
+            Constraint::Percentage(8),
+            Constraint::Percentage(84),
+            Constraint::Percentage(8),
+        ])
+        .areas(area);
+        let [_, vc, _] = Layout::vertical([
+            Constraint::Percentage(8),
+            Constraint::Percentage(84),
+            Constraint::Percentage(8),
+        ])
+        .areas(hc);
+
+        UiWidget::render(&Clear, vc, buf);
+        let block = Block::bordered()
+            .style(
+                ratatui::prelude::Style::default()
+                    .fg(COLOR_SCHEME.hi)
+                    .bg(COLOR_SCHEME.bg),
+            )
+            .title_alignment(HorizontalAlignment::Center)
+            .title(" Templates (Enter: insert, Tab: preview, Esc/q: close) ");
+        let block_inner = block.inner(vc);
+        block.render(vc, buf);
+        let inner = block_inner.inner(Margin {
+            vertical: 1,
+            horizontal: 2,
+        });
+
+        let [list_area, preview_area] =
+            Layout::horizontal([Constraint::Max(50), Constraint::Min(1)]).areas(inner);
+
+        self.table
+            .state
+            .set_focused(self.focus == BrowserFocus::List);
+        self.preview
+            .state
+            .set_focused(self.focus == BrowserFocus::Preview);
+
+        StatefulWidget::render(&self.table.widget, list_area, buf, &mut self.table.state);
+        StatefulWidget::render(
+            &self.preview.widget,
+            preview_area,
+            buf,
+            &mut self.preview.state,
+        );
+    }
+}
+
+/// Feed one key through `browser`, if the template browser is open. Clears `*browser` on close and
+/// on insert (the overlay is single-use, like the other script-dialog popups).
+pub fn route_template_browser(
+    browser: &mut Option<TemplateBrowser>,
+    modifiers: KeyModifiers,
+    code: KeyCode,
+) -> TemplateBrowserOutcome {
+    let Some(b) = browser.as_mut() else {
+        return TemplateBrowserOutcome::NotActive;
+    };
+    match b.handle_key(modifiers, code) {
+        TemplateBrowserEvent::Consumed => TemplateBrowserOutcome::Consumed,
+        TemplateBrowserEvent::Close => {
+            *browser = None;
+            TemplateBrowserOutcome::Consumed
+        }
+        TemplateBrowserEvent::Insert(template) => {
+            *browser = None;
+            TemplateBrowserOutcome::Insert(template)
+        }
+    }
+}
+
+fn rows(templates: &[&'static ScriptTemplate]) -> Vec<TemplateRow> {
+    templates
+        .iter()
+        .map(|t| TemplateRow {
+            name: t.name.to_string(),
+            description: t.description.to_string(),
+        })
+        .collect()
+}
+
+fn template_table(rows: Vec<TemplateRow>) -> TemplateTable {
+    Widget {
+        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        widget: TableBuilder::default()
+            .border(Border::Full(Margin::new(1, 0)))
+            .title(Some("Templates".into()))
+            .style(TableStyleBuilder::default().build().unwrap())
+            .row_margin(Margin {
+                vertical: 0,
+                horizontal: 0,
+            })
+            .build()
+            .unwrap(),
+    }
+}
+
+/// The preview pane: a Lua code editor kept `disabled`, i.e. read-only (UI-R-036).
+fn preview_editor() -> Widget<CodeInputFieldState, CodeInputField> {
+    Widget {
+        state: CodeInputFieldStateBuilder::default()
+            .focused(false)
+            .disabled(true)
+            .placeholder(Some("-- no template selected".to_string()))
+            .language(Some(Language::Lua))
+            .build()
+            .unwrap(),
+        widget: CodeInputFieldBuilder::default()
+            .border(Border::Full(Margin::new(1, 0)))
+            .title(Some("Preview".into()))
+            .style(
+                InputFieldStyleBuilder::default()
+                    .border(border_style())
+                    .build()
+                    .unwrap(),
+            )
+            .margin(Margin {
+                vertical: 0,
+                horizontal: 0,
+            })
+            .build()
+            .unwrap(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_ui::state::VimMode;
+
+    /// UI-R-053 — the browser lists only the templates of its own script context.
+    #[test]
+    fn ut_lists_only_context_templates() {
+        let browser = TemplateBrowser::new(ScriptContext::Modbus);
+        assert!(!browser.templates.is_empty());
+        for template in &browser.templates {
+            assert!(
+                template.contexts.contains(&ScriptContext::Modbus),
+                "'{}' is not a modbus template",
+                template.name
+            );
+        }
+    }
+
+    /// UI-R-053 — the preview shows the selected template's code and cannot be edited.
+    #[test]
+    fn ut_preview_is_read_only_and_follows_selection() {
+        let mut browser = TemplateBrowser::new(ScriptContext::Modbus);
+        let first = browser.selected().unwrap();
+        assert_eq!(browser.preview.state.content().trim(), first.code.trim());
+        assert!(browser.preview.state.disabled());
+
+        // Typing into the focused preview must not change it.
+        browser.focus = BrowserFocus::Preview;
+        let before = browser.preview.state.content();
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Char('i'));
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Char('x'));
+        assert_eq!(browser.preview.state.content(), before);
+
+        // Moving the selection re-loads the preview.
+        browser.focus = BrowserFocus::List;
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Down);
+        let second = browser.selected().unwrap();
+        assert_ne!(second.name, first.name);
+        assert_eq!(browser.preview.state.content().trim(), second.code.trim());
+    }
+
+    /// UI-R-053 — `Esc` and `q` close the overlay without picking anything.
+    #[test]
+    fn ut_esc_and_q_close() {
+        let mut browser = TemplateBrowser::new(ScriptContext::Session);
+        assert_eq!(
+            browser.handle_key(KeyModifiers::NONE, KeyCode::Esc),
+            TemplateBrowserEvent::Close
+        );
+        assert_eq!(
+            browser.handle_key(KeyModifiers::NONE, KeyCode::Char('q')),
+            TemplateBrowserEvent::Close
+        );
+    }
+
+    /// UI-R-054 — `Enter` yields the selected template for insertion.
+    #[test]
+    fn ut_enter_yields_selected_template() {
+        let mut browser = TemplateBrowser::new(ScriptContext::Session);
+        let selected = browser.selected().unwrap();
+        assert_eq!(
+            browser.handle_key(KeyModifiers::NONE, KeyCode::Enter),
+            TemplateBrowserEvent::Insert(selected)
+        );
+    }
+
+    #[test]
+    fn ut_tab_cycles_list_and_preview() {
+        let mut browser = TemplateBrowser::new(ScriptContext::Modbus);
+        assert_eq!(browser.focus, BrowserFocus::List);
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Tab);
+        assert_eq!(browser.focus, BrowserFocus::Preview);
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Tab);
+        assert_eq!(browser.focus, BrowserFocus::List);
+    }
+
+    #[test]
+    fn ut_route_not_active_when_none() {
+        let mut browser: Option<TemplateBrowser> = None;
+        assert_eq!(
+            route_template_browser(&mut browser, KeyModifiers::NONE, KeyCode::Enter),
+            TemplateBrowserOutcome::NotActive
+        );
+    }
+
+    #[test]
+    fn ut_route_insert_clears_overlay() {
+        let mut browser = Some(TemplateBrowser::new(ScriptContext::Session));
+        let outcome = route_template_browser(&mut browser, KeyModifiers::NONE, KeyCode::Enter);
+        assert!(matches!(outcome, TemplateBrowserOutcome::Insert(_)));
+        assert!(browser.is_none());
+    }
+
+    #[test]
+    fn ut_route_close_clears_overlay() {
+        let mut browser = Some(TemplateBrowser::new(ScriptContext::Session));
+        assert_eq!(
+            route_template_browser(&mut browser, KeyModifiers::NONE, KeyCode::Esc),
+            TemplateBrowserOutcome::Consumed
+        );
+        assert!(browser.is_none());
+    }
+
+    #[test]
+    fn ut_render_does_not_panic() {
+        let mut browser = TemplateBrowser::new(ScriptContext::OcppServer);
+        let area = Rect::new(0, 0, 100, 30);
+        let mut buf = Buffer::empty(area);
+        browser.render(area, &mut buf);
+    }
+
+    #[test]
+    fn ut_preview_stays_in_normal_mode() {
+        // Sanity: a disabled vim editor never leaves Normal mode, so `i` cannot start typing.
+        let mut browser = TemplateBrowser::new(ScriptContext::Modbus);
+        browser.focus = BrowserFocus::Preview;
+        browser.handle_key(KeyModifiers::NONE, KeyCode::Char('i'));
+        assert_eq!(browser.preview.state.vim_mode(), VimMode::Normal);
+    }
+}

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -16,6 +16,7 @@ mod lua;
 mod migrate;
 mod module;
 mod registry;
+mod script_template;
 #[cfg(test)]
 mod session_e2e_tests;
 mod session_sim;
@@ -159,54 +160,15 @@ fn demo_ocpp_tab(name: String, version: OcppVersion, role: OcppRole, port: u16) 
     Tab::new_from_view(spec.name.clone(), view)
 }
 
-/// The demo session's example script: uses `C_Module` to read the `Power` value of every modbus
-/// server instance and every OCPP connector (client-side connector 1, server-side all connectors
-/// of every connected station), printing them to the session log once per cycle. Reads are
-/// `pcall`-guarded so a scope without the field (e.g. a client whose connection is down) logs
-/// nothing instead of erroring every cycle.
+/// The demo session's example script: the bundled `power-report` template (SC-R-036), which uses
+/// `C_Module` to read the `Power` value of every modbus server instance and every OCPP connector,
+/// printing the total to the session log once per cycle.
 fn demo_session_script() -> crate::config::script::ScriptDef {
+    let template = script_template::by_name("power-report")
+        .expect("the bundled power-report session template");
     crate::config::script::ScriptDef {
-        name: "power-report".to_string(),
-        code: r#"-- Demo: read `Power` from every modbus server and OCPP connector via C_Module.
-local total_power = 0
-local num_modbus = 0
-local num_ocpp = 0
-
--- Go over all modules
-for _, name in ipairs(C_Module:List()) do
-    -- Get module context
-    local m = C_Module:Get(name)
-    local ty = m:Type()
-    local r = m:Role()
-
-    if ty == "modbus" and r == "server" then
-        -- Get power of modbus charger
-        local reg = m:Register()
-
-        -- Check if register exists before access
-        if reg:Has("Power") then
-            total_power = total_power + reg:Get("Power")
-        end
-
-        num_modbus = num_modbus + 1
-    elseif ty == "ocpp" and r == "client" then
-        -- Get power of ocpp charger
-        local o = m:OCPP()
-
-        -- Get all available connector ids
-        for _, i in ipairs(o:GetConnectors()) do
-            -- Get connector context
-            local con = o:Connector(i)
-            total_power = total_power + con:Get("Power")
-
-            num_ocpp = num_ocpp + 1
-        end
-    end
-end
-
--- Print to log
-print("[M" .. num_modbus .. "|O" .. num_ocpp .. "] Total Power = " .. total_power)"#
-            .to_string(),
+        name: template.name.to_string(),
+        code: template.code.to_string(),
         enabled: true,
     }
 }

--- a/ferrowl/src/script_template.rs
+++ b/ferrowl/src/script_template.rs
@@ -1,0 +1,146 @@
+//! The bundled Lua script templates (SC-R-036): starting points a user can drop into a module's
+//! script list from the script dialog's template browser.
+//!
+//! A template is *not* a script: its code is compiled into the binary and only ever **copied** into
+//! a [`ScriptDef`](crate::config::script::ScriptDef) — nothing reads template code from disk at run
+//! time, so scripts stay stored inline in the config files (SC-R-023).
+
+use crate::dialog::lua_help::ScriptContext;
+
+/// One bundled template: its display name, a one-line description, the script contexts it applies
+/// to, and its Lua code.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ScriptTemplate {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub contexts: &'static [ScriptContext],
+    pub code: &'static str,
+}
+
+static TEMPLATES: &[ScriptTemplate] = &[
+    ScriptTemplate {
+        name: "register-mirror",
+        description: "Copy one register's value into another every cycle",
+        contexts: &[ScriptContext::Modbus],
+        code: include_str!("../templates/modbus/register-mirror.lua"),
+    },
+    ScriptTemplate {
+        name: "register-ramp",
+        description: "Ramp a register up and down between two bounds",
+        contexts: &[ScriptContext::Modbus],
+        code: include_str!("../templates/modbus/register-ramp.lua"),
+    },
+    ScriptTemplate {
+        name: "sine-wave",
+        description: "Drive a register with a clock-derived sine wave",
+        contexts: &[ScriptContext::Modbus],
+        code: include_str!("../templates/modbus/sine-wave.lua"),
+    },
+    ScriptTemplate {
+        name: "meter-values",
+        description: "Set each connector's Power and send MeterValues",
+        contexts: &[ScriptContext::OcppClient],
+        code: include_str!("../templates/ocpp-client/meter-values.lua"),
+    },
+    ScriptTemplate {
+        name: "transaction-cycle",
+        description: "Start/stop a transaction on connector 1 in a loop",
+        contexts: &[ScriptContext::OcppClient],
+        code: include_str!("../templates/ocpp-client/transaction-cycle.lua"),
+    },
+    ScriptTemplate {
+        name: "station-report",
+        description: "Sum the Power reported by every connected station",
+        contexts: &[ScriptContext::OcppServer],
+        code: include_str!("../templates/ocpp-server/station-report.lua"),
+    },
+    ScriptTemplate {
+        name: "power-report",
+        description: "Sum Power across every modbus server and OCPP connector",
+        contexts: &[ScriptContext::Session],
+        code: include_str!("../templates/session/power-report.lua"),
+    },
+    ScriptTemplate {
+        name: "module-inventory",
+        description: "List every module in the session with its type and role",
+        contexts: &[ScriptContext::Session],
+        code: include_str!("../templates/session/module-inventory.lua"),
+    },
+];
+
+/// The templates applicable to `ctx`, in declaration order.
+pub fn templates(ctx: ScriptContext) -> Vec<&'static ScriptTemplate> {
+    TEMPLATES
+        .iter()
+        .filter(|t| t.contexts.contains(&ctx))
+        .collect()
+}
+
+/// The bundled session template the `--demo` session script is built from.
+pub fn by_name(name: &str) -> Option<&'static ScriptTemplate> {
+    TEMPLATES.iter().find(|t| t.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTEXTS: [ScriptContext; 4] = [
+        ScriptContext::Modbus,
+        ScriptContext::OcppClient,
+        ScriptContext::OcppServer,
+        ScriptContext::Session,
+    ];
+
+    /// SC-R-037 — every bundled template's code body loads in the Lua runtime; a syntax error in a
+    /// template is a test failure, never something a user meets after inserting it.
+    #[test]
+    fn ut_every_template_compiles() {
+        for template in TEMPLATES {
+            let ctx = ferrowl_lua::ContextBuilder::<String>::default()
+                .with_stdlib()
+                .with_script(template.name.to_string(), template.code)
+                .build();
+            assert!(
+                ctx.is_ok(),
+                "template '{}' failed to load: {:?}",
+                template.name,
+                ctx.err()
+            );
+        }
+    }
+
+    /// SC-R-036 — `templates(ctx)` returns exactly the templates declaring `ctx`.
+    #[test]
+    fn ut_templates_filtered_by_context() {
+        for ctx in CONTEXTS {
+            for template in templates(ctx) {
+                assert!(
+                    template.contexts.contains(&ctx),
+                    "'{}' listed under {ctx:?} without declaring it",
+                    template.name
+                );
+            }
+        }
+        let modbus: Vec<_> = templates(ScriptContext::Modbus)
+            .iter()
+            .map(|t| t.name)
+            .collect();
+        assert!(modbus.contains(&"register-ramp"));
+        assert!(!modbus.contains(&"power-report"));
+    }
+
+    /// SC-R-036 — every script context has at least one template, so the browser is never empty.
+    #[test]
+    fn ut_every_context_has_a_template() {
+        for ctx in CONTEXTS {
+            assert!(!templates(ctx).is_empty(), "{ctx:?} has no template");
+        }
+    }
+
+    #[test]
+    fn ut_by_name_finds_bundled_template() {
+        assert!(by_name("power-report").is_some());
+        assert!(by_name("nope").is_none());
+    }
+}

--- a/ferrowl/src/script_template.rs
+++ b/ferrowl/src/script_template.rs
@@ -37,6 +37,12 @@ static TEMPLATES: &[ScriptTemplate] = &[
         code: include_str!("../templates/modbus/sine-wave.lua"),
     },
     ScriptTemplate {
+        name: "apply-limit",
+        description: "Reflect given limit as actual measurements.",
+        contexts: &[ScriptContext::Modbus],
+        code: include_str!("../templates/modbus/apply-limit.lua"),
+    },
+    ScriptTemplate {
         name: "meter-values",
         description: "Set each connector's Power and send MeterValues",
         contexts: &[ScriptContext::OcppClient],

--- a/ferrowl/templates/modbus/apply-limit.lua
+++ b/ferrowl/templates/modbus/apply-limit.lua
@@ -1,0 +1,47 @@
+-- Script to apply a given input limit as the current power draw
+-- Created By: @TumbleOwlee
+
+-- If condition is false, all target registers are set to 0
+local condition = true
+
+-- Register definitions, set nil for unsupported
+local set_point = "SetPoint"
+local set_point_unit = "A" -- or "W"
+local set_point_resolution = 1
+
+-- Actual values
+local power_resolution = 3.0 -- for 3 phases
+local power = "Power"
+
+local current_resolution = 1
+local current_l1 = "Current L1"
+local current_l2 = "Current L2"
+local current_l3 = "Current L3"
+
+-- Get current limit
+local limit_a = C_Register:Get(set_point) * set_point_resolution
+
+if set_point_unit == "W" then
+    limit_a = limit_a / 230.0
+end
+
+if not condition then
+    limit_a = 0
+end
+
+-- Set all values
+if current_l1 then
+    C_Register:Set(current_l1, limit_a * current_resolution)
+end
+
+if current_l2 then
+    C_Register:Set(current_l2, limit_a * current_resolution)
+end
+
+if current_l3 then
+    C_Register:Set(current_l3, limit_a * current_resolution)
+end
+
+if power then
+    C_Register:Set(power, limit_a * 230.0 * power_resolution)
+end

--- a/ferrowl/templates/modbus/register-mirror.lua
+++ b/ferrowl/templates/modbus/register-mirror.lua
@@ -1,7 +1,7 @@
 -- Mirror one register into another every cycle.
 -- Adjust the names to registers this device actually has.
-local SOURCE = "setpoint"
-local TARGET = "power"
+local SOURCE = "SetPoint"
+local TARGET = "Power"
 
 if C_Register:Has(SOURCE) and C_Register:Has(TARGET) then
     C_Register:Set(TARGET, C_Register:Get(SOURCE))

--- a/ferrowl/templates/modbus/register-mirror.lua
+++ b/ferrowl/templates/modbus/register-mirror.lua
@@ -1,0 +1,10 @@
+-- Mirror one register into another every cycle.
+-- Adjust the names to registers this device actually has.
+local SOURCE = "setpoint"
+local TARGET = "power"
+
+if C_Register:Has(SOURCE) and C_Register:Has(TARGET) then
+    C_Register:Set(TARGET, C_Register:Get(SOURCE))
+else
+    C_Log:Warn("register-mirror: '" .. SOURCE .. "' or '" .. TARGET .. "' does not exist")
+end

--- a/ferrowl/templates/modbus/register-ramp.lua
+++ b/ferrowl/templates/modbus/register-ramp.lua
@@ -1,0 +1,25 @@
+-- Ramp a register up and down between two bounds, one step per sim cycle.
+-- The sim restarts with fresh globals on every script edit, so `direction` restarts too.
+local REGISTER = "power"
+local MIN = 0
+local MAX = 100
+local STEP = 5
+
+direction = direction or 1
+
+if not C_Register:Has(REGISTER) then
+    C_Log:Warn("register-ramp: no register '" .. REGISTER .. "'")
+    return
+end
+
+local value = C_Register:Get(REGISTER) + STEP * direction
+
+if value >= MAX then
+    value = MAX
+    direction = -1
+elseif value <= MIN then
+    value = MIN
+    direction = 1
+end
+
+C_Register:Set(REGISTER, value)

--- a/ferrowl/templates/modbus/register-ramp.lua
+++ b/ferrowl/templates/modbus/register-ramp.lua
@@ -1,6 +1,6 @@
 -- Ramp a register up and down between two bounds, one step per sim cycle.
 -- The sim restarts with fresh globals on every script edit, so `direction` restarts too.
-local REGISTER = "power"
+local REGISTER = "Power"
 local MIN = 0
 local MAX = 100
 local STEP = 5

--- a/ferrowl/templates/modbus/sine-wave.lua
+++ b/ferrowl/templates/modbus/sine-wave.lua
@@ -1,5 +1,5 @@
 -- Drive a register with a sine wave derived from the module clock.
-local REGISTER = "power"
+local REGISTER = "Power"
 local AMPLITUDE = 50
 local OFFSET = 50
 local PERIOD = 60 -- seconds per full wave

--- a/ferrowl/templates/modbus/sine-wave.lua
+++ b/ferrowl/templates/modbus/sine-wave.lua
@@ -1,0 +1,15 @@
+-- Drive a register with a sine wave derived from the module clock.
+local REGISTER = "power"
+local AMPLITUDE = 50
+local OFFSET = 50
+local PERIOD = 60 -- seconds per full wave
+
+if not C_Register:Has(REGISTER) then
+    C_Log:Warn("sine-wave: no register '" .. REGISTER .. "'")
+    return
+end
+
+local t = C_Time:Get()
+local value = OFFSET + AMPLITUDE * math.sin(2 * math.pi * t / PERIOD)
+
+C_Register:Set(REGISTER, value)

--- a/ferrowl/templates/ocpp-client/meter-values.lua
+++ b/ferrowl/templates/ocpp-client/meter-values.lua
@@ -1,0 +1,9 @@
+-- Raise the meter reading of every connector and send MeterValues once per cycle.
+local POWER = 11000 -- W, written to each connector before reporting
+
+for _, id in ipairs(C_OCPP:GetConnectors()) do
+    local con = C_OCPP:Connector(id)
+
+    con:Set("Power", POWER)
+    con:MeterValues()
+end

--- a/ferrowl/templates/ocpp-client/transaction-cycle.lua
+++ b/ferrowl/templates/ocpp-client/transaction-cycle.lua
@@ -1,0 +1,28 @@
+-- Charge in a loop on connector 1: start a transaction, run for CHARGE_S, stop, idle for IDLE_S.
+-- Globals reset whenever the script is edited, so the cycle restarts from Idle.
+local CONNECTOR = 1
+local CHARGE_S = 30
+local IDLE_S = 10
+local ID_TAG = "ABC123"
+
+phase = phase or "idle"
+since = since or C_Time:Get()
+
+local con = C_OCPP:Connector(CONNECTOR)
+local now = C_Time:Get()
+
+if phase == "idle" and now - since >= IDLE_S then
+    con:StartTransaction({ idTag = ID_TAG })
+    C_Log:Info("transaction-cycle: started on connector " .. CONNECTOR)
+    phase = "charging"
+    since = now
+elseif phase == "charging" then
+    con:MeterValues()
+
+    if now - since >= CHARGE_S then
+        con:StopTransaction()
+        C_Log:Info("transaction-cycle: stopped on connector " .. CONNECTOR)
+        phase = "idle"
+        since = now
+    end
+end

--- a/ferrowl/templates/ocpp-server/station-report.lua
+++ b/ferrowl/templates/ocpp-server/station-report.lua
@@ -1,0 +1,20 @@
+-- Report every connected charging station and the Power its connectors report.
+local total = 0
+local stations = C_OCPP:GetChargingStations()
+
+for _, cs in ipairs(stations) do
+    for _, id in ipairs(C_OCPP:GetConnectors(cs)) do
+        local con = C_OCPP:Connector(cs, id)
+
+        -- A connector that has not reported yet has no Power field: guard the read.
+        local ok, power = pcall(function()
+            return con:Get("Power")
+        end)
+
+        if ok and power then
+            total = total + power
+        end
+    end
+end
+
+print("[" .. #stations .. " stations] Total Power = " .. total)

--- a/ferrowl/templates/session/module-inventory.lua
+++ b/ferrowl/templates/session/module-inventory.lua
@@ -1,0 +1,6 @@
+-- List every module in the session with its type and role, once per cycle.
+for _, name in ipairs(C_Module:List()) do
+    local m = C_Module:Get(name)
+
+    print(name .. ": " .. m:Type() .. "/" .. m:Role())
+end

--- a/ferrowl/templates/session/power-report.lua
+++ b/ferrowl/templates/session/power-report.lua
@@ -1,0 +1,39 @@
+-- Demo: read `Power` from every modbus server and OCPP connector via C_Module.
+local total_power = 0
+local num_modbus = 0
+local num_ocpp = 0
+
+-- Go over all modules
+for _, name in ipairs(C_Module:List()) do
+    -- Get module context
+    local m = C_Module:Get(name)
+    local ty = m:Type()
+    local r = m:Role()
+
+    if ty == "modbus" and r == "server" then
+        -- Get power of modbus charger
+        local reg = m:Register()
+
+        -- Check if register exists before access
+        if reg:Has("Power") then
+            total_power = total_power + reg:Get("Power")
+        end
+
+        num_modbus = num_modbus + 1
+    elseif ty == "ocpp" and r == "client" then
+        -- Get power of ocpp charger
+        local o = m:OCPP()
+
+        -- Get all available connector ids
+        for _, i in ipairs(o:GetConnectors()) do
+            -- Get connector context
+            local con = o:Connector(i)
+            total_power = total_power + con:Get("Power")
+
+            num_ocpp = num_ocpp + 1
+        end
+    end
+end
+
+-- Print to log
+print("[M" .. num_modbus .. "|O" .. num_ocpp .. "] Total Power = " .. total_power)


### PR DESCRIPTION
Closes #61

## Why

The script dialog dropped users into an empty Lua editor with nothing to start from — the repo carried no `.lua` files at all, and the only way to learn the `C_*` API was the `?` overlay plus guesswork. This ships a template library, a browser to pick from it, and — since a script's name was previously fixed at creation — a rename prompt.

## What

- **Template library** (`SC-R-036`, `SC-R-037`) — eight Lua templates in `ferrowl/templates/`, compiled in with `include_str!` (no new dependency). Each declares its applicable script contexts. A test loads every template through the Lua runtime, so a broken template fails CI rather than the user.
- **Templates button + browser overlay** (`UI-R-052`, `UI-R-053`, `UI-R-054`) — a focusable button in the dialog's Tab cycle; the overlay lists only the current context's templates with a read-only, syntax-highlighted preview (a `disabled` code editor, so vim motions work and edits don't). Enter copies the template in as a new enabled script; a name collision auto-suffixes (`power-report-2`) rather than silently no-op'ing.
- **Script rename** (`UI-R-055`) — `Enter` on the script table opens a prompt pre-filled with the current name; empty or duplicate names are refused and the prompt stays open.
- The demo's `power-report` script now *is* the bundled session template, replacing a raw string literal in `main.rs`.

Templates are copied inline into the config — SC-R-023 (scripts stored inline, never as external `.lua` files) is untouched.

## Verification

`cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` — all green.

Driven in the real TUI (`--demo`, under tmux), not just tests:

- Session dialog listed only its 2 session templates; inserting `power-report` (already present in the demo) landed as `power-report-2`, selected, code loaded.
- Rename: prompt opened pre-filled, `power-report` was refused with the prompt staying open, `power-report-v2` committed.
- Modbus tab listed exactly `register-mirror`, `register-ramp`, `sine-wave` — no OCPP or session templates.
- Inserted `register-ramp`, closed the dialog, watched the Power register ramp 10 → 20 → 30 → 40.

That last check caught a real bug: the Modbus templates defaulted to `power`/`setpoint` (the naming in `configs/evse.toml`), but the demo device names them `Power`/`SetPoint`, so the ramp correctly warned and did nothing. Defaults changed to the capitalized names — third commit.

## Notes

Planned an OCPP-server `broadcast-remote-start` template but shipped `station-report` instead: server action names vary by OCPP version, so a template hardcoding one would break on the others, while a read-only report over `GetChargingStations`/`GetConnectors` works across all of them. The spec doesn't enumerate templates, so this isn't a spec change.

Merge as a **squash merge** per AGENTS.md, so the branch's spec-ahead-of-code commit never reaches `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
