### PR TITLE
docs(agents): describe what CI actually enforces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,8 @@ cargo check -p ferrowl-ocpp               # typecheck one crate
 ```
 
 Run these before considering work done — `lefthook` enforces `fmt --check` and
-`clippy -D warnings` pre-commit; CI runs `check` + `test` on every push.
+`clippy -D warnings` pre-commit, and CI runs all four as separate steps of the `check`
+pipeline on every push **and every pull request**, so a lint failure is caught either way.
 
 Dev loop: `cargo run --release -- --demo` (built-in demo tabs, no config needed) or
 `cargo build --profile fastrel` for faster iterative builds (opt-level 1).


### PR DESCRIPTION
## Why

`AGENTS.md`'s Build/test/lint section still said *"CI runs `check` + `test` on every push."*
Since #68 that is wrong: the check pipeline runs `fmt`, `clippy -D warnings`, `check` and
`test` as four separate steps, on every push **and every pull request**.

`CONTRIBUTING.md` was corrected in #68; `AGENTS.md` carried the same stale claim and was
missed. It matters more here than in most docs — `AGENTS.md` is the file agents read to
learn what "done" means, so an understated CI contract invites work that a stricter
pipeline then rejects.

## Requirements

None — documentation only, no `ferrowl` behavior change and no `docs/specs/` impact.

## Verification

The claim's truth was established by #68: Woodpecker pipeline 902 ran on `event: pull_request`
and executed `fmt`, `clippy`, `check` and `test` as four distinct steps, all successful. This
PR makes the doc match that.

The full check set was also re-run on this branch: fmt clean, clippy clean at `-D warnings`,
`cargo check` clean, and `cargo test --workspace` green — 1150 passed, 0 failed, 36 suites.

The neighbouring comment `# CI and lefthook run with -D warnings` (line 129) was aspirational
before #68 and is now accurate as written, so it is left alone.

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check`
- [x] `cargo test --workspace`
- [x] Spec updated — n/a, no behavior change
- [x] Requirement tests — n/a, no new requirements
- [x] README updated — n/a, nothing user-facing changed
