### PR TITLE
refactor: ban bare unwrap in non-test code, document each site with expect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ publish = false
 # `cargo clippy` and the editor see it too.
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
+# Bare `unwrap` is denied in non-test code: every fallible call must document why it cannot fail
+# via `expect("...")`. `expect_used` stays off — `expect` is the sanctioned, documented form. Test
+# code is exempt (see clippy.toml).
+unwrap_used = "deny"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# Bare `unwrap` is denied in non-test code (see [workspace.lints.clippy] in Cargo.toml):
+# every fallible call must document why it cannot fail via `expect("...")`. Tests are exempt —
+# a panicking `unwrap` there is the assertion, and a message would only restate the test name.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/ferrowl-lua/src/context.rs
+++ b/ferrowl-lua/src/context.rs
@@ -114,7 +114,7 @@ where
             .iter_mut()
             .map(|(_, v)| v.exec())
             .filter(|r| r.is_err())
-            .map(|e| e.err().unwrap())
+            .map(|e| e.expect_err("filter kept only Err results"))
             .collect();
 
         if errors.is_empty() {
@@ -135,7 +135,7 @@ where
             .filter(|(_, v)| v.since_last_execution() >= since)
             .map(|(_, v)| v.exec())
             .filter(|r| r.is_err())
-            .map(|e| e.err().unwrap())
+            .map(|e| e.expect_err("filter kept only Err results"))
             .collect();
 
         if errors.is_empty() {

--- a/ferrowl-lua/tests/modules.rs
+++ b/ferrowl-lua/tests/modules.rs
@@ -1,6 +1,9 @@
 //! Integration tests exercising the host modules (Time, Statics, Register)
 //! end-to-end through a real Lua context built with [`ContextBuilder`].
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
 use std::collections::HashMap;
 use std::time::Duration;
 

--- a/ferrowl-lua/tests/print.rs
+++ b/ferrowl-lua/tests/print.rs
@@ -2,6 +2,9 @@
 //! would corrupt the host TUI's alternate screen, so `with_print_sink` redirects it to a host
 //! `LogSink` instead.
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, Mutex};
 
 use ferrowl_lua::ContextBuilder;

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -2,6 +2,9 @@
 //! loopback socket. Drives the shared client loop (`client_core`) through every
 //! read function code and every write command, plus graceful termination.
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/ferrowl-ocpp/tests/ws_loopback_security.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_security.rs
@@ -6,6 +6,8 @@
 //! `BasicConstraints::Ca` issuer, which is enough extra scaffolding that it's left for a
 //! follow-up rather than bolted on to this pass.
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "v1_6")]
 
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/ferrowl-ocpp/tests/ws_loopback_v16.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v16.rs
@@ -1,6 +1,8 @@
 //! Low-level layer: a CSMS server and a CS client exchange Calls in both directions over a real
 //! websocket loopback, OCPP 1.6. Mirrors `ferrowl-modbus/tests/tcp_loopback.rs`.
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "v1_6")]
 
 use std::sync::Arc;

--- a/ferrowl-ocpp/tests/ws_loopback_v201.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v201.rs
@@ -2,6 +2,8 @@
 //! websocket loopback, OCPP 2.0.1. Mirrors `ws_loopback_v16.rs`; its primary job is to prove the
 //! `ocpp2.0.1` subprotocol is negotiated end-to-end (regression guard for the 400-Bad-Request bug).
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "v2_0_1")]
 
 use std::sync::Arc;

--- a/ferrowl-ocpp/tests/ws_loopback_v21.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v21.rs
@@ -2,6 +2,8 @@
 //! websocket loopback, OCPP 2.1. Mirrors `ws_loopback_v201.rs`; its primary job is to prove the
 //! `ocpp2.1` subprotocol is negotiated end-to-end (regression guard for the 400-Bad-Request bug).
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "v2_1")]
 
 use std::sync::Arc;

--- a/ferrowl-store/src/memory.rs
+++ b/ferrowl-store/src/memory.rs
@@ -81,7 +81,7 @@ where
             // slice then writes its own cells back over them, preserving type and value.
             let mut merged = Slice::from_range(kind, Range::new(start, end - start));
             for t in &targets {
-                let slice = m.remove(t).unwrap();
+                let slice = m.remove(t).expect("t is drawn from m's own ranges");
                 let offset = slice.range.start - start;
                 for (i, cell) in slice.buffer.into_iter().enumerate() {
                     merged.buffer[offset + i] = cell;
@@ -137,7 +137,7 @@ where
             });
         }
         self.writable(&id, ty, range)?;
-        let map = self.slices.get_mut(&id).unwrap();
+        let map = self.slices.get_mut(&id).expect("writable() confirmed the id is registered");
         let mut idx = 0;
         walk_slices_mut(map, range, |slice, seg| {
             let count = seg.length();
@@ -190,7 +190,7 @@ where
     /// readable as type `ty`.
     pub fn read(&self, id: K, ty: &CellType, range: &Range) -> Result<Vec<u16>, MemoryError> {
         self.readable(&id, ty, range)?;
-        let map = self.slices.get(&id).unwrap();
+        let map = self.slices.get(&id).expect("readable() confirmed the id is registered");
         let mut output: Vec<u16> = Vec::with_capacity(range.length());
         walk_slices(map, range, |slice, seg| {
             if let Some(mut v) = slice.read(&seg) {

--- a/ferrowl-store/src/memory.rs
+++ b/ferrowl-store/src/memory.rs
@@ -137,7 +137,10 @@ where
             });
         }
         self.writable(&id, ty, range)?;
-        let map = self.slices.get_mut(&id).expect("writable() confirmed the id is registered");
+        let map = self
+            .slices
+            .get_mut(&id)
+            .expect("writable() confirmed the id is registered");
         let mut idx = 0;
         walk_slices_mut(map, range, |slice, seg| {
             let count = seg.length();
@@ -190,7 +193,10 @@ where
     /// readable as type `ty`.
     pub fn read(&self, id: K, ty: &CellType, range: &Range) -> Result<Vec<u16>, MemoryError> {
         self.readable(&id, ty, range)?;
-        let map = self.slices.get(&id).expect("readable() confirmed the id is registered");
+        let map = self
+            .slices
+            .get(&id)
+            .expect("readable() confirmed the id is registered");
         let mut output: Vec<u16> = Vec::with_capacity(range.length());
         walk_slices(map, range, |slice, seg| {
             if let Some(mut v) = slice.read(&seg) {

--- a/ferrowl-ui-derive/src/table_entry.rs
+++ b/ferrowl-ui-derive/src/table_entry.rs
@@ -90,7 +90,12 @@ pub fn expand_table_entry(input: syn::DeriveInput) -> syn::Result<TokenStream> {
             col_names.push(name.ok_or_else(|| err("`column` requires `name`"))?);
             col_mins.push(min.ok_or_else(|| err("`column` requires `min`"))?);
             col_maxs.push(max.ok_or_else(|| err("`column` requires `max`"))?);
-            col_fields.push(field.ident.clone().expect("TableEntry rejects non-named-field structs above"));
+            col_fields.push(
+                field
+                    .ident
+                    .clone()
+                    .expect("TableEntry rejects non-named-field structs above"),
+            );
         }
     }
 

--- a/ferrowl-ui-derive/src/table_entry.rs
+++ b/ferrowl-ui-derive/src/table_entry.rs
@@ -90,7 +90,7 @@ pub fn expand_table_entry(input: syn::DeriveInput) -> syn::Result<TokenStream> {
             col_names.push(name.ok_or_else(|| err("`column` requires `name`"))?);
             col_mins.push(min.ok_or_else(|| err("`column` requires `min`"))?);
             col_maxs.push(max.ok_or_else(|| err("`column` requires `max`"))?);
-            col_fields.push(field.ident.clone().unwrap());
+            col_fields.push(field.ident.clone().expect("TableEntry rejects non-named-field structs above"));
         }
     }
 

--- a/ferrowl-ui/examples/dialog.rs
+++ b/ferrowl-ui/examples/dialog.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use derive_builder::Builder;
 use ratatui::{

--- a/ferrowl-ui/examples/input_field.rs
+++ b/ferrowl-ui/examples/input_field.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ferrowl_ui::{
     AlternateScreen, Border, EventResult,

--- a/ferrowl-ui/examples/selection.rs
+++ b/ferrowl-ui/examples/selection.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use derive_builder::Builder;
 use ferrowl_ui::{

--- a/ferrowl-ui/examples/suggest_input.rs
+++ b/ferrowl-ui/examples/suggest_input.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ferrowl_ui::{
     AlternateScreen, Border, EventResult,

--- a/ferrowl-ui/examples/table.rs
+++ b/ferrowl-ui/examples/table.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use derive_builder::Builder;
 use ferrowl_ui::{

--- a/ferrowl-ui/examples/text.rs
+++ b/ferrowl-ui/examples/text.rs
@@ -1,3 +1,6 @@
+// Example binary: unwrap keeps the demo focused on the widget being shown.
+#![allow(clippy::unwrap_used)]
+
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ferrowl_ui::{AlternateScreen, Border, style::TextStyle, widgets::TextBuilder};
 use ratatui::{

--- a/ferrowl-ui/src/state/suggest_input.rs
+++ b/ferrowl-ui/src/state/suggest_input.rs
@@ -27,7 +27,7 @@ where
     /// Suggestion labels, kept in a `SelectionState` so navigation/scroll
     /// logic can be reused for rendering.
     #[builder(
-        default = "SelectionStateBuilder::default().values(Vec::new()).build().unwrap()",
+        default = "SelectionStateBuilder::default().values(Vec::new()).build().expect(\"SelectionStateBuilder has its values set\")",
         setter(skip)
     )]
     list: SelectionState<String>,
@@ -115,7 +115,7 @@ where
         self.list = SelectionStateBuilder::default()
             .values(labels)
             .build()
-            .unwrap();
+            .expect("SelectionStateBuilder has its values set above");
         self.open = true;
     }
 

--- a/ferrowl-ui/src/style/button.rs
+++ b/ferrowl-ui/src/style/button.rs
@@ -15,6 +15,8 @@ pub struct ButtonStyle {
 
 impl Default for ButtonStyle {
     fn default() -> Self {
-        ButtonStyleBuilder::default().build().expect("ButtonStyleBuilder fields all default")
+        ButtonStyleBuilder::default()
+            .build()
+            .expect("ButtonStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/button.rs
+++ b/ferrowl-ui/src/style/button.rs
@@ -15,6 +15,6 @@ pub struct ButtonStyle {
 
 impl Default for ButtonStyle {
     fn default() -> Self {
-        ButtonStyleBuilder::default().build().unwrap()
+        ButtonStyleBuilder::default().build().expect("ButtonStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/input_field.rs
+++ b/ferrowl-ui/src/style/input_field.rs
@@ -38,6 +38,6 @@ pub struct InputFieldStyle {
 
 impl Default for InputFieldStyle {
     fn default() -> Self {
-        InputFieldStyleBuilder::default().build().unwrap()
+        InputFieldStyleBuilder::default().build().expect("InputFieldStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/input_field.rs
+++ b/ferrowl-ui/src/style/input_field.rs
@@ -38,6 +38,8 @@ pub struct InputFieldStyle {
 
 impl Default for InputFieldStyle {
     fn default() -> Self {
-        InputFieldStyleBuilder::default().build().expect("InputFieldStyleBuilder fields all default")
+        InputFieldStyleBuilder::default()
+            .build()
+            .expect("InputFieldStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/scrolling_tabs.rs
+++ b/ferrowl-ui/src/style/scrolling_tabs.rs
@@ -14,6 +14,8 @@ pub struct ScrollingTabsStyle {
 
 impl Default for ScrollingTabsStyle {
     fn default() -> Self {
-        ScrollingTabsStyleBuilder::default().build().expect("ScrollingTabsStyleBuilder fields all default")
+        ScrollingTabsStyleBuilder::default()
+            .build()
+            .expect("ScrollingTabsStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/scrolling_tabs.rs
+++ b/ferrowl-ui/src/style/scrolling_tabs.rs
@@ -14,6 +14,6 @@ pub struct ScrollingTabsStyle {
 
 impl Default for ScrollingTabsStyle {
     fn default() -> Self {
-        ScrollingTabsStyleBuilder::default().build().unwrap()
+        ScrollingTabsStyleBuilder::default().build().expect("ScrollingTabsStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/selection.rs
+++ b/ferrowl-ui/src/style/selection.rs
@@ -26,6 +26,6 @@ pub struct SelectionStyle {
 
 impl Default for SelectionStyle {
     fn default() -> Self {
-        SelectionStyleBuilder::default().build().unwrap()
+        SelectionStyleBuilder::default().build().expect("SelectionStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/selection.rs
+++ b/ferrowl-ui/src/style/selection.rs
@@ -26,6 +26,8 @@ pub struct SelectionStyle {
 
 impl Default for SelectionStyle {
     fn default() -> Self {
-        SelectionStyleBuilder::default().build().expect("SelectionStyleBuilder fields all default")
+        SelectionStyleBuilder::default()
+            .build()
+            .expect("SelectionStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/suggest_input.rs
+++ b/ferrowl-ui/src/style/suggest_input.rs
@@ -22,6 +22,6 @@ pub struct SuggestInputStyle {
 
 impl Default for SuggestInputStyle {
     fn default() -> Self {
-        SuggestInputStyleBuilder::default().build().unwrap()
+        SuggestInputStyleBuilder::default().build().expect("SuggestInputStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/suggest_input.rs
+++ b/ferrowl-ui/src/style/suggest_input.rs
@@ -22,6 +22,8 @@ pub struct SuggestInputStyle {
 
 impl Default for SuggestInputStyle {
     fn default() -> Self {
-        SuggestInputStyleBuilder::default().build().expect("SuggestInputStyleBuilder fields all default")
+        SuggestInputStyleBuilder::default()
+            .build()
+            .expect("SuggestInputStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/syntax.rs
+++ b/ferrowl-ui/src/style/syntax.rs
@@ -59,6 +59,8 @@ impl SyntaxTheme {
 
 impl Default for SyntaxTheme {
     fn default() -> Self {
-        SyntaxThemeBuilder::default().build().expect("SyntaxThemeBuilder fields all default")
+        SyntaxThemeBuilder::default()
+            .build()
+            .expect("SyntaxThemeBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/syntax.rs
+++ b/ferrowl-ui/src/style/syntax.rs
@@ -59,6 +59,6 @@ impl SyntaxTheme {
 
 impl Default for SyntaxTheme {
     fn default() -> Self {
-        SyntaxThemeBuilder::default().build().unwrap()
+        SyntaxThemeBuilder::default().build().expect("SyntaxThemeBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/table.rs
+++ b/ferrowl-ui/src/style/table.rs
@@ -32,6 +32,8 @@ pub struct TableStyle {
 
 impl Default for TableStyle {
     fn default() -> Self {
-        TableStyleBuilder::default().build().expect("TableStyleBuilder fields all default")
+        TableStyleBuilder::default()
+            .build()
+            .expect("TableStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/table.rs
+++ b/ferrowl-ui/src/style/table.rs
@@ -32,6 +32,6 @@ pub struct TableStyle {
 
 impl Default for TableStyle {
     fn default() -> Self {
-        TableStyleBuilder::default().build().unwrap()
+        TableStyleBuilder::default().build().expect("TableStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/text.rs
+++ b/ferrowl-ui/src/style/text.rs
@@ -13,6 +13,6 @@ pub struct TextStyle {
 
 impl Default for TextStyle {
     fn default() -> Self {
-        TextStyleBuilder::default().build().unwrap()
+        TextStyleBuilder::default().build().expect("TextStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/style/text.rs
+++ b/ferrowl-ui/src/style/text.rs
@@ -13,6 +13,8 @@ pub struct TextStyle {
 
 impl Default for TextStyle {
     fn default() -> Self {
-        TextStyleBuilder::default().build().expect("TextStyleBuilder fields all default")
+        TextStyleBuilder::default()
+            .build()
+            .expect("TextStyleBuilder fields all default")
     }
 }

--- a/ferrowl-ui/src/widgets/selection.rs
+++ b/ferrowl-ui/src/widgets/selection.rs
@@ -82,7 +82,7 @@ where
     ValueType: ToLabel + Clone,
 {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = SelectionStateBuilder::default().build().unwrap();
+        let mut state = SelectionStateBuilder::default().build().expect("SelectionStateBuilder fields all default");
         StatefulWidget::render(self, area, buf, &mut state);
     }
 }

--- a/ferrowl-ui/src/widgets/selection.rs
+++ b/ferrowl-ui/src/widgets/selection.rs
@@ -82,7 +82,9 @@ where
     ValueType: ToLabel + Clone,
 {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = SelectionStateBuilder::default().build().expect("SelectionStateBuilder fields all default");
+        let mut state = SelectionStateBuilder::default()
+            .build()
+            .expect("SelectionStateBuilder fields all default");
         StatefulWidget::render(self, area, buf, &mut state);
     }
 }

--- a/ferrowl-ui/src/widgets/suggest_input.rs
+++ b/ferrowl-ui/src/widgets/suggest_input.rs
@@ -28,7 +28,7 @@ where
     P: SuggestionProvider + Clone,
 {
     #[getset(get = "pub")]
-    #[builder(default = "InputFieldBuilder::default().build().unwrap()")]
+    #[builder(default = "InputFieldBuilder::default().build().expect(\"InputFieldBuilder fields all default\")")]
     input_field: InputField<ValueType>,
     #[getset(get = "pub")]
     #[builder(default = "SuggestInputStyle::default()")]

--- a/ferrowl-ui/src/widgets/suggest_input.rs
+++ b/ferrowl-ui/src/widgets/suggest_input.rs
@@ -28,7 +28,9 @@ where
     P: SuggestionProvider + Clone,
 {
     #[getset(get = "pub")]
-    #[builder(default = "InputFieldBuilder::default().build().expect(\"InputFieldBuilder fields all default\")")]
+    #[builder(
+        default = "InputFieldBuilder::default().build().expect(\"InputFieldBuilder fields all default\")"
+    )]
     input_field: InputField<ValueType>,
     #[getset(get = "pub")]
     #[builder(default = "SuggestInputStyle::default()")]

--- a/ferrowl-ui/src/widgets/table.rs
+++ b/ferrowl-ui/src/widgets/table.rs
@@ -95,7 +95,7 @@ where
     H: Header<N>,
 {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = TableStateBuilder::default().build().unwrap();
+        let mut state = TableStateBuilder::default().build().expect("TableStateBuilder fields all default");
         StatefulWidget::render(self, area, buf, &mut state);
     }
 }
@@ -162,7 +162,7 @@ where
             .map(|h| h.chars().count())
             .collect::<Vec<usize>>()
             .try_into()
-            .unwrap();
+            .expect("header() yields exactly N columns");
         let column_max_widths = state
             .values()
             .iter()
@@ -198,7 +198,7 @@ where
         state.set_total_width(std::cmp::max(table_width, area.width));
 
         let rows = state.values().iter().enumerate().map(|(i, item)| {
-            let color = self.style.rows.get(i % 2).unwrap();
+            let color = self.style.rows.get(i % 2).expect("rows is [Style; 2]; i % 2 is in bounds");
             let spacing =
                 itertools::repeat_n('\n', self.row_margin.vertical as usize).collect::<String>();
             let cell_styles = item.cell_styles();

--- a/ferrowl-ui/src/widgets/table.rs
+++ b/ferrowl-ui/src/widgets/table.rs
@@ -95,7 +95,9 @@ where
     H: Header<N>,
 {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let mut state = TableStateBuilder::default().build().expect("TableStateBuilder fields all default");
+        let mut state = TableStateBuilder::default()
+            .build()
+            .expect("TableStateBuilder fields all default");
         StatefulWidget::render(self, area, buf, &mut state);
     }
 }
@@ -198,7 +200,11 @@ where
         state.set_total_width(std::cmp::max(table_width, area.width));
 
         let rows = state.values().iter().enumerate().map(|(i, item)| {
-            let color = self.style.rows.get(i % 2).expect("rows is [Style; 2]; i % 2 is in bounds");
+            let color = self
+                .style
+                .rows
+                .get(i % 2)
+                .expect("rows is [Style; 2]; i % 2 is in bounds");
             let spacing =
                 itertools::repeat_n('\n', self.row_margin.vertical as usize).collect::<String>();
             let cell_styles = item.cell_styles();

--- a/ferrowl-ui/tests/render.rs
+++ b/ferrowl-ui/tests/render.rs
@@ -4,6 +4,9 @@
 //! branches. We assert that rendering does not panic and (where cheap) that
 //! something was drawn; the goal is to drive the layout/scroll logic.
 
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
 use ratatui::buffer::Buffer;
 use ratatui::layout::{HorizontalAlignment, Margin, Rect};
 use ratatui::widgets::{StatefulWidget, Widget as RWidget};

--- a/ferrowl/src/app/keys.rs
+++ b/ferrowl/src/app/keys.rs
@@ -111,7 +111,10 @@ impl App {
             // Ctrl+t then a digit: jump straight there, or wait for a second digit if one could
             // still form a valid two-digit index.
             (Some(KeyMode::CtrlTab), _, KeyCode::Char(c)) if c.is_ascii_digit() => {
-                let d = c.to_digit(10).unwrap() as usize;
+                let d = c
+                    .to_digit(10)
+                    .expect("c is an ASCII digit, matched by the guard above")
+                    as usize;
                 match digit_outcome(None, d, self.tabs.len()) {
                     DigitOutcome::Wait(first) => {
                         self.keymode = Some(KeyMode::TabDigit {
@@ -129,7 +132,10 @@ impl App {
             // Second digit of the chord, within the timeout window.
             (Some(KeyMode::TabDigit { first, .. }), _, KeyCode::Char(c)) if c.is_ascii_digit() => {
                 let first = *first;
-                let d = c.to_digit(10).unwrap() as usize;
+                let d = c
+                    .to_digit(10)
+                    .expect("c is an ASCII digit, matched by the guard above")
+                    as usize;
                 self.keymode = None;
                 if let DigitOutcome::Jump(idx) = digit_outcome(Some(first), d, self.tabs.len()) {
                     self.switch_tab(idx);

--- a/ferrowl/src/dialog/close_confirm.rs
+++ b/ferrowl/src/dialog/close_confirm.rs
@@ -89,7 +89,7 @@ impl CloseConfirmDialog {
                     .label("CLOSE".to_string())
                     .disabled(false)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
                 widget: ButtonBuilder::default()
                     .border_margin(Margin::new(1, 0))
                     .margin(Margin {
@@ -99,7 +99,7 @@ impl CloseConfirmDialog {
                     .style(button_style)
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .keybinds(Widget {
                 state: "<Enter>: close | <Esc>: cancel".to_string(),
@@ -111,10 +111,10 @@ impl CloseConfirmDialog {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(text_style)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .build()
-            .unwrap()
+            .expect("all required builder fields are set")
     }
 
     /// Feed one key while the confirm is open.

--- a/ferrowl/src/dialog/rename.rs
+++ b/ferrowl/src/dialog/rename.rs
@@ -57,7 +57,7 @@ impl RenamePrompt {
                 .disabled(false)
                 .placeholder(Some("Script name".to_string()))
                 .build()
-                .unwrap(),
+                .expect("all required builder fields are set"),
             widget: InputFieldBuilder::default()
                 .border(Border::Full(Margin::new(1, 0)))
                 .title(Some(("New name", HorizontalAlignment::Left).into()))
@@ -65,14 +65,14 @@ impl RenamePrompt {
                     InputFieldStyleBuilder::default()
                         .border(border_style())
                         .build()
-                        .unwrap(),
+                        .expect("all required builder fields are set"),
                 )
                 .margin(Margin {
                     vertical: 0,
                     horizontal: 0,
                 })
                 .build()
-                .unwrap(),
+                .expect("all required builder fields are set"),
         };
         input.state.set_input(current.to_string());
         input.state.set_cursor(current.chars().count());
@@ -90,7 +90,7 @@ impl RenamePrompt {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(TextStyle::default())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             },
         }
     }

--- a/ferrowl/src/dialog/script_manager.rs
+++ b/ferrowl/src/dialog/script_manager.rs
@@ -191,19 +191,26 @@ pub(crate) fn rows(scripts: &[ScriptDef]) -> Vec<ScriptRow> {
 
 pub(crate) fn script_table(rows: Vec<ScriptRow>) -> ScriptTable {
     Widget {
-        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        state: TableStateBuilder::default()
+            .values(rows)
+            .build()
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             // UI-R-056 — the full binding list lived here and overflowed the panel; it now lives in
             // the `?` overlay, and the title only points at it.
             .title(Some("Scripts (?: help)".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -214,7 +221,7 @@ pub(crate) fn name_input(border: Style) -> Widget<InputFieldState, InputField<St
             .disabled(false)
             .placeholder(Some("New Script".to_string()))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(("New Script", HorizontalAlignment::Left).into()))
@@ -222,14 +229,14 @@ pub(crate) fn name_input(border: Style) -> Widget<InputFieldState, InputField<St
                 InputFieldStyleBuilder::default()
                     .border(border)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -241,7 +248,7 @@ pub(crate) fn templates_button() -> Widget<ButtonState, Button> {
             .label("TEMPLATES".to_string())
             .disabled(false)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: ButtonBuilder::default()
             .border_margin(Margin::new(1, 0))
             .margin(Margin {
@@ -251,7 +258,7 @@ pub(crate) fn templates_button() -> Widget<ButtonState, Button> {
             .style(ButtonStyle::default())
             .horizontal_alignment(HorizontalAlignment::Center)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -263,7 +270,7 @@ pub(crate) fn code_editor(border: Style) -> Widget<CodeInputFieldState, CodeInpu
             .placeholder(Some("-- select or create a script".to_string()))
             .language(Some(Language::Lua))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: CodeInputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Code".into()))
@@ -271,14 +278,14 @@ pub(crate) fn code_editor(border: Style) -> Widget<CodeInputFieldState, CodeInpu
                 InputFieldStyleBuilder::default()
                     .border(border)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -493,19 +493,23 @@ fn interval_input() -> Widget<InputFieldState, InputField<Interval>> {
             .placeholder(Some("1.0".to_string()))
             .allowed_for::<Interval>()
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(
                 ("Interval (seconds)", HorizontalAlignment::Left).into(),
             ))
-            .style(InputFieldStyleBuilder::default().build().unwrap())
+            .style(
+                InputFieldStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/dialog/template_browser.rs
+++ b/ferrowl/src/dialog/template_browser.rs
@@ -220,17 +220,24 @@ fn rows(templates: &[&'static ScriptTemplate]) -> Vec<TemplateRow> {
 
 fn template_table(rows: Vec<TemplateRow>) -> TemplateTable {
     Widget {
-        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        state: TableStateBuilder::default()
+            .values(rows)
+            .build()
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Templates".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -243,7 +250,7 @@ fn preview_editor() -> Widget<CodeInputFieldState, CodeInputField> {
             .placeholder(Some("-- no template selected".to_string()))
             .language(Some(Language::Lua))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: CodeInputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Preview".into()))
@@ -251,14 +258,14 @@ fn preview_editor() -> Widget<CodeInputFieldState, CodeInputField> {
                 InputFieldStyleBuilder::default()
                     .border(border_style())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/module/modbus/dialog/add_value.rs
+++ b/ferrowl/src/module/modbus/dialog/add_value.rs
@@ -49,7 +49,7 @@ impl AddNamedValueDialog {
                     .disabled(false)
                     .placeholder(Some("Name...".to_string()))
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
                 widget: InputFieldBuilder::default()
                     .border(Border::Full(Margin::new(1, 0)))
                     .title(Some("Label".into()))
@@ -59,7 +59,7 @@ impl AddNamedValueDialog {
                     })
                     .style(input_style.clone())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .value(Widget {
                 state: InputFieldStateBuilder::default()
@@ -67,7 +67,7 @@ impl AddNamedValueDialog {
                     .disabled(false)
                     .placeholder(Some("0".to_string()))
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
                 widget: InputFieldBuilder::default()
                     .border(Border::Full(Margin::new(1, 0)))
                     .title(Some("Value".into()))
@@ -77,7 +77,7 @@ impl AddNamedValueDialog {
                     })
                     .style(input_style.clone())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .error(Widget {
                 state: "".to_string(),
@@ -90,7 +90,7 @@ impl AddNamedValueDialog {
                     })
                     .style(error_style.clone())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .keybinds([
                 Widget {
@@ -103,7 +103,7 @@ impl AddNamedValueDialog {
                         .horizontal_alignment(HorizontalAlignment::Center)
                         .style(text_style.clone())
                         .build()
-                        .unwrap(),
+                        .expect("all required builder fields are set"),
                 },
                 Widget {
                     state: "<Esc>: cancel | <Enter>: confirm / newline".to_string(),
@@ -115,12 +115,12 @@ impl AddNamedValueDialog {
                         .horizontal_alignment(HorizontalAlignment::Center)
                         .style(text_style.clone())
                         .build()
-                        .unwrap(),
+                        .expect("all required builder fields are set"),
                 },
             ])
             .focus(AddNamedValueDialogFocus::Label)
             .build()
-            .unwrap()
+            .expect("all required builder fields are set")
     }
 
     fn validate(&self) -> Result<(), String> {

--- a/ferrowl/src/module/modbus/dialog/confirm.rs
+++ b/ferrowl/src/module/modbus/dialog/confirm.rs
@@ -121,7 +121,7 @@ impl ConfirmDeleteDialog {
                     })
                     .style(warn_style)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .cancel_button(Widget {
                 state: ButtonStateBuilder::default()
@@ -129,7 +129,7 @@ impl ConfirmDeleteDialog {
                     .label("CANCEL".to_string())
                     .disabled(false)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
                 widget: ButtonBuilder::default()
                     .border_margin(Margin::new(1, 0))
                     .margin(Margin {
@@ -139,7 +139,7 @@ impl ConfirmDeleteDialog {
                     .style(button_style.clone())
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .delete_button(Widget {
                 state: ButtonStateBuilder::default()
@@ -147,7 +147,7 @@ impl ConfirmDeleteDialog {
                     .label("DELETE".to_string())
                     .disabled(false)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
                 widget: ButtonBuilder::default()
                     .border_margin(Margin::new(1, 0))
                     .margin(Margin {
@@ -157,7 +157,7 @@ impl ConfirmDeleteDialog {
                     .style(button_style)
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .keybinds(Widget {
                 state: "<Tab>: switch | <Space>/<Enter>: select | <Esc>: cancel".to_string(),
@@ -169,11 +169,11 @@ impl ConfirmDeleteDialog {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(text_style)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .focus(ConfirmDeleteDialogFocus::CancelButton)
             .build()
-            .unwrap()
+            .expect("all required builder fields are set")
     }
 
     /// Whether the DELETE button (rather than CANCEL) currently holds focus.

--- a/ferrowl/src/module/modbus/dialog/selection/render.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/render.rs
@@ -209,7 +209,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
                 })
                 .multiline(true)
                 .build()
-                .unwrap();
+                .expect("all required builder fields are set");
             let mut message: String = "No predefined values — reopen to use free-text input".into();
             StatefulWidget::render(&text, horizontal_layout[0], buf, &mut message);
         } else {

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -403,7 +403,7 @@ impl SetupDialog {
                     .multiline(true)
                     .style(error_style)
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .keybinds(Widget {
                 state: "<Tab> next   <Enter> confirm   <Esc> cancel".to_string(),
@@ -415,12 +415,12 @@ impl SetupDialog {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(TextStyle::default())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .mode(mode)
             .focus(SetupDialogFocus::Name)
             .build()
-            .unwrap();
+            .expect("all required builder fields are set");
 
         // Prefill timing inputs with the resolved defaults so clients always show a value.
         set_input(&mut dialog.timeout, &timing.timeout_ms.to_string());
@@ -824,7 +824,7 @@ fn input<T: Validate + Clone>(
             .placeholder(Some(placeholder.to_string()))
             .allowed_for::<T>()
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(
@@ -836,7 +836,7 @@ fn input<T: Validate + Clone>(
             })
             .style(style.clone())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -859,11 +859,11 @@ fn suggest_input<T: Validate + Clone, P: ferrowl_ui::traits::SuggestionProvider 
                     .placeholder(Some(placeholder.to_string()))
                     .allowed_for::<T>()
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .provider(provider)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: SuggestInputBuilder::default()
             .input_field(
                 InputFieldBuilder::default()
@@ -877,10 +877,10 @@ fn suggest_input<T: Validate + Clone, P: ferrowl_ui::traits::SuggestionProvider 
                     })
                     .style(style.clone())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -895,7 +895,7 @@ fn selection<T: ToLabel + Clone>(
             .focused(false)
             .values(values)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: SelectionBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(
@@ -907,7 +907,7 @@ fn selection<T: ToLabel + Clone>(
             })
             .style(style.clone())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -211,11 +211,18 @@ impl TableView {
     pub fn new(values: Vec<Definition>) -> Self {
         TableViewBuilder::default()
             .table(Widget {
-                state: TableStateBuilder::default().values(values).build().unwrap(),
+                state: TableStateBuilder::default()
+                    .values(values)
+                    .build()
+                    .expect("all required builder fields are set"),
                 widget: TableBuilder::default()
                     .border(Border::Full(Margin::new(1, 0)))
                     .title(Some("Register".into()))
-                    .style(TableStyleBuilder::default().build().unwrap())
+                    .style(
+                        TableStyleBuilder::default()
+                            .build()
+                            .expect("all required builder fields are set"),
+                    )
                     .split_by_whitespace([
                         true, true, true, true, true, true, true, true, true, false, true,
                     ])
@@ -224,11 +231,11 @@ impl TableView {
                         horizontal: 0,
                     })
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             })
             .focus(TableViewFocus::Table)
             .build()
-            .unwrap()
+            .expect("all required builder fields are set")
     }
 
     pub fn render(&mut self, area: Rect, buf: &mut Buffer) {

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -150,19 +150,24 @@ impl ModbusModuleView {
 
         if overlay.has_confirm_delete() {
             match code {
-                KeyCode::Esc => self.register_overlay_mut().unwrap().close_confirm_delete(),
+                KeyCode::Esc => self
+                    .register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .close_confirm_delete(),
                 KeyCode::Tab => self
                     .register_overlay_mut()
-                    .unwrap()
+                    .expect("a Register overlay was confirmed present at the top of this function")
                     .confirm_delete_focus_next(),
                 KeyCode::BackTab => self
                     .register_overlay_mut()
-                    .unwrap()
+                    .expect("a Register overlay was confirmed present at the top of this function")
                     .confirm_delete_focus_previous(),
                 KeyCode::Enter | KeyCode::Char(' ') => {
                     if self
                         .register_overlay()
-                        .unwrap()
+                        .expect(
+                            "a Register overlay was confirmed present at the top of this function",
+                        )
                         .confirm_delete_is_confirmed()
                     {
                         let name = self.table.selected().map(|d| d.name.clone());
@@ -171,7 +176,7 @@ impl ModbusModuleView {
                             self.pending = Some(PendingAction::Delete(name));
                         }
                     } else {
-                        self.register_overlay_mut().unwrap().close_confirm_delete();
+                        self.register_overlay_mut().expect("a Register overlay was confirmed present at the top of this function").close_confirm_delete();
                     }
                 }
                 _ => {}
@@ -181,26 +186,39 @@ impl ModbusModuleView {
 
         if overlay.has_sub_dialog() {
             match code {
-                KeyCode::Esc => self.register_overlay_mut().unwrap().close_add_dialog(),
-                KeyCode::Enter => self.register_overlay_mut().unwrap().confirm_add_dialog(),
-                KeyCode::Tab => self.register_overlay_mut().unwrap().add_dialog_focus_next(),
+                KeyCode::Esc => self
+                    .register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .close_add_dialog(),
+                KeyCode::Enter => self
+                    .register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .confirm_add_dialog(),
+                KeyCode::Tab => self
+                    .register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .add_dialog_focus_next(),
                 KeyCode::BackTab => self
                     .register_overlay_mut()
-                    .unwrap()
+                    .expect("a Register overlay was confirmed present at the top of this function")
                     .add_dialog_focus_previous(),
                 _ => self
                     .register_overlay_mut()
-                    .unwrap()
+                    .expect("a Register overlay was confirmed present at the top of this function")
                     .add_dialog_handle_events(modifiers, code),
             }
             return;
         }
 
         // The close-confirm popup takes precedence once open.
-        if self.register_overlay().unwrap().close_confirm_is_active() {
+        if self
+            .register_overlay()
+            .expect("a Register overlay was confirmed present at the top of this function")
+            .close_confirm_is_active()
+        {
             match self
                 .register_overlay_mut()
-                .unwrap()
+                .expect("a Register overlay was confirmed present at the top of this function")
                 .close_confirm_handle_key(modifiers, code)
             {
                 CloseConfirmEvent::Close => self.overlay.close(),
@@ -209,21 +227,32 @@ impl ModbusModuleView {
             return;
         }
 
-        self.register_overlay_mut().unwrap().clear_name_error();
+        self.register_overlay_mut()
+            .expect("a Register overlay was confirmed present at the top of this function")
+            .clear_name_error();
 
-        let confirm_button_focused = self.register_overlay().unwrap().is_confirm_button_focused();
+        let confirm_button_focused = self
+            .register_overlay()
+            .expect("a Register overlay was confirmed present at the top of this function")
+            .is_confirm_button_focused();
         let delete_button_focused = self
             .register_overlay()
-            .unwrap()
+            .expect("a Register overlay was confirmed present at the top of this function")
             .is_delete_register_button_focused();
 
         match (modifiers, code) {
             (KeyModifiers::NONE, KeyCode::Esc) => {
-                self.register_overlay_mut().unwrap().close_confirm_open();
+                self.register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .close_confirm_open();
             }
             (KeyModifiers::NONE, KeyCode::Enter) => {
                 if delete_button_focused {
-                    self.register_overlay_mut().unwrap().open_confirm_delete();
+                    self.register_overlay_mut()
+                        .expect(
+                            "a Register overlay was confirmed present at the top of this function",
+                        )
+                        .open_confirm_delete();
                 } else {
                     self.confirm_overlay();
                 }
@@ -232,21 +261,29 @@ impl ModbusModuleView {
                 if confirm_button_focused {
                     self.confirm_overlay();
                 } else {
-                    self.register_overlay_mut().unwrap().handle_space();
+                    self.register_overlay_mut()
+                        .expect(
+                            "a Register overlay was confirmed present at the top of this function",
+                        )
+                        .handle_space();
                 }
             }
             (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::BackTab) => {
-                self.register_overlay_mut().unwrap().focus_previous();
+                self.register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .focus_previous();
             }
             (KeyModifiers::NONE, KeyCode::Tab) => {
-                self.register_overlay_mut().unwrap().focus_next();
+                self.register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .focus_next();
             }
             (KeyModifiers::NONE, KeyCode::Char('z')) => {
                 self.table.set_compact(!self.table.compact);
             }
             _ => {
                 self.register_overlay_mut()
-                    .unwrap()
+                    .expect("a Register overlay was confirmed present at the top of this function")
                     .handle_events(modifiers, code);
             }
         }
@@ -273,12 +310,18 @@ impl ModbusModuleView {
                     && self.device.definitions.contains_key(&edited.name)
                 {
                     let msg = format!("Name '{}' already in use", edited.name);
-                    self.register_overlay_mut().unwrap().set_name_error(msg);
+                    self.register_overlay_mut()
+                        .expect(
+                            "a Register overlay was confirmed present at the top of this function",
+                        )
+                        .set_name_error(msg);
                     return;
                 }
             } else if self.device.definitions.contains_key(&edited.name) {
                 let msg = format!("Name '{}' already in use", edited.name);
-                self.register_overlay_mut().unwrap().set_name_error(msg);
+                self.register_overlay_mut()
+                    .expect("a Register overlay was confirmed present at the top of this function")
+                    .set_name_error(msg);
                 return;
             }
             self.overlay.close();
@@ -352,7 +395,7 @@ impl ModuleView for ModbusModuleView {
                         .bold(),
                 })
                 .build()
-                .unwrap();
+                .expect("all required builder fields are set");
             let mut label = if online {
                 "ONLINE".to_string()
             } else {

--- a/ferrowl/src/module/ocpp/client/config.rs
+++ b/ferrowl/src/module/ocpp/client/config.rs
@@ -174,7 +174,7 @@ fn input(title: &str, current: &str) -> Widget<InputFieldState, InputField<Strin
         .focused(false)
         .disabled(false)
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     state.set_input(current.to_string());
     state.set_cursor(current.chars().count());
     Widget {
@@ -188,7 +188,7 @@ fn input(title: &str, current: &str) -> Widget<InputFieldState, InputField<Strin
                 horizontal: 1,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -198,7 +198,7 @@ fn readonly_select(current: bool) -> Widget<SelectionState<String>, Selection<St
         .focused(false)
         .values(values)
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     state.set_selection(if current { 1 } else { 0 });
     Widget {
         state,
@@ -211,7 +211,7 @@ fn readonly_select(current: bool) -> Widget<SelectionState<String>, Selection<St
                 horizontal: 1,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/module/ocpp/client/view/render.rs
+++ b/ferrowl/src/module/ocpp/client/view/render.rs
@@ -156,7 +156,7 @@ impl<V: ClientVersion> ClientView<V> {
                     .bold(),
             })
             .build()
-            .unwrap();
+            .expect("all required builder fields are set");
         let mut status = if online { "ONLINE" } else { "OFFLINE" }.to_string();
         StatefulWidget::render(&status_widget, status_area, buf, &mut status);
     }
@@ -241,50 +241,71 @@ fn boxed(title: &str) -> Block<'_> {
 
 pub(super) fn nv_table(rows: Vec<NvRow>) -> StateTable {
     Widget {
-        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        state: TableStateBuilder::default()
+            .values(rows)
+            .build()
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("State".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
 pub(super) fn conn_table(rows: Vec<ConnRow>) -> ConnTable {
     Widget {
-        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        state: TableStateBuilder::default()
+            .values(rows)
+            .build()
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Connectors".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             // Always compact (no vertical margin), independent of `:compact`, to save space.
             .row_margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
 pub(super) fn config_table<V: ClientVersion>(rows: Vec<ConfigRow>) -> ConfigTable {
     Widget {
-        state: TableStateBuilder::default().values(rows).build().unwrap(),
+        state: TableStateBuilder::default()
+            .values(rows)
+            .build()
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(V::config_title().into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -295,7 +316,7 @@ pub(super) fn panel_input(title: &str) -> Widget<InputFieldState, InputField<Str
             .disabled(false)
             .placeholder(Some(title.to_string()))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some((title, HorizontalAlignment::Left).into()))
@@ -303,14 +324,14 @@ pub(super) fn panel_input(title: &str) -> Widget<InputFieldState, InputField<Str
                 InputFieldStyleBuilder::default()
                     .border(border_style())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -319,17 +340,21 @@ pub(super) fn msg_table() -> MsgTable {
         state: TableStateBuilder::default()
             .values(Vec::new())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Messages".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -341,7 +366,7 @@ pub(super) fn action_list(
             .focused(false)
             .values(values)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: SelectionBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some(("Actions", HorizontalAlignment::Left).into()))
@@ -355,14 +380,14 @@ pub(super) fn action_list(
                             .bold(),
                     )
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -376,7 +401,7 @@ pub fn choice(
         .focused(true)
         .values(values)
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     if let Some(idx) = options.iter().position(|o| *o == current) {
         state.set_selection(idx);
     }
@@ -389,7 +414,7 @@ pub fn choice(
                 horizontal: 1,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -400,7 +425,7 @@ pub fn number(current: f64) -> Widget<InputFieldState, InputField<f64>> {
         .disabled(false)
         .allowed_for::<f64>()
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     let text = format!("{current}");
     state.set_input(text.clone());
     state.set_cursor(text.chars().count());
@@ -413,7 +438,7 @@ pub fn number(current: f64) -> Widget<InputFieldState, InputField<f64>> {
                 horizontal: 1,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -423,7 +448,7 @@ pub fn text_input(current: &str) -> Widget<InputFieldState, InputField<String>> 
         .focused(true)
         .disabled(false)
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     state.set_input(current.to_string());
     state.set_cursor(current.chars().count());
     Widget {
@@ -435,7 +460,7 @@ pub fn text_input(current: &str) -> Widget<InputFieldState, InputField<String>> 
                 horizontal: 1,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -446,7 +471,7 @@ pub(super) fn scripts_button() -> Widget<ButtonState, Button> {
             .label("Lua Scripts".to_string())
             .disabled(false)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: ButtonBuilder::default()
             .border_margin(Margin::new(1, 0))
             .margin(Margin {
@@ -459,7 +484,7 @@ pub(super) fn scripts_button() -> Widget<ButtonState, Button> {
             })
             .horizontal_alignment(HorizontalAlignment::Center)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -471,7 +496,7 @@ pub(super) fn code_view() -> Widget<CodeInputFieldState, CodeInputField> {
             .placeholder(Some("select a message".to_string()))
             .language(Some(Language::Json))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: CodeInputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Payload".into()))
@@ -479,13 +504,13 @@ pub(super) fn code_view() -> Widget<CodeInputFieldState, CodeInputField> {
                 InputFieldStyleBuilder::default()
                     .border(border_style())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }

--- a/ferrowl/src/module/ocpp/server/view/render.rs
+++ b/ferrowl/src/module/ocpp/server/view/render.rs
@@ -137,7 +137,7 @@ where
                     .bold(),
             })
             .build()
-            .unwrap();
+            .expect("all required builder fields are set");
         let mut status = if online {
             format!("ONLINE  {}", self.backend.bound_addr().unwrap_or_default())
         } else {
@@ -179,17 +179,21 @@ pub(super) fn cs_table() -> CsTable {
         state: TableStateBuilder::default()
             .values(Vec::new())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(ratatui::layout::Margin::new(1, 0)))
             .title(Some("Charging Stations".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(ratatui::layout::Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -198,17 +202,21 @@ pub(super) fn msg_table() -> MsgTable {
         state: TableStateBuilder::default()
             .values(Vec::new())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(ratatui::layout::Margin::new(1, 0)))
             .title(Some("Messages".into()))
-            .style(TableStyleBuilder::default().build().unwrap())
+            .style(
+                TableStyleBuilder::default()
+                    .build()
+                    .expect("all required builder fields are set"),
+            )
             .row_margin(ratatui::layout::Margin {
                 vertical: 1,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -220,7 +228,7 @@ pub(super) fn action_list(
             .focused(false)
             .values(values)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: SelectionBuilder::default()
             .border(Border::Full(ratatui::layout::Margin::new(1, 0)))
             .title(Some(("Actions", HorizontalAlignment::Left).into()))
@@ -234,14 +242,14 @@ pub(super) fn action_list(
                             .bold(),
                     )
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(ratatui::layout::Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -252,7 +260,7 @@ pub(super) fn scripts_button() -> Widget<ButtonState, Button> {
             .label("Lua Scripts".to_string())
             .disabled(false)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: ButtonBuilder::default()
             .border_margin(ratatui::layout::Margin::new(1, 0))
             .margin(ratatui::layout::Margin {
@@ -265,7 +273,7 @@ pub(super) fn scripts_button() -> Widget<ButtonState, Button> {
             })
             .horizontal_alignment(HorizontalAlignment::Center)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -277,7 +285,7 @@ pub(super) fn code_view() -> Widget<CodeInputFieldState, CodeInputField> {
             .placeholder(Some("select a message".to_string()))
             .language(Some(Language::Json))
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: CodeInputFieldBuilder::default()
             .border(Border::Full(ratatui::layout::Margin::new(1, 0)))
             .title(Some("Payload".into()))
@@ -285,13 +293,13 @@ pub(super) fn code_view() -> Widget<CodeInputFieldState, CodeInputField> {
                 InputFieldStyleBuilder::default()
                     .border(border_style())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .margin(ratatui::layout::Margin {
                 vertical: 0,
                 horizontal: 0,
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }

--- a/ferrowl/src/module/ocpp/setup_dialog.rs
+++ b/ferrowl/src/module/ocpp/setup_dialog.rs
@@ -395,7 +395,7 @@ impl OcppSetupDialog {
             .keybinds(keybinds_text())
             .focus(OcppSetupDialogFocus::Name)
             .build()
-            .unwrap()
+            .expect("all required builder fields are set")
     }
 
     /// Build a dialog pre-filled with an existing spec + device-config path, for `:edit`.
@@ -1034,7 +1034,7 @@ fn input<T: Validate + Clone>(
             .placeholder(Some(placeholder.to_string()))
             .allowed_for::<T>()
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some((title, HorizontalAlignment::Left).into()))
@@ -1044,7 +1044,7 @@ fn input<T: Validate + Clone>(
             })
             .style(style.clone())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -1062,7 +1062,7 @@ fn suggest_input<T: Validate + Clone>(
     let mut state = SuggestInputStateBuilder::default()
         .provider(provider)
         .build()
-        .unwrap();
+        .expect("all required builder fields are set");
     state.set_placeholder(Some(placeholder.to_string()));
 
     Widget {
@@ -1078,11 +1078,11 @@ fn suggest_input<T: Validate + Clone>(
                     })
                     .style(style.clone())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .popup_style(SuggestInputStyle::default())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -1104,7 +1104,7 @@ fn selection<T: ToLabel + Clone>(
             .focused(false)
             .values(values)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: SelectionBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some((title, HorizontalAlignment::Left).into()))
@@ -1114,7 +1114,7 @@ fn selection<T: ToLabel + Clone>(
             })
             .style(style.clone())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -1132,7 +1132,7 @@ fn text(style: TextStyle) -> Widget<String, Text> {
             .horizontal_alignment(HorizontalAlignment::Center)
             .style(style)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -1149,7 +1149,7 @@ fn hint_text() -> Widget<String, Text> {
             .horizontal_alignment(HorizontalAlignment::Left)
             .style(TextStyle::default())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 
@@ -1165,7 +1165,7 @@ fn keybinds_text() -> Widget<String, Text> {
             .horizontal_alignment(HorizontalAlignment::Center)
             .style(TextStyle::default())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/module/type_select.rs
+++ b/ferrowl/src/module/type_select.rs
@@ -55,7 +55,7 @@ impl TypeSelectDialog {
                 .focused(true)
                 .values(values)
                 .build()
-                .unwrap(),
+                .expect("all required builder fields are set"),
             widget: SelectionBuilder::default()
                 .border(Border::Full(Margin::new(1, 0)))
                 .title(Some(("Type", HorizontalAlignment::Left).into()))
@@ -65,7 +65,7 @@ impl TypeSelectDialog {
                 })
                 .style(SelectionStyle::default())
                 .build()
-                .unwrap(),
+                .expect("all required builder fields are set"),
         };
 
         let keybinds = [
@@ -80,7 +80,7 @@ impl TypeSelectDialog {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(TextStyle::default())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             },
             Widget {
                 state: "<Esc>: cancel".to_string(),
@@ -93,7 +93,7 @@ impl TypeSelectDialog {
                     .horizontal_alignment(HorizontalAlignment::Center)
                     .style(TextStyle::default())
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             },
         ];
 

--- a/ferrowl/src/view/command.rs
+++ b/ferrowl/src/view/command.rs
@@ -19,7 +19,7 @@ pub fn new_command_line() -> CommandLine {
             .focused(false)
             .disabled(false)
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: InputFieldBuilder::default()
             .border(Border::None)
             .multiline(false)
@@ -34,7 +34,7 @@ pub fn new_command_line() -> CommandLine {
                 ..InputFieldStyle::default()
             })
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/view/log.rs
+++ b/ferrowl/src/view/log.rs
@@ -100,7 +100,7 @@ pub fn new_log_view() -> LogView {
             .focused(false)
             .values(Vec::new())
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
         widget: TableBuilder::default()
             .border(Border::Full(Margin::new(1, 0)))
             .title(Some("Log".into()))
@@ -112,10 +112,10 @@ pub fn new_log_view() -> LogView {
                             .fg(COLOR_SCHEME.text_hi),
                     )
                     .build()
-                    .unwrap(),
+                    .expect("all required builder fields are set"),
             )
             .build()
-            .unwrap(),
+            .expect("all required builder fields are set"),
     }
 }
 

--- a/ferrowl/src/view/tabs.rs
+++ b/ferrowl/src/view/tabs.rs
@@ -5,7 +5,9 @@ use ratatui::{buffer::Buffer, layout::Rect, widgets::StatefulWidget};
 
 /// Render the tab bar with `names`, scrolling as needed to keep `active` visible.
 pub fn render_tabs(names: &[String], active: usize, area: Rect, buf: &mut Buffer) {
-    let widget = ScrollingTabsBuilder::<String>::default().build().unwrap();
+    let widget = ScrollingTabsBuilder::<String>::default()
+        .build()
+        .expect("all required builder fields are set");
     let mut state = ScrollingTabsState {
         titles: names.to_vec(),
         selected: active,


### PR DESCRIPTION
Closes #84.

## Why

Every non-test `.unwrap()` should say why it cannot fail, and CI should keep it that way. An audit (`clippy::unwrap_used` with `allow-unwrap-in-tests`) found **176 bare `.unwrap()`** in non-test code across five crates. All were provably safe — no latent panics — so this is a legibility and ratchet change, not a bug fix:

- **142** derive_builder `build().unwrap()` with required fields set by adjacent literals
- **23** guarded Option access (modbus overlay), Some established by an early-return at the top of the enclosing function
- **4** map lookups after a `writable()?`/`readable()?` key check
- **7** misc: known-`Err` `.err()`, `to_digit` under an `is_ascii_digit()` guard, named-field proc-macro idents

## What

- Convert all 176 bare `.unwrap()` → `.expect("<why it cannot fail>")`. Only panic-message text changes; behavior is identical.
- The lua Result-filter idiom (`.err().unwrap()`) became `.expect_err(...)`, satisfying `clippy::err_expect`.
- Add workspace `clippy.toml`: `allow-unwrap-in-tests = true`, `allow-expect-in-tests = true`.
- Add `[workspace.lints.clippy] unwrap_used = "deny"`. `expect_used` stays off — `expect` is the sanctioned, documented form.
- Examples (`ferrowl-ui/examples/*`) and integration-test crates get a file-level `#![allow(clippy::unwrap_used)]` with a justifying comment. `allow-unwrap-in-tests` does not reach example binaries or helper code outside `#[test]` fns; those are demo/test code, exempt by intent.

## Non-goals

No behavior change, no new `Result` propagation (audited sites are provably safe), `expect` not banned, test code untouched.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean with the deny lint active, proving zero bare unwraps remain in non-test code.
- `cargo test --workspace` — green, 0 failures.
- `cargo fmt --check` — clean.
- Ratchet check: injected `Some(1u8).unwrap()` in non-test code, confirmed clippy rejects it, reverted.

No spec change — semantics are identical, so nothing in `docs/specs/` moves.