### PR TITLE
Exit the app when the startup new-module dialog is cancelled instead of leaving an empty shell

### DIFF
--- a/docs/specs/tui/edge-cases.md
+++ b/docs/specs/tui/edge-cases.md
@@ -41,6 +41,7 @@ it is not mistaken for an oversight and silently "fixed".
 |---|---|
 | `Esc` on a dialog with edits | Opens a close-confirm popup rather than discarding; `Enter`/`Space` confirms close, `Esc` returns to editing |
 | Creating a tab whose name collides with an existing tab | Refused; a Warning is logged to the active tab's log and the setup dialog stays open |
+| Startup new-module selector cancelled before any tab is created | The application exits — zero tabs with no dialog open is not a reachable resting state (UI-R-057) |
 | A rename/session-load produces a duplicate tab name | The later duplicate is auto-suffixed and a Warning is logged into the renamed tab's own log |
 | Dialog focus cycle reaches a field whose enabling condition is false | That field is skipped in the `Tab`/`Shift+Tab` cycle |
 | `:` or `?` pressed while a view overlay is open | Not treated as global; the key is delivered to the overlay (so `?` types into a Lua editor, `:` into a text field) |

--- a/docs/specs/tui/requirements.md
+++ b/docs/specs/tui/requirements.md
@@ -68,6 +68,14 @@ purposes.
 new-module type selector immediately, so the user is never left on an empty shell
 with no obvious action.
 
+**UI-R-057** — Whenever the application holds zero tabs and no modal layer is open
+— no app-level creation/type-select overlay, no session dialog, and no keybind-help
+dialog — it shall exit through the normal terminal-restoring exit path (UI-R-001).
+In particular, cancelling the startup new-module selector opened by UI-R-008 before
+any tab has been created shall quit the application rather than leave an empty shell.
+This invariant is a safety net independent of `:quit`/`:qall` (UI-R-019), which quit
+explicitly.
+
 ## Navigation & tab switching
 
 **UI-R-009** — `Ctrl+w` shall begin a window-switch chord; the following `j`, `k`,

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -295,6 +295,11 @@ pub struct App {
     session_sim: SessionSim,
 }
 
+/// UI-R-057: no tab and no open modal layer ⇒ nothing to interact with, so exit.
+fn is_empty_shell(tab_count: usize, modal_open: bool) -> bool {
+    tab_count == 0 && !modal_open
+}
+
 impl App {
     pub fn new(
         tabs: Vec<Tab>,
@@ -374,6 +379,13 @@ impl App {
         });
 
         loop {
+            // UI-R-057: no tab and no modal layer left is not a resting state — the only way to
+            // reach it is cancelling the startup selector (UI-R-008), so exit rather than sit on an
+            // empty shell. Checked at loop top so the frame after the cancel breaks before drawing.
+            if self.should_exit_empty() {
+                break;
+            }
+
             // A pending single-digit tab jump expires on its own if no second digit arrives.
             if let Some(KeyMode::TabDigit { first, deadline }) = self.keymode
                 && Instant::now() >= deadline
@@ -549,6 +561,13 @@ impl App {
         false
     }
 
+    /// UI-R-057: true once the app holds no tab and no modal layer (creation/type-select overlay,
+    /// session dialog, or keybind-help), i.e. there is nothing left to interact with.
+    fn should_exit_empty(&self) -> bool {
+        let modal_open = self.overlay.is_some() || self.session_dialog.is_some() || self.help_open;
+        is_empty_shell(self.tabs.len(), modal_open)
+    }
+
     fn close_overlay(&mut self) {
         self.overlay = None;
         self.focus = Focus::Content;
@@ -566,6 +585,17 @@ impl App {
 mod tests {
     use super::*;
     use std::io::Read;
+
+    /// UI-R-057 — exit only when zero tabs and no modal layer remain; any tab, or any open
+    /// layer with zero tabs (e.g. the startup selector before cancel), keeps the app running.
+    #[test]
+    fn ut_is_empty_shell() {
+        assert!(is_empty_shell(0, false));
+        assert!(!is_empty_shell(0, true)); // startup selector still open
+        assert!(!is_empty_shell(1, false)); // a tab exists
+        assert!(!is_empty_shell(3, false));
+        assert!(!is_empty_shell(2, true));
+    }
 
     #[test]
     fn log_ring_persists_lines_to_file_sink() {


### PR DESCRIPTION
## Why
Starting Ferrowl with no tabs configured opens the new-module type selector (UI-R-008). Cancelling that selector left the user on an empty shell — zero tabs, no dialog, no obvious action, loop still running. This makes that state exit instead.

## What changed (UI-R-057)
New requirement:

> **UI-R-057** — Whenever the application holds zero tabs and no modal layer is open — no app-level creation/type-select overlay, no session dialog, and no keybind-help dialog — it shall exit through the normal terminal-restoring exit path (UI-R-001). In particular, cancelling the startup new-module selector opened by UI-R-008 before any tab has been created shall quit the application rather than leave an empty shell. This invariant is a safety net independent of `:quit`/`:qall` (UI-R-019), which quit explicitly.

## How it was resolved
- Pure `is_empty_shell(tab_count, modal_open)` holds the rule; unit-testable without a terminal-bound `App`.
- `App::should_exit_empty(&self)` folds the three modal layers (`overlay`, `session_dialog`, `help_open`) into `modal_open` and forwards.
- The run loop checks it at loop top, so the frame after a cancel breaks before drawing the empty shell. Exit flows through the existing terminal-restore path (UI-R-001).
- The only reachable path into the state today is cancelling the UI-R-008 startup selector — no tab-close path can empty the list (`:quit` on the last tab quits directly, UI-R-019). Stated generally so it stays correct if future close paths appear.

## Verification
- `ut_is_empty_shell` (cites UI-R-057); `cargo test --workspace`, `clippy -D warnings`, `fmt --check` all green.
- Drove the real TUI with no config: startup selector stays open, a single `Esc` exits cleanly (code 0). Confirmed it does not exit prematurely while the selector is open.

Closes #96
