### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+Ferrowl is spec-driven: docs/specs/ is the authoritative statement of what the
+software must do. See CONTRIBUTING.md for the full expectations.
+Delete any section that genuinely does not apply.
+-->
+
+## Why
+
+<!-- The problem this solves, not a restatement of the diff. -->
+
+## Requirements
+
+<!--
+New or changed requirement IDs (MB-R-*, OC-R-*, UI-R-*, ...), each quoted with its
+normative text so a reviewer does not have to go look it up. Mark changes old -> new.
+Write "None — no behavior change." for a refactor, docs or tooling PR.
+-->
+
+- `XX-R-000` — "The system shall …"
+
+## Verification
+
+<!--
+What you actually ran, not what could have been run. Be specific: the tests that pin
+the new requirements, driving the demo TUI (`cargo run --release -- --demo`), a real
+CSMS, a physical device. Paste the outcome if it is interesting.
+-->
+
+## Checklist
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --workspace -- -D warnings`
+- [ ] `cargo check`
+- [ ] `cargo test --workspace`
+- [ ] Spec updated in `docs/specs/<area>/` — a behavior change with no spec change is incomplete
+- [ ] Each new or changed requirement has a test whose doc comment cites its ID
+- [ ] README updated, if user-facing commands, keybindings, config fields or the Lua API changed
+
+Closes #


### PR DESCRIPTION
## Why

The repo has issue templates but no PR template. `CONTRIBUTING.md` and `AGENTS.md` describe
what a PR must explain — why the change exists, which requirement IDs it adds or changes,
how it was actually verified, and the issue it closes — but the PR form asked for none of
it, so it depended on the author remembering. A contributor is now prompted for exactly
what review needs.

## Requirements

None — documentation only.

## What changed

New `.github/PULL_REQUEST_TEMPLATE.md` (GitHub picks it up by name; no config change) with
**Why**, **Requirements** (IDs quoted with their normative text, so a reviewer need not go
look them up), **Verification** (what was actually run, not what could have been), a
checklist mirroring CONTRIBUTING's "Before Submitting" plus the AGENTS.md rule that each new
requirement ships with a test citing its ID, and `Closes #`.

Wording tracks `CONTRIBUTING.md` so the two do not drift apart.

## Verification

Documentation only — nothing to execute. The template renders in the *Compare & pull
request* form; note it will only pre-fill PRs opened **after** this merges, so this PR's own
body is written by hand to the same shape.

Closes #67
