### PR TITLE
ci: check the whole workspace, and audit the dependency tree

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    # The 12 crates are versioned in lockstep and share one [workspace.dependencies]
+    # table, so updates land as a single workspace-wide PR rather than per-crate noise.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+    groups:
+      # Bumping one half of a pair like tokio/tokio-rustls on its own tends to fail to
+      # resolve. Group the ecosystems that move together.
+      tokio:
+        patterns:
+          - "tokio"
+          - "tokio-*"
+      rustls:
+        patterns:
+          - "rustls"
+          - "rustls-*"
+          - "webpki-roots"
+          - "rcgen"
+      ratatui:
+        patterns:
+          - "ratatui"
+          - "crossterm"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.woodpecker/check.yml
+++ b/.woodpecker/check.yml
@@ -19,9 +19,16 @@ steps:
   check:
     image: rust:latest
     commands:
-      - cargo check
+      - cargo check --workspace
 
   test:
     image: rust:latest
     commands:
-      - cargo test
+      - cargo test --workspace
+
+  # Advisories, licenses, and banned/duplicate crates. Policy lives in deny.toml.
+  deny:
+    image: rust:latest
+    commands:
+      - cargo install cargo-deny --locked
+      - cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ members = [
 version = "0.4.14"
 edition = "2024"
 authors = ["David Loewe <49597367+TumbleOwlee@users.noreply.github.com>"]
+license = "MIT"
+# The workspace ships a binary, not libraries: releases are GitHub artifacts and nothing here
+# is on crates.io. Saying so lets the crates depend on each other by bare path.
+publish = false
 
 # The lint policy CI enforces (`cargo clippy --workspace -- -D warnings`), stated here so a bare
 # `cargo clippy` and the editor see it too.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,75 @@
+# cargo-deny policy. Run locally with `cargo deny check`; CI runs it as the `deny` step
+# of the check pipeline.
+
+[graph]
+# Ferrowl targets Linux, macOS and Windows (see docs/specs/non-functional-requirements.md).
+# Restricting the graph to those keeps advisories for platforms we do not ship from
+# failing the build.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+version = 2
+# Every entry here needs a comment saying why it is accepted and what would let us drop it.
+# An unexplained ignore is indistinguishable from an unnoticed vulnerability.
+ignore = [
+    # proc-macro-error2 is unmaintained. Transitive and not ours to fix: it arrives via
+    # validator_derive <- validator, which both ferrowl-ocpp and rust-ocpp depend on. It is a
+    # compile-time-only proc-macro crate, so it ships no code in the binary and the
+    # unmaintained status carries no runtime exposure. Drop this once validator moves off it.
+    "RUSTSEC-2026-0173",
+    # rustls-pemfile is unmaintained; the crate is now a thin wrapper around the PEM parsing
+    # already in rustls-pki-types, and the advisory's own guidance is to call that directly.
+    # That is a source change in ferrowl-ocpp, not a dependency bump, so it is deliberately
+    # out of scope for the PR that introduced this file and is tracked separately. Drop this
+    # once ferrowl-ocpp uses rustls_pki_types::pem::PemObject.
+    "RUSTSEC-2025-0134",
+]
+
+[licenses]
+version = 2
+# Permissive licenses only. Ferrowl itself is MIT (see LICENSE); a strong-copyleft dependency
+# would change what downstream users may do with the binary, so it is a decision, not a
+# dependency bump.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    # serialport, reached via tokio-serial, which is what gives Modbus RTU a serial port at
+    # all — so this is not an optional dependency we could simply drop. MPL-2.0 is file-level
+    # copyleft: it obliges us to publish changes to serialport's own files, and says nothing
+    # about the rest of the binary. Linking it into an MIT program is fine. Anything stronger
+    # (GPL/LGPL/AGPL) stays rejected.
+    "MPL-2.0",
+    # webpki-roots. The "code" here is Mozilla's CA certificate list, and CDLA-Permissive-2.0
+    # is a permissive *data* license — no copyleft, no attribution burden on the binary.
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+# Duplicates are reported but not fatal: nearly all of them are transitive crates mid-major-
+# version-migration (bitflags 1/2, thiserror 1/2, ...) that we do not select and cannot unify.
+multiple-versions = "warn"
+wildcards = "deny"
+# The 12 workspace crates depend on each other by path with no version requirement, which is a
+# wildcard by cargo-deny's reckoning. That is correct for an unpublished workspace — the
+# lockstep version in [workspace.package] is what pins them.
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+# rust-ocpp is consumed from a fork (see ferrowl-ocpp/Cargo.toml) rather than crates.io.
+allow-git = ["https://github.com/TumbleOwlee/rust-ocpp"]

--- a/ferrowl-codec/Cargo.toml
+++ b/ferrowl-codec/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-codec"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-lua-derive/Cargo.toml
+++ b/ferrowl-lua-derive/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-lua-derive"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-lua/Cargo.toml
+++ b/ferrowl-lua/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-lua"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-modbus"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-ocpp/Cargo.toml
+++ b/ferrowl-ocpp/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-ocpp"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-ring/Cargo.toml
+++ b/ferrowl-ring/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-ring"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-store/Cargo.toml
+++ b/ferrowl-store/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-store"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-syntax/Cargo.toml
+++ b/ferrowl-syntax/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-syntax"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-ui-derive/Cargo.toml
+++ b/ferrowl-ui-derive/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-ui-derive"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-ui/Cargo.toml
+++ b/ferrowl-ui/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-ui"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl-util/Cargo.toml
+++ b/ferrowl-util/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl-util"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/ferrowl/Cargo.toml
+++ b/ferrowl/Cargo.toml
@@ -3,6 +3,8 @@ name = "ferrowl"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Why

Two gaps in what CI actually guarded.

**The check pipeline was narrower than the documented commands.** `check` and `test` ran
without `--workspace` while `clippy` passed it, so CI's typecheck and test coverage depended
on default-member resolution rather than on the workspace — a crate could stop compiling or
start failing its tests without the pipeline going red. Both now pass `--workspace`, matching
what `AGENTS.md` documents.

**Nothing audited the dependency tree.** No cargo-deny, no cargo-audit, no dependabot, and
CodeQL does not cover Rust advisories — on a tree that contains `rustls`, `tokio-rustls`,
`rcgen` and `webpki-roots`. A `deny` step now runs cargo-deny (advisories, licenses, bans,
sources) against a new `deny.toml`, and `.github/dependabot.yml` opens weekly cargo PRs with
tokio/rustls/ratatui grouped, since those families fail to resolve when bumped apart.

### What the first audit run found

Three advisories. One was fixable:

- **`RUSTSEC-2026-0190` — unsoundness in `anyhow`'s `Error::downcast_mut`.** UB when an error
  gets `.context()` added and is later downcast mutably. **Fixed** by bumping anyhow
  1.0.102 → 1.0.103; the existing requirement already admitted that version, so this is a
  `Cargo.lock` change only.
- **`RUSTSEC-2026-0173` — `proc-macro-error2` unmaintained.** Transitive via
  `validator_derive` ← `validator` (both `ferrowl-ocpp` and `rust-ocpp` pull it). Compile-time
  proc-macro only, so nothing ships in the binary; no upgrade exists. **Ignored** with the
  reasoning written into `deny.toml`.
- **`RUSTSEC-2025-0134` — `rustls-pemfile` unmaintained.** There is a real migration path
  (`rustls_pki_types::pem::PemObject`), but it is a source change in `ferrowl-ocpp`, not a
  dependency bump, so it is deliberately out of scope for a CI PR. **Ignored** with reasoning,
  and tracked in #74 — closing that issue means deleting the ignore entry.

### Two license decisions worth a reviewer's eye

The policy allows permissive licenses only. Two dependencies needed an explicit call:

- **`serialport` is MPL-2.0.** It arrives via `tokio-serial`, which is what gives Modbus RTU a
  serial port at all — not a dependency we could simply drop. MPL is *file-level* copyleft: it
  obliges publishing changes to serialport's own files and says nothing about the rest of the
  binary, so linking it into an MIT program is fine. Allowed.
- **`webpki-roots` is CDLA-Permissive-2.0.** The "code" is Mozilla's CA certificate list, and
  CDLA-Permissive is a permissive *data* license. Allowed.

GPL/LGPL/AGPL stay rejected. If you would rather MPL-2.0 not be blanket-allowed, the
alternative is a targeted per-crate exception for `serialport` only — say so and I will narrow
it.

### Manifest additions

The workspace crates gained `license = "MIT"` (which matches `LICENSE` — they had simply never
declared it) and `publish = false` (already true: releases are GitHub artifacts, nothing is on
crates.io). The second one is not cosmetic — it is what lets cargo-deny read the 12 inter-crate
path dependencies as legitimate rather than as wildcard dependencies.

## Requirements

None — no behavior change. This is a CI and build-configuration change; no requirement in
`docs/specs/` is added, changed, or removed.

## Verification

Tests and tooling alone — no source file is touched, so there is no runtime surface to drive.

Run locally against the rebased branch:

- `cargo fmt --check` — clean
- `cargo check --workspace` — clean, no warnings
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 issues
- `cargo test --workspace` — 36 suites, 0 failed
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`

The audit genuinely went red on its first run (the three advisories above, plus every workspace
crate flagged unlicensed and every path dependency flagged as a wildcard); the green result is
after fixing anyhow, declaring the license, and writing down the two ignores. It is not green
because the policy is empty.

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check`
- [x] `cargo test --workspace`
- [x] Spec updated in `docs/specs/<area>/` — n/a, no behavior change
- [x] Each new or changed requirement has a test whose doc comment cites its ID — n/a, no new requirements
- [x] README updated — n/a, no user-facing commands, keybindings, config fields or Lua API changed

Closes #72
