### PR TITLE
ci: enforce fmt and clippy, run the check pipeline on pull requests

### DIFF
--- a/.woodpecker/check.yml
+++ b/.woodpecker/check.yml
@@ -1,11 +1,27 @@
+when:
+  - event: push
+  - event: pull_request
+  - event: manual
+
 steps:
+  fmt:
+    image: rust:latest
+    commands:
+      - rustup component add rustfmt
+      - cargo fmt --check
+
+  clippy:
+    image: rust:latest
+    commands:
+      - rustup component add clippy
+      - cargo clippy --workspace -- -D warnings
+
   check:
     image: rust:latest
     commands:
       - cargo check
+
+  test:
+    image: rust:latest
+    commands:
       - cargo test
-    when:
-      - event: push
-      - event: manual
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,13 @@ expected to conform to it. Before changing behavior, read the relevant area's
 Please make sure the following pass locally:
 
 ```sh
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
 cargo check
 cargo test --workspace
-cargo clippy --workspace
-cargo fmt --check
 ```
 
-CI runs `cargo check` and `cargo test` on every push (`check` workflow); a `nightly` workflow (only run on `main`) builds the prebuilt executables published on the Release page.
+CI runs all four as separate steps of the `check` pipeline — on every push **and every pull request** — so anything the pre-commit hook would reject is rejected by CI too. A `nightly` workflow (only run on `main`) builds the prebuilt executables published on the Release page.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Why

The check pipeline ran only `cargo check` + `cargo test`, on `push` and `manual`.

- clippy and rustfmt lived only in the `lefthook` pre-commit hook, which is skipped by
  anyone who has not installed lefthook and by any `git commit --no-verify`. Lint and
  format regressions could land on `main` with a fully green pipeline — while
  `AGENTS.md` and `CONTRIBUTING.md` both claim CI enforces `-D warnings`.
- Pull requests had no trigger at all, so a contributor got no build, no tests and no
  lints until after merge, when the push pipeline fired on `main`.

Now: what the pre-commit hook rejects, CI rejects too, and it rejects it before merge.

## Requirements

None — tooling only, no change to `ferrowl` behavior and no `docs/specs/` impact.

## What changed

- `.woodpecker/check.yml` — one step per tool (`fmt`, `clippy`, `check`, `test`) so a red
  pipeline names the failing tool without opening the log. Steps run sequentially on a
  shared workspace, so `target/` carries between them rather than rebuilding four times.
  The trigger is hoisted to a pipeline-level `when:` and gains `pull_request`.
- `CONTRIBUTING.md` — "Before Submitting" claimed CI runs only check and test, and listed
  `cargo clippy --workspace` *without* `-D warnings`, so a contributor could run the
  documented commands and still be rejected by CI. It now matches the pipeline exactly.

No secrets are added. A Rust build executes arbitrary code from the branch under test
(`build.rs`, proc macros), so a pipeline running a fork's code must have nothing to leak;
the check pipeline needs no credentials. Approval-for-outside-contributors stays enabled
(a Woodpecker repo setting, not a file), so a fork's pipeline only runs after a maintainer
has looked at the diff.

## Verification

Ran the four new steps locally, exactly as CI will:

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace -- -D warnings` | clean |
| `cargo check` | clean |
| `cargo test` | pass |

The workspace is already clippy-clean at `--workspace` scope (wider than lefthook's plain
`cargo clippy`), so the stricter pipeline goes green rather than red on merge. YAML parses;
steps resolve in order with the trigger carrying `push`, `pull_request`, `manual`.

This PR is itself the end-to-end test of the `pull_request` trigger: it should show four
separate steps, each green.

Closes #65
Closes #66
