### PR TITLE
build: centralize crate metadata, dependencies, and lints in the workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,67 @@ members = [
     "ferrowl-lua-derive",
 ]
 
+# All 12 crates are versioned in lockstep — bump this, not the members.
+[workspace.package]
+version = "0.4.14"
+edition = "2024"
+authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+
+# The lint policy CI enforces (`cargo clippy --workspace -- -D warnings`), stated here so a bare
+# `cargo clippy` and the editor see it too.
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+# Every external dependency lives here so two crates cannot drift onto different versions of the
+# same one. Members add features on top; they never restate a version.
 [workspace.dependencies]
+anyhow = "1.0.100"
+async-trait = "0.1.89"
+base64 = "0.22.1"
+clap = { version = "4.5.54", features = ["derive"] }
+convert_case = "0.11.0"
+crossterm = "0.29.0"
+derive_builder = "0.20.2"
+futures-util = "0.3.31"
+getset = "0.1.6"
+itertools = "0.14.0"
+mlua = { version = "0.11.4", features = ["anyhow", "lua54", "vendored"] }
+once_cell = "1.21.3"
 parking_lot = "0.12"
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+ratatui = { version = "0.30.0", features = [
+    "all-widgets",
+    "unstable-widget-ref",
+] }
+rcgen = "0.14.8"
+rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", branch = "main", default-features = false }
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+    "tls12",
+] }
+rustls-pemfile = "2.2.0"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+syn = "2.0.117"
+thiserror = "2.0"
+tokio = "1.49.0"
+tokio-modbus = "0.17.0"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+tokio-serial = "5.4.5"
+tokio-tungstenite = { version = "0.24", default-features = false, features = [
+    "connect",
+    "handshake",
+    "rustls-tls-webpki-roots",
+] }
+toml = "0.9.11"
+uuid = { version = "1", features = ["v4"] }
+validator = "0.20.0"
+webpki-roots = "1.0.8"
 
 # Speed up repeated release builds during development.
 [profile.release]

--- a/ferrowl-codec/Cargo.toml
+++ b/ferrowl-codec/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "ferrowl-codec"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
-derive_builder = "0.20.2"
-getset = "0.1.6"
-itertools = "0.14.0"
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0"
-tokio-modbus = "0.17.0"
+derive_builder = { workspace = true }
+getset = { workspace = true }
+itertools = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio-modbus = { workspace = true }

--- a/ferrowl-lua-derive/Cargo.toml
+++ b/ferrowl-lua-derive/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 name = "ferrowl-lua-derive"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-syn = "2.0.117"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 ferrowl-lua = { path = "../ferrowl-lua" }

--- a/ferrowl-lua/Cargo.toml
+++ b/ferrowl-lua/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "ferrowl-lua"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 ferrowl-lua-derive = { path = "../ferrowl-lua-derive" }
-mlua = { version = "0.11.4", features = ["anyhow", "lua54", "vendored"] }
+mlua = { workspace = true }

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -1,26 +1,29 @@
 [package]
 name = "ferrowl-modbus"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 ferrowl-store = { path = "../ferrowl-store" }
 ferrowl-codec = { path = "../ferrowl-codec" }
 
-anyhow = "1.0.100"
-thiserror = "2.0"
-itertools = "0.14.0"
-serde = { version = "1.0.228", features = ["derive"] }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+itertools = { workspace = true }
+serde = { workspace = true }
 parking_lot = { workspace = true }
-tokio = { version = "1.48.0", features = ["time"] }
-tokio-modbus = { version = "0.17.0", features = [
+tokio = { workspace = true, features = ["time"] }
+tokio-modbus = { workspace = true, features = [
     "futures-util",
     "rtu-server",
     "tcp-server",
 ] }
-tokio-serial = "5.4.5"
-clap = { version = "4.5.51", features = ["derive"] }
+tokio-serial = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 # Async test harness for the `handle_request` server logic (the crate's own tokio dep is
@@ -29,7 +32,7 @@ clap = { version = "4.5.51", features = ["derive"] }
 # test body sleeps between assertions (no longer required for any blocking bridge — the server's
 # request path is synchronous end-to-end and also passes on a current-thread runtime).
 # `ferrowl-store`/`ferrowl-codec` let that test build and seed memory directly.
-tokio = { version = "1.48.0", features = [
+tokio = { workspace = true, features = [
     "rt",
     "rt-multi-thread",
     "macros",
@@ -39,4 +42,4 @@ tokio = { version = "1.48.0", features = [
 ferrowl-store = { path = "../ferrowl-store" }
 ferrowl-codec = { path = "../ferrowl-codec" }
 # Only used to unit-test `rtu::Config`'s serde defaults (`reconnect` missing vs. explicit).
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/ferrowl-ocpp/Cargo.toml
+++ b/ferrowl-ocpp/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "ferrowl-ocpp"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [features]
 default = ["v1_6", "v2_0_1", "v2_1"]
@@ -11,31 +14,25 @@ v2_0_1 = ["rust-ocpp/v2_0_1"]
 v2_1 = ["rust-ocpp/v2_1"]
 
 [dependencies]
-rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", branch = "main", default-features = false }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0"
-uuid = { version = "1", features = ["v4"] }
-tokio = { version = "1.48.0", features = [
-    "time",
-    "sync",
-    "rt",
-    "net",
-    "macros",
-] }
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
-futures-util = { version = "0.3", features = ["sink", "std"] }
-validator = "0.20.0"
-base64 = "0.22.1"
-rustls-pemfile = "2.2.0"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-webpki-roots = "1.0.8"
-rcgen = "0.14.8"
+rust-ocpp = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true, features = ["time", "sync", "rt", "net", "macros"] }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true, features = ["sink", "std"] }
+validator = { workspace = true }
+base64 = { workspace = true }
+rustls-pemfile = { workspace = true }
+rustls = { workspace = true }
+tokio-rustls = { workspace = true }
+webpki-roots = { workspace = true }
+rcgen = { workspace = true }
 parking_lot = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.48.0", features = [
+tokio = { workspace = true, features = [
     "rt",
     "rt-multi-thread",
     "macros",
@@ -43,4 +40,4 @@ tokio = { version = "1.48.0", features = [
     "time",
     "net",
 ] }
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/ferrowl-ring/Cargo.toml
+++ b/ferrowl-ring/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ferrowl-ring"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]

--- a/ferrowl-store/Cargo.toml
+++ b/ferrowl-store/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "ferrowl-store"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
-itertools = "0.14.0"
-serde = { version = "1.0.228", features = ["derive"] }
-thiserror = "2.0"
+itertools = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/ferrowl-syntax/Cargo.toml
+++ b/ferrowl-syntax/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ferrowl-syntax"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]

--- a/ferrowl-ui-derive/Cargo.toml
+++ b/ferrowl-ui-derive/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "ferrowl-ui-derive"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-convert_case = "0.11.0"
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-syn = "2.0.117"
+convert_case = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 ferrowl-ui = { path = "../ferrowl-ui" }
-crossterm = "0.29.0"
-derive_builder = "0.20.2"
-ratatui = "0.30.0"
+crossterm = { workspace = true }
+derive_builder = { workspace = true }
+ratatui = { workspace = true }

--- a/ferrowl-ui/Cargo.toml
+++ b/ferrowl-ui/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "ferrowl-ui"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [features]
 default = ["vscode_dark"]
@@ -11,15 +14,12 @@ catppuccin_mocha = []
 gruvbox_dark = []
 
 [dependencies]
-crossterm = "0.29.0"
-derive_builder = "0.20.2"
-getset = "0.1.6"
+crossterm = { workspace = true }
+derive_builder = { workspace = true }
+getset = { workspace = true }
 ferrowl-syntax = { path = "../ferrowl-syntax" }
-itertools = "0.14.0"
-ratatui = { version = "0.30.0", features = [
-    "all-widgets",
-    "unstable-widget-ref",
-] }
+itertools = { workspace = true }
+ratatui = { workspace = true }
 
 [dev-dependencies]
 ferrowl-ui-derive = { path = "../ferrowl-ui-derive" }

--- a/ferrowl-util/Cargo.toml
+++ b/ferrowl-util/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
 name = "ferrowl-util"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
-async-trait = "0.1.89"
-clap = { version = "4.5.54", features = ["derive"] }
-futures-util = "0.3.31"
-once_cell = "1.21.3"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-thiserror = "2.0"
-tokio = { version = "1.49.0", features = ["rt", "sync", "time"] }
-toml = "0.9.11"
+async-trait = { workspace = true }
+clap = { workspace = true }
+futures-util = { workspace = true }
+once_cell = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
+toml = { workspace = true }
 
 [dev-dependencies]
 # The `#[tokio::main]` doctests in `tokio.rs` need the macro + multi-thread runtime, which the
 # library itself does not depend on. Declared here so `cargo test -p ferrowl-util` is self-contained
 # (previously these passed only via workspace-wide feature unification).
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/ferrowl/Cargo.toml
+++ b/ferrowl/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "ferrowl"
-version = "0.4.14"
-edition = "2024"
-authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
 
 [features]
 default = ["vscode_dark"]
@@ -21,20 +24,17 @@ ferrowl-ocpp = { path = "../ferrowl-ocpp" }
 ferrowl-lua = { path = "../ferrowl-lua" }
 ferrowl-syntax = { path = "../ferrowl-syntax" }
 ferrowl-ui-derive = { path = "../ferrowl-ui-derive" }
-anyhow = "1.0.100"
-thiserror = "2.0"
-clap = { version = "4.5.54", features = ["derive"] }
-crossterm = "0.29.0"
-ratatui = { version = "0.30.0", features = [
-    "all-widgets",
-    "unstable-widget-ref",
-] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.49.0", features = ["sync", "time", "rt", "signal"] }
-derive_builder = "0.20.2"
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+crossterm = { workspace = true }
+ratatui = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "signal"] }
+derive_builder = { workspace = true }
 parking_lot = { workspace = true }
-futures-util = "0.3.31"
-mlua = { version = "0.11.4", default-features = false }
+futures-util = { workspace = true }
+mlua = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Why

The 12 crate manifests each repeated their own `version`, `edition`, and `authors`,
declared every external dependency independently, and shared no lint policy. Metadata
that has to agree across the workspace had nowhere single to live, so agreement was
maintained by hand — and had already started to slip:

| dependency | before | now |
|---|---|---|
| `clap` | `4.5.51` (ferrowl-modbus) vs `4.5.54` (ferrowl-util, ferrowl) | `4.5.54` |
| `tokio` | `1.48.0` (ferrowl-modbus, ferrowl-ocpp) vs `1.49.0` (ferrowl-util, ferrowl) | `1.49.0` |
| `serde_json` | `"1.0"` vs `"1.0.149"` | `"1.0.149"` |
| `futures-util` | `"0.3"` vs `"0.3.31"` | `"0.3.31"` |

`AGENTS.md` already requires that "all 12 workspace crates are versioned in lockstep" —
until now that was a rule with nothing enforcing it, and a release bump was 12 hand-edits
with nothing to catch a missed one.

The change:

- **`[workspace.package]`** owns `version` / `edition` / `authors`; members inherit. A
  release bump is one edit.
- **`[workspace.dependencies]`** owns every external dependency. Members add features on
  top and never restate a version, so two crates can no longer drift onto different
  versions of the same crate. Path dependencies stay declared per-crate — they carry no
  version number, so they were never a drift risk.
- **`[workspace.lints]`** states the policy CI already enforces (`clippy::all = deny`), so
  a bare `cargo clippy` and the editor see it too, plus `unsafe_code = "forbid"` (the
  workspace already contains no `unsafe`).

**`Cargo.lock` is unchanged, and that is the point.** The resolver was already unifying
these crates onto their highest requested version, so the manifests were describing a
dependency graph that did not exist. The drift was latent, not yet active — this pins it
before it becomes real.

### Deviation from the issue

#71 proposed also adding `clippy::unwrap_used = "warn"` as a cheap on-ramp to the eventual
unwrap audit. **It is not in this PR.** CI runs `clippy -- -D warnings`, which promotes
*every* warning to an error — a warn-level lint with 918 hits across the workspace would
turn the pipeline red on the first run. It only becomes viable once that audit has cut the
count, so it belongs to the audit, not here.

## Requirements

None — no behavior change. This is a build-configuration change; no requirement in
`docs/specs/` is added, changed, or removed.

## Verification

Tests alone — there is no runtime surface to drive, since no source file is touched (13
`Cargo.toml` files, nothing else). The meaningful check is that the resolved build graph is
identical to `main`, which `Cargo.lock` being unchanged demonstrates directly.

All four gates run locally against the branch:

- `cargo check --workspace` — clean, no warnings
- `cargo test --workspace` — all green (576 in `ferrowl`, plus every other crate's suite; 0 failed)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Acceptance criteria from #71, checked directly:

- No crate manifest declares `version`, `edition`, or `authors` — verified by grep, none remain.
- No crate manifest declares a dependency version number — verified by grep, none remain.
- `cargo tree --duplicates` reports only `bitflags` v1 vs v2, pulled transitively via
  `nix` → `serialport` → `tokio-serial`. Not first-party-declared, so nothing the workspace
  can unify.

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check`
- [x] `cargo test --workspace`
- [x] Spec updated in `docs/specs/<area>/` — n/a, no behavior change
- [x] Each new or changed requirement has a test whose doc comment cites its ID — n/a, no new requirements
- [x] README updated — n/a, no user-facing commands, keybindings, config fields or Lua API changed

Closes #71
