### PR TITLE
fix(ocpp): parse PEM via rustls-pki-types, drop unmaintained rustls-pemfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,6 @@ dependencies = [
  "rcgen",
  "rust-ocpp",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2329,15 +2328,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ rustls = { version = "0.23", default-features = false, features = [
     "std",
     "tls12",
 ] }
-rustls-pemfile = "2.2.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 syn = "2.0.117"

--- a/deny.toml
+++ b/deny.toml
@@ -24,12 +24,6 @@ ignore = [
     # compile-time-only proc-macro crate, so it ships no code in the binary and the
     # unmaintained status carries no runtime exposure. Drop this once validator moves off it.
     "RUSTSEC-2026-0173",
-    # rustls-pemfile is unmaintained; the crate is now a thin wrapper around the PEM parsing
-    # already in rustls-pki-types, and the advisory's own guidance is to call that directly.
-    # That is a source change in ferrowl-ocpp, not a dependency bump, so it is deliberately
-    # out of scope for the PR that introduced this file and is tracked separately. Drop this
-    # once ferrowl-ocpp uses rustls_pki_types::pem::PemObject.
-    "RUSTSEC-2025-0134",
 ]
 
 [licenses]

--- a/ferrowl-ocpp/Cargo.toml
+++ b/ferrowl-ocpp/Cargo.toml
@@ -26,7 +26,6 @@ tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true, features = ["sink", "std"] }
 validator = { workspace = true }
 base64 = { workspace = true }
-rustls-pemfile = { workspace = true }
 rustls = { workspace = true }
 tokio-rustls = { workspace = true }
 webpki-roots = { workspace = true }

--- a/ferrowl-ocpp/src/security.rs
+++ b/ferrowl-ocpp/src/security.rs
@@ -9,13 +9,12 @@
 //! Profiles 2 and 3 share the same rustls plumbing; a [`CsTlsConfig`]/[`CsmsTlsConfig`] only
 //! becomes "profile 3" once a client certificate (CS) or `require_client_cert` (CSMS) is set.
 
-use std::fs::File;
-use std::io::BufReader;
 use std::sync::Arc;
 
 use base64::Engine;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::crypto::{CryptoProvider, verify_tls12_signature, verify_tls13_signature};
+use rustls::pki_types::pem::{self, PemObject};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
 use tokio_tungstenite::Connector;
@@ -269,17 +268,28 @@ fn generate_self_signed(
     Ok((vec![cert_der], key_der))
 }
 
+/// Map a PEM failure onto the `io::Error` shape the rest of this module already speaks. A file
+/// that cannot be opened arrives as `pem::Error::Io` and is passed through unchanged; every other
+/// variant is a parse failure, which the previous `rustls-pemfile` codec also surfaced as an
+/// `InvalidData` `io::Error`.
+fn pem_io_error(err: pem::Error) -> std::io::Error {
+    match err {
+        pem::Error::Io(io) => io,
+        other => std::io::Error::new(std::io::ErrorKind::InvalidData, other.to_string()),
+    }
+}
+
 /// Load a PEM certificate chain from `path`.
 fn load_certs(path: &str) -> Result<Vec<CertificateDer<'static>>, Error> {
-    let file = File::open(path).map_err(|source| TlsError::Io {
-        path: path.to_owned(),
-        source,
-    })?;
-    let certs = rustls_pemfile::certs(&mut BufReader::new(file))
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(|source| TlsError::Io {
+            path: path.to_owned(),
+            source: pem_io_error(source),
+        })?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|source| TlsError::Io {
             path: path.to_owned(),
-            source,
+            source: pem_io_error(source),
         })?;
     if certs.is_empty() {
         return Err(TlsError::NoCertificates(path.to_owned()).into());
@@ -289,15 +299,90 @@ fn load_certs(path: &str) -> Result<Vec<CertificateDer<'static>>, Error> {
 
 /// Load a PEM private key from `path`.
 fn load_private_key(path: &str) -> Result<PrivateKeyDer<'static>, Error> {
-    let file = File::open(path).map_err(|source| TlsError::Io {
-        path: path.to_owned(),
-        source,
-    })?;
-    let mut reader = BufReader::new(file);
-    rustls_pemfile::private_key(&mut reader)
-        .map_err(|source| TlsError::Io {
+    match PrivateKeyDer::from_pem_file(path) {
+        Ok(key) => Ok(key),
+        Err(pem::Error::NoItemsFound) => Err(TlsError::NoPrivateKey(path.to_owned()).into()),
+        Err(source) => Err(TlsError::Io {
             path: path.to_owned(),
-            source,
-        })?
-        .ok_or_else(|| TlsError::NoPrivateKey(path.to_owned()).into())
+            source: pem_io_error(source),
+        }
+        .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Write `contents` to a fresh file under the OS temp dir and return its path. Left in place;
+    /// the platform reclaims its temp dir, and this keeps the tests free of a TempDir dependency.
+    fn temp_pem(tag: &str, contents: &str) -> String {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-ocpp-sec-{tag}-{}-{n}.pem",
+            std::process::id()
+        ));
+        std::fs::File::create(&path)
+            .and_then(|mut f| f.write_all(contents.as_bytes()))
+            .expect("write temp pem");
+        path.to_string_lossy().into_owned()
+    }
+
+    /// A self-signed certificate and its matching key, both PEM-encoded (PKCS#8 key, as rcgen
+    /// emits and as the loopback tests feed the real TLS stack).
+    fn cert_and_key_pem() -> (String, String) {
+        let params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        let key = rcgen::KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        (cert.pem(), key.serialize_pem())
+    }
+
+    /// OC-R-041 — a well-formed certificate and key load, pinning the happy path the negative
+    /// cases below are measured against.
+    #[test]
+    fn ut_load_certs_and_key_roundtrip() {
+        let (cert_pem, key_pem) = cert_and_key_pem();
+        let cert_path = temp_pem("roundtrip-cert", &cert_pem);
+        let key_path = temp_pem("roundtrip-key", &key_pem);
+        assert_eq!(load_certs(&cert_path).unwrap().len(), 1);
+        load_private_key(&key_path).expect("key should load");
+    }
+
+    /// OC-R-041 — failing to open a certificate file is a TLS error, not a panic or a silent
+    /// empty chain.
+    #[test]
+    fn ut_load_certs_missing_file_is_tls_error() {
+        let missing = temp_pem("missing-cert", "");
+        std::fs::remove_file(&missing).unwrap();
+        assert!(matches!(
+            load_certs(&missing),
+            Err(Error::Tls(TlsError::Io { .. }))
+        ));
+    }
+
+    /// OC-R-041 — a readable file with no certificate section fails as NoCertificates rather than
+    /// being accepted as an empty chain.
+    #[test]
+    fn ut_load_certs_without_certificate_section_is_no_certificates() {
+        let (_cert, key_pem) = cert_and_key_pem();
+        let path = temp_pem("key-only", &key_pem);
+        assert!(matches!(
+            load_certs(&path),
+            Err(Error::Tls(TlsError::NoCertificates(_)))
+        ));
+    }
+
+    /// OC-R-041 — failing to find a private key in a readable file is NoPrivateKey.
+    #[test]
+    fn ut_load_private_key_without_key_section_is_no_private_key() {
+        let (cert_pem, _key) = cert_and_key_pem();
+        let path = temp_pem("cert-only", &cert_pem);
+        assert!(matches!(
+            load_private_key(&path),
+            Err(Error::Tls(TlsError::NoPrivateKey(_)))
+        ));
+    }
 }


### PR DESCRIPTION
## Why

`rustls-pemfile` is unmaintained — its repository is archived (RUSTSEC-2025-0134). The crate
is now a thin wrapper over the PEM parser already shipped in `rustls-pki-types`, which is
in our tree as a dependency of `rustls`. `ferrowl-ocpp/src/security.rs` now loads certificate
chains and private keys through the `PemObject` trait (`CertificateDer::pem_file_iter`,
`PrivateKeyDer::from_pem_file`), so this **removes** a direct dependency rather than trading
one for another.

The advisory was ignored-with-justification in `deny.toml` (added in #72/#75); this PR deletes
that ignore, and `cargo deny check` passes with it gone — the advisory is cleared, not
re-suppressed.

## Requirements

None — no behavior change. **OC-R-041** ("Failing to open, parse, or find a certificate or
private key in a configured PEM file shall fail the start of the CS connection or the CSMS
listener with a TLS error, before any socket work") is unchanged and stays satisfied. No spec
diff.

The migration is deliberately behavior-preserving down to the error variant, not just the
"some TLS error" the spec requires:

- a missing file stays `TlsError::Io`,
- a readable file with no certificate section stays `NoCertificates`,
- a readable file with no key section stays `NoPrivateKey`.

`rustls-pemfile` already surfaced parse failures as an `InvalidData` `io::Error`; `pem::Error`
is mapped back the same way, so even the internal error shape does not move. Verified against
the rustls-pki-types 1.15 source that `PrivateKeyDer::from_pem` accepts the same three key
encodings the old codec did (PKCS#1 / PKCS#8 / SEC1), and that a garbage / no-section file
yields an empty result rather than a parse error — so the variant boundary above holds.

## Verification

These failure paths had **no test coverage before** — `NoCertificates` / `NoPrivateKey` were
never asserted anywhere. Added four unit tests in `security.rs`, each citing OC-R-041:

- `ut_load_certs_and_key_roundtrip` — a well-formed cert + key load (happy path pinned).
- `ut_load_certs_missing_file_is_tls_error` — open failure → `TlsError::Io`.
- `ut_load_certs_without_certificate_section_is_no_certificates` — key-only file → `NoCertificates`.
- `ut_load_private_key_without_key_section_is_no_private_key` — cert-only file → `NoPrivateKey`.

Beyond unit tests: the existing `tests/ws_loopback_security.rs` integration tests stand up a
live CS ↔ CSMS TLS handshake using real PEM files loaded through the exact functions changed
here, and they still pass — so the happy path is exercised over a real socket, not mocked.

Ran locally against the rebased branch:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 issues
- `cargo test --workspace` — 36 suites, 0 failed (the 4 new unit tests + the TLS loopback suite included)
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`, with the
  RUSTSEC-2025-0134 ignore removed

## Note

The error mapping is kept bug-for-bug compatible (parse failures wrapped as `InvalidData`
`io::Error` under `TlsError::Io`) rather than introducing a distinct `TlsError::Pem` variant.
That keeps the change behavior-preserving and gate-free. If a dedicated PEM error variant is
wanted for better diagnostics, it is a small follow-up and a real (if minor) change to the
error surface — out of scope here.

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check`
- [x] `cargo test --workspace`
- [x] Spec updated in `docs/specs/<area>/` — n/a, no behavior change; OC-R-041 unchanged and still satisfied
- [x] Each new or changed requirement has a test whose doc comment cites its ID — the 4 new tests cite OC-R-041 (existing requirement, new coverage; no IDs backfilled onto existing tests)
- [x] README updated — n/a, no user-facing commands, keybindings, config fields or Lua API changed

Closes #74
