### PR TITLE
Add integration-test coverage for codec, store, syntax, and util

### DIFF
--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -1,0 +1,119 @@
+//! Integration coverage for `ferrowl-codec`'s public API: building a [`Register`], and
+//! round-tripping typed [`Value`]s through raw register words with `encode_value`/`decode`.
+//! These drive the crate exactly as a consumer (the Modbus module) does, over public paths only.
+
+use ferrowl_codec::format::{Resolution, Width};
+use ferrowl_codec::{
+    Access, Alignment, BitField, Endian, Format, Kind, RegisterBuilder, Value, decode, encode,
+    encode_value,
+};
+
+fn res() -> Resolution {
+    Resolution(1.0)
+}
+
+fn int(endian: Endian) -> Format {
+    Format::U16((endian, res(), BitField::default()))
+}
+
+#[test]
+fn it_register_builder_applies_documented_defaults() {
+    let reg = RegisterBuilder::default()
+        .format(int(Endian::Big))
+        .build()
+        .expect("only `format` is required to build a Register");
+    assert_eq!(*reg.slave_id(), 0);
+    assert_eq!(*reg.access(), Access::ReadWrite);
+    assert_eq!(*reg.kind(), Kind::InputRegister);
+}
+
+#[test]
+fn it_u16_value_roundtrips_through_words() {
+    let fmt = int(Endian::Big);
+    let words = encode_value(&fmt, &Value::U16((300, res()))).expect("300 fits a u16 register");
+    let back = decode(&fmt, &words).expect("freshly encoded words decode");
+    match back {
+        Value::U16((v, _)) => assert_eq!(v, 300),
+        other => panic!("expected U16, got {other:?}"),
+    }
+}
+
+#[test]
+fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
+    let value = Value::U32((0x0001_0002, res()));
+    let be = encode_value(
+        &Format::U32((Endian::Big, res(), BitField::default())),
+        &value,
+    )
+    .expect("value encodes big-endian");
+    let le = encode_value(
+        &Format::U32((Endian::Little, res(), BitField::default())),
+        &value,
+    )
+    .expect("value encodes little-endian");
+    assert_ne!(be, le, "the two byte orders must differ for this value");
+
+    let decoded = |fmt: Format, words: &[u16]| match decode(&fmt, words).expect("decodes") {
+        Value::U32((v, _)) => v,
+        other => panic!("expected U32, got {other:?}"),
+    };
+    assert_eq!(
+        decoded(Format::U32((Endian::Big, res(), BitField::default())), &be),
+        0x0001_0002
+    );
+    assert_eq!(
+        decoded(
+            Format::U32((Endian::Little, res(), BitField::default())),
+            &le
+        ),
+        0x0001_0002
+    );
+}
+
+#[test]
+fn it_signed_value_roundtrips_negative() {
+    let fmt = Format::I16((Endian::Big, res(), BitField::default()));
+    let words = encode_value(&fmt, &Value::I16((-5, res()))).expect("encodes -5");
+    match decode(&fmt, &words).expect("decodes") {
+        Value::I16((v, _)) => assert_eq!(v, -5),
+        other => panic!("expected I16, got {other:?}"),
+    }
+}
+
+#[test]
+fn it_float_value_roundtrips() {
+    let fmt = Format::F32((Endian::Big, res()));
+    let words = encode_value(&fmt, &Value::F32((1.5, res()))).expect("encodes 1.5");
+    match decode(&fmt, &words).expect("decodes") {
+        Value::F32((v, _)) => assert_eq!(v, 1.5),
+        other => panic!("expected F32, got {other:?}"),
+    }
+}
+
+#[test]
+fn it_ascii_value_roundtrips_through_string_encoding() {
+    let fmt = Format::Ascii((Alignment::Left, Width(4)));
+    let words = encode(&fmt, "Hi").expect("ASCII text encodes into 4 registers");
+    match decode(&fmt, &words).expect("decodes") {
+        Value::Ascii(s) => assert_eq!(s.trim_end_matches('\0').trim_end(), "Hi"),
+        other => panic!("expected Ascii, got {other:?}"),
+    }
+}
+
+#[test]
+fn it_decode_rejects_too_few_words() {
+    let fmt = Format::U32((Endian::Big, res(), BitField::default()));
+    assert!(
+        decode(&fmt, &[0x0001]).is_err(),
+        "a u32 needs two words; one must be rejected"
+    );
+}
+
+#[test]
+fn it_encode_rejects_unparseable_string() {
+    let fmt = int(Endian::Big);
+    assert!(
+        encode(&fmt, "not-a-number").is_err(),
+        "a non-numeric string must not encode into a numeric register"
+    );
+}

--- a/ferrowl-store/tests/memory_api.rs
+++ b/ferrowl-store/tests/memory_api.rs
@@ -1,0 +1,106 @@
+//! Integration coverage for `ferrowl-store`'s public [`Memory`] API: declaring regions, the
+//! access-checked read/write paths, the error variants they return, and the merge/widen
+//! semantics of [`Memory::add_ranges`]. Exercised through public paths as a consumer would.
+
+use ferrowl_store::{CellKind, CellType, Memory, MemoryError, Range};
+
+fn mem() -> Memory<u8> {
+    Memory::default()
+}
+
+#[test]
+fn it_declared_readwrite_region_roundtrips_values() {
+    let mut m = mem();
+    assert!(m.add_ranges(
+        1,
+        &CellKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)]
+    ));
+    m.write(1, &CellType::Register, &Range::new(0, 4), &[10, 20, 30, 40])
+        .expect("writing a declared read/write range succeeds");
+    let got = m
+        .read(1, &CellType::Register, &Range::new(0, 4))
+        .expect("reading a declared read/write range succeeds");
+    assert_eq!(got, vec![10, 20, 30, 40]);
+}
+
+#[test]
+fn it_read_on_unregistered_key_is_unknown_key() {
+    let m = mem();
+    let err = m
+        .read(9, &CellType::Register, &Range::new(0, 1))
+        .expect_err("a key with no declared regions cannot be read");
+    assert_eq!(err, MemoryError::UnknownKey);
+}
+
+#[test]
+fn it_write_with_wrong_length_is_length_mismatch() {
+    let mut m = mem();
+    m.add_ranges(
+        1,
+        &CellKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let err = m
+        .write(1, &CellType::Register, &Range::new(0, 4), &[1, 2])
+        .expect_err("value count must match the range length");
+    assert_eq!(
+        err,
+        MemoryError::LengthMismatch {
+            expected: 4,
+            got: 2
+        }
+    );
+}
+
+#[test]
+fn it_write_to_read_only_region_is_not_writable() {
+    let mut m = mem();
+    m.add_ranges(1, &CellKind::Read(CellType::Register), &[Range::new(0, 2)]);
+    let err = m
+        .write(1, &CellType::Register, &Range::new(0, 2), &[1, 2])
+        .expect_err("a read-only region rejects writes");
+    assert_eq!(err, MemoryError::AddressNotWritable);
+}
+
+#[test]
+fn it_read_from_write_only_region_is_not_readable() {
+    let mut m = mem();
+    m.add_ranges(1, &CellKind::Write(CellType::Register), &[Range::new(0, 2)]);
+    let err = m
+        .read(1, &CellType::Register, &Range::new(0, 2))
+        .expect_err("a write-only region rejects reads");
+    assert_eq!(err, MemoryError::AddressNotReadable);
+}
+
+#[test]
+fn it_overlapping_read_and_write_ranges_widen_to_readwrite() {
+    let mut m = mem();
+    assert!(m.add_ranges(1, &CellKind::Read(CellType::Register), &[Range::new(0, 4)]));
+    // A write range over the same cells widens their access rather than conflicting.
+    assert!(m.add_ranges(1, &CellKind::Write(CellType::Register), &[Range::new(0, 4)]));
+    m.write(1, &CellType::Register, &Range::new(0, 4), &[5, 6, 7, 8])
+        .expect("widened cells accept writes");
+    let got = m
+        .read(1, &CellType::Register, &Range::new(0, 4))
+        .expect("widened cells accept reads");
+    assert_eq!(got, vec![5, 6, 7, 8]);
+}
+
+#[test]
+fn it_incompatible_cell_type_overlap_is_rejected_and_leaves_memory_unchanged() {
+    let mut m = mem();
+    assert!(m.add_ranges(
+        1,
+        &CellKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)]
+    ));
+    m.write(1, &CellType::Register, &Range::new(0, 4), &[1, 2, 3, 4])
+        .expect("initial write succeeds");
+    // A coil range over register cells is an incompatible type: all-or-nothing rejection.
+    assert!(!m.add_ranges(1, &CellKind::ReadWrite(CellType::Coil), &[Range::new(2, 4)]));
+    let got = m
+        .read(1, &CellType::Register, &Range::new(0, 4))
+        .expect("the rejected declaration left the register region intact");
+    assert_eq!(got, vec![1, 2, 3, 4]);
+}

--- a/ferrowl-syntax/tests/format_and_indent.rs
+++ b/ferrowl-syntax/tests/format_and_indent.rs
@@ -1,0 +1,58 @@
+//! Integration coverage for `ferrowl-syntax`'s public API: [`format`] (source re-indenting,
+//! or `None` when the input can't be safely reformatted) and [`indent_delta`] (the block-depth
+//! hint an editor uses on Enter). Driven over public paths, as the TUI editor widget does.
+
+use ferrowl_syntax::{Language, format, indent_delta};
+
+#[test]
+fn it_format_returns_none_for_invalid_json() {
+    assert_eq!(
+        format(Language::Json, "{ not valid json "),
+        None,
+        "unparseable JSON must be left untouched (None), never mangled"
+    );
+}
+
+#[test]
+fn it_format_reformats_valid_json_and_is_idempotent() {
+    let once =
+        format(Language::Json, "{\"b\":2,\"a\":[1,2]}").expect("valid JSON reformats to Some");
+    assert!(once.contains('\n'), "pretty output spans multiple lines");
+    let twice = format(Language::Json, &once).expect("reformatted JSON is still valid");
+    assert_eq!(once, twice, "formatting is idempotent");
+}
+
+#[test]
+fn it_format_lua_always_returns_some() {
+    // Lua re-indenting never rejects: the caller always gets a buffer back.
+    assert!(format(Language::Lua, "local x=1\nif x then\nprint(x)\nend").is_some());
+}
+
+#[test]
+fn it_indent_delta_lua_opener_deepens_next_line() {
+    assert_eq!(indent_delta(Language::Lua, "function foo()"), 1);
+    assert_eq!(indent_delta(Language::Lua, "if cond then"), 1);
+}
+
+#[test]
+fn it_indent_delta_leading_closer_does_not_shift_next_line() {
+    // A leading closer dedents its own line, not the following one, so its net delta is zero.
+    assert_eq!(indent_delta(Language::Lua, "end"), 0);
+    assert_eq!(indent_delta(Language::Json, "}"), 0);
+}
+
+#[test]
+fn it_indent_delta_json_open_bracket_deepens() {
+    assert_eq!(indent_delta(Language::Json, "{"), 1);
+    assert_eq!(indent_delta(Language::Json, "["), 1);
+}
+
+#[test]
+fn it_indent_delta_ignores_block_words_inside_strings() {
+    // The lexers classify `if`/`then`/`end` inside a string literal as string text, so they
+    // must not count as block openers/closers.
+    assert_eq!(
+        indent_delta(Language::Lua, "local s = \"if x then end\""),
+        0
+    );
+}

--- a/ferrowl-util/tests/util_api.rs
+++ b/ferrowl-util/tests/util_api.rs
@@ -1,0 +1,120 @@
+//! Integration coverage for `ferrowl-util`'s public surface: the [`Converter`] file
+//! (de)serialization helpers and [`FileType`] inference, the `str!` macro, the [`Expect`]
+//! trait, and the tracked-task `tokio::spawn_detach`/`join_all` pair.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use ferrowl_util::convert::{Converter, Error, FileType};
+use ferrowl_util::{Expect, str};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Config {
+    name: String,
+    count: u32,
+    flags: Vec<bool>,
+}
+
+fn sample() -> Config {
+    Config {
+        name: "ferrowl".into(),
+        count: 3,
+        flags: vec![true, false, true],
+    }
+}
+
+/// A unique temp path so parallel test binaries never collide; removed on drop.
+struct TempPath(String);
+impl TempPath {
+    fn new(ext: &str) -> Self {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let p = std::env::temp_dir().join(format!(
+            "ferrowl-util-{}-{}.{ext}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        TempPath(p.to_string_lossy().into_owned())
+    }
+}
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn it_save_then_load_roundtrips_toml() {
+    let path = TempPath::new("toml");
+    Converter::save(&sample(), &path.0, FileType::Toml).expect("saves TOML");
+    let back: Config = Converter::load(&path.0, FileType::Toml).expect("loads TOML");
+    assert_eq!(back, sample());
+}
+
+#[test]
+fn it_save_then_load_roundtrips_json() {
+    let path = TempPath::new("json");
+    Converter::save(&sample(), &path.0, FileType::Json).expect("saves JSON");
+    let back: Config = Converter::load(&path.0, FileType::Json).expect("loads JSON");
+    assert_eq!(back, sample());
+}
+
+#[test]
+fn it_convert_toml_to_json_preserves_data() {
+    let toml = TempPath::new("toml");
+    let json = TempPath::new("json");
+    Converter::save(&sample(), &toml.0, FileType::Toml).expect("saves source TOML");
+    Converter::convert::<Config>(&toml.0, FileType::Toml, &json.0, FileType::Json)
+        .expect("converts TOML to JSON");
+    let back: Config = Converter::load(&json.0, FileType::Json).expect("loads converted JSON");
+    assert_eq!(back, sample());
+}
+
+#[test]
+fn it_filetype_infers_from_extension() {
+    assert_eq!(FileType::from_path("a/b.toml"), Some(FileType::Toml));
+    assert_eq!(FileType::from_path("a/b.JSON"), Some(FileType::Json));
+    assert_eq!(FileType::from_path("a/b.yaml"), None);
+    assert_eq!(FileType::from_path("noext"), None);
+}
+
+#[test]
+fn it_load_missing_file_is_deserialize_error() {
+    let err = Converter::load::<Config>("/no/such/ferrowl/file.toml", FileType::Toml)
+        .expect_err("a missing file cannot be loaded");
+    assert!(matches!(err, Error::Deserialize(_)));
+}
+
+#[test]
+fn it_str_macro_returns_owned_string() {
+    let owned: String = str!("literal");
+    assert_eq!(owned, "literal".to_string());
+}
+
+#[test]
+fn it_expect_trait_returns_value_on_ok() {
+    let r: Result<u8, &str> = Ok(7);
+    assert_eq!(r.panic(|e| format!("unexpected: {e}")), 7);
+}
+
+#[test]
+#[should_panic(expected = "boom happened")]
+fn it_expect_trait_panics_with_formatted_message_on_err() {
+    let r: Result<u8, &str> = Err("boom");
+    let _ = r.panic(|e| format!("{e} happened"));
+}
+
+#[tokio::test]
+async fn it_spawn_detach_runs_task_and_join_all_awaits_it() {
+    let done = Arc::new(AtomicBool::new(false));
+    let flag = done.clone();
+    ferrowl_util::tokio::spawn_detach(async move {
+        flag.store(true, Ordering::SeqCst);
+    })
+    .await;
+    ferrowl_util::tokio::join_all().await;
+    assert!(
+        done.load(Ordering::SeqCst),
+        "join_all must await the detached task to completion"
+    );
+}


### PR DESCRIPTION
Closes #87.

## Why

Four workspace crates shipped only inline `#[cfg(test)]` unit tests and no `tests/` directory, so nothing exercised their public API the way a consumer crate does. This adds a `tests/` suite to each, driving it over public paths only.

## What

**31 integration tests**, distinct from the existing inline `ut_` unit tests:

| Crate | Suite | Tests | Covers |
|---|---|---|---|
| `ferrowl-codec` | `codec_roundtrip.rs` | 8 | `Value`↔register-word round-trips (u16, u32 big/little-endian, signed, float, ASCII), builder defaults, decode/encode error paths |
| `ferrowl-store` | `memory_api.rs` | 7 | region declaration, access-checked read/write, all four `MemoryError` variants, merge/widen and all-or-nothing rejection of incompatible overlaps |
| `ferrowl-syntax` | `format_and_indent.rs` | 7 | `format` (None on invalid JSON, idempotent pretty-print, Lua), `indent_delta` (openers, leading-closer nets zero, block words inside strings ignored) |
| `ferrowl-util` | `util_api.rs` | 9 | `Converter` TOML/JSON round-trip and cross-conversion, `FileType::from_path`, `str!`, `Expect` (value + panic), tracked `tokio::spawn_detach`/`join_all` |

Tests use `expect`/`expect_err` throughout, so they satisfy the `unwrap_used` deny lint (#85) without a file-level allow.

## Non-goals

Test-only — no behavior change, no `docs/specs/` change, no refactoring of the crates under test. `ferrowl-syntax` coverage is intentionally shallower: its public surface is just `format`/`indent_delta` (the span highlighter is not public).

## Verification

- `cargo test --workspace` — the four new suites run, 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.