### PR TITLE
Cite requirement IDs on the test suite, and add the missing requirements it surfaced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ type (`feat/`, `fix/`, `docs/`).
    or helper detail that no requirement governs may stay untagged. Where a test verifies real
    behavior that no requirement yet states, add the requirement (a normative change — gate 1)
    rather than attach a loose ID.
+   The citing doc comment goes on the line **directly below** the `#[test]`/`#[tokio::test]`
+   attribute, immediately above the `fn`. A given requirement ID appears **at most once** per
+   test — one test verifying several requirements lists each once; never repeat the same ID.
    The task is not done until the plan's Verification method has actually been run and
    its outcome reported. Waiving it requires asking.
 7. **Reconcile the spec.** If implementation forced the behavior to differ from what

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,11 @@ type (`feat/`, `fix/`, `docs/`).
    the why. The spec is the first stage, hence the first commit — legal on a branch,
    never on `main`.
    Every new or changed requirement ships with at least one test whose doc comment cites
-   its ID (`/// UI-R-051 — …`). Do not backfill IDs onto existing tests.
+   its ID (`/// UI-R-051 — …`). Existing tests carry IDs on the same terms: every test that
+   pins observable behavior shall cite the requirement it verifies. A test of a pure internal
+   or helper detail that no requirement governs may stay untagged. Where a test verifies real
+   behavior that no requirement yet states, add the requirement (a normative change — gate 1)
+   rather than attach a loose ID.
    The task is not done until the plan's Verification method has actually been run and
    its outcome reported. Waiving it requires asking.
 7. **Reconcile the spec.** If implementation forced the behavior to differ from what

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,13 @@ type (`feat/`, `fix/`, `docs/`).
    functions change, the chosen approach. That is part of the implementation, so it belongs
    to the plan (gate 2) and to the PR that describes how the issue was resolved, never to
    the issue.
+
+   **Structure every issue with `##` section headers**, not a wall of prose, so a reader can
+   scan it: a `## Background` (or `## Why`) stating the problem and context, a `## Scope` (or
+   the requirement changes) naming what is in scope, and a `## Goal` stating the outcome.
+   Add further sections as the issue warrants. Keep long enumerations compact (grouped ID
+   ranges, not one paragraph per item). The same structured, header-per-section shape applies
+   to PR bodies (gate 3).
 4. **Write the spec into the working tree.** Do not mark it "unfinished" in the file —
    the file only ever contains normative text. The plan tracks what is not yet backed by
    a passing test.

--- a/docs/specs/modbus/data-contract.md
+++ b/docs/specs/modbus/data-contract.md
@@ -51,7 +51,7 @@ Thirteen formats. Every one of them determines a fixed width in 16-bit registers
 ### 2.1 `U8` / `I8`
 
 An 8-bit format still occupies a **whole 16-bit register**, never half of one. The
-byte sits in the register's **high** byte under `Big` endian and in its **low**
+byte sits in the register's **low** byte under `Big` endian and in its **high**
 byte under `Little` endian.
 
 ### 2.2 Byte order

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -61,7 +61,7 @@ aliasing the same address. Words absent from `old` shall be treated as zero.
 configured width. Byte length shall be twice the register width.
 
 **MB-R-012** — `U8` and `I8` shall occupy a whole 16-bit register; the byte shall
-sit in the high byte for big-endian and the low byte for little-endian.
+sit in the low byte for big-endian and the high byte for little-endian.
 
 **MB-R-013** — Every integer and float format shall carry a byte order of either
 `Big` or `Little`. Big-endian shall interpret the register words' byte stream in

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -31,6 +31,9 @@ tables: coil, discrete input, holding register, input register.
 **MB-R-005** — A register's access shall be one of `ReadOnly`, `WriteOnly`,
 `ReadWrite`, defaulting to `ReadWrite`.
 
+**MB-R-097** — A register definition's kind shall default to holding register
+when unspecified.
+
 **MB-R-006** — A register's format shall determine its width in 16-bit registers,
 and that width shall be the number of consecutive addresses the register occupies
 starting at its address.

--- a/docs/specs/scripting/requirements.md
+++ b/docs/specs/scripting/requirements.md
@@ -198,6 +198,14 @@ from disk at run time (SC-R-023 stands).
 **SC-R-037** — Every template's code body shall be loadable by the Lua runtime — a
 template that fails to compile shall be a build/test failure, not a run-time one.
 
+**SC-R-038** — The `C_Test` module shall expose `Assert(cond, msg)` and
+`Fail(msg)`. `Assert` shall raise a runtime error `assertion failed: <msg>` when
+`cond` is Lua-falsy (only `nil` or `false`) and shall otherwise return with no
+effect — every other value, including `0` and the empty string, is truthy and
+passes. `Fail(msg)` shall always raise `assertion failed: <msg>`. The
+`assertion failed:` prefix is the text a headless runner keys its exit code off
+(see [`../cli-headless/requirements.md`](../cli-headless/requirements.md)).
+
 ---
 
 ## State access semantics

--- a/docs/specs/tui/requirements.md
+++ b/docs/specs/tui/requirements.md
@@ -222,6 +222,17 @@ run once, toggle enabled, delete, compact) with a one-line description each. `Es
 keys. The script table's title shall advertise only this overlay, not the individual
 bindings.
 
+**UI-R-058** — In the script-manager dialog, while the script table is focused, the
+table shall support editing its working script list: entering a non-empty name in the
+new-script input and confirming shall add a new enabled, empty script (a name that is
+empty or already used by another script is refused, per the same rule as UI-R-055);
+`t` shall toggle the selected script between enabled and disabled; `d` shall delete the
+selected script after a yes/no confirmation (UI-R-023); and `c` shall toggle the table
+between compact and normal row rendering. `t` and `d` shall be a no-op when no script is
+selected. These edits change the dialog's working list only and take effect on the owner
+when the dialog is applied (per SC-R-024); they are the bindings advertised by the
+table's help overlay (UI-R-056).
+
 ## Code editor (vim-modal)
 
 **UI-R-027** — The multi-line code editor shall support two operating profiles:

--- a/ferrowl-codec/src/access.rs
+++ b/ferrowl-codec/src/access.rs
@@ -29,8 +29,8 @@ impl Display for Access {
 mod tests {
     use super::Access;
 
-    /// MB-R-005 — access is exactly one of `ReadOnly`, `WriteOnly`, `ReadWrite`.
     #[test]
+    /// MB-R-005 — access is exactly one of `ReadOnly`, `WriteOnly`, `ReadWrite`.
     fn ut_access_display() {
         assert_eq!(Access::ReadOnly.to_string(), "ReadOnly");
         assert_eq!(Access::WriteOnly.to_string(), "WriteOnly");

--- a/ferrowl-codec/src/access.rs
+++ b/ferrowl-codec/src/access.rs
@@ -29,6 +29,7 @@ impl Display for Access {
 mod tests {
     use super::Access;
 
+    /// MB-R-005 — access is exactly one of `ReadOnly`, `WriteOnly`, `ReadWrite`.
     #[test]
     fn ut_access_display() {
         assert_eq!(Access::ReadOnly.to_string(), "ReadOnly");

--- a/ferrowl-codec/src/address.rs
+++ b/ferrowl-codec/src/address.rs
@@ -26,8 +26,8 @@ impl Display for Address {
 mod tests {
     use super::Address;
 
-    /// MB-R-003 — an address is either a fixed 16-bit Modbus address or virtual.
     #[test]
+    /// MB-R-003 — an address is either a fixed 16-bit Modbus address or virtual.
     fn ut_address_display() {
         assert_eq!(Address::Fixed(42).to_string(), "42");
         assert_eq!(Address::Virtual.to_string(), "virtual");

--- a/ferrowl-codec/src/address.rs
+++ b/ferrowl-codec/src/address.rs
@@ -26,6 +26,7 @@ impl Display for Address {
 mod tests {
     use super::Address;
 
+    /// MB-R-003 — an address is either a fixed 16-bit Modbus address or virtual.
     #[test]
     fn ut_address_display() {
         assert_eq!(Address::Fixed(42).to_string(), "42");

--- a/ferrowl-codec/src/codec.rs
+++ b/ferrowl-codec/src/codec.rs
@@ -486,6 +486,7 @@ mod tests {
 
     // --- Too few bytes ---
 
+    /// MB-R-023 — decoding fails with a too-few-bytes error when fewer words than the format width are supplied.
     #[test]
     fn ut_decode_too_few_bytes() {
         assert!(reg(u32_be()).decode(&[0x0001]).is_err());
@@ -533,6 +534,7 @@ mod tests {
 
     // --- U8 round-trip ---
 
+    /// MB-R-007 — encoding then decoding a U8 recovers the value.
     #[test]
     fn ut_roundtrip_u8_big() {
         let r = reg(u8_be());
@@ -541,6 +543,7 @@ mod tests {
         assert_eq!(decoded.to_string(), "200");
     }
 
+    /// MB-R-007 — encoding then decoding a little-endian U8 recovers the value.
     #[test]
     fn ut_roundtrip_u8_little() {
         let r = reg(u8_le());
@@ -570,17 +573,20 @@ mod tests {
 
     // --- I8 encode ---
 
+    /// MB-R-022 — a signed format accepts a plain negative decimal literal.
     #[test]
     fn ut_encode_i8_decimal_negative() {
         assert_eq!(reg(i8_be()).encode("-1").unwrap(), vec![-1i8 as u16]);
     }
 
+    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the bit pattern.
     #[test]
     fn ut_encode_i8_hex() {
         // "0xFF" → u8 0xFF as i8 = -1
         assert_eq!(reg(i8_be()).encode("0xFF").unwrap(), vec![-1i8 as u16]);
     }
 
+    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     #[test]
     fn ut_encode_i8_neg_hex() {
         // "-0x01" → -1i8
@@ -589,6 +595,7 @@ mod tests {
 
     // --- I8 round-trip ---
 
+    /// MB-R-007 — encoding then decoding an I8 recovers the value across its range.
     #[test]
     fn ut_roundtrip_i8() {
         let r = reg(i8_be());
@@ -601,6 +608,7 @@ mod tests {
 
     // --- U32 decode ---
 
+    /// MB-R-013 — big-endian decodes the register words' byte stream in wire order.
     #[test]
     fn ut_decode_u32_big() {
         match reg(u32_be()).decode(&[0x0001, 0x0002]).unwrap() {
@@ -609,6 +617,7 @@ mod tests {
         }
     }
 
+    /// MB-R-013 — little-endian decodes the register words' byte stream fully reversed.
     #[test]
     fn ut_decode_u32_little() {
         // Bytes [0x01, 0x02, 0x03, 0x04] reversed = [0x04, 0x03, 0x02, 0x01]
@@ -621,6 +630,7 @@ mod tests {
 
     // --- U32 encode ---
 
+    /// MB-R-013 — big-endian encodes the value's byte stream in wire order.
     #[test]
     fn ut_encode_u32_big() {
         // 65538 = 0x00010002
@@ -630,6 +640,7 @@ mod tests {
         );
     }
 
+    /// MB-R-022 — a `0x`-prefixed hex literal is accepted for numeric input.
     #[test]
     fn ut_encode_u32_big_hex() {
         assert_eq!(
@@ -638,6 +649,7 @@ mod tests {
         );
     }
 
+    /// MB-R-013 — little-endian encodes the value's byte stream fully reversed.
     #[test]
     fn ut_encode_u32_little() {
         // 0x00010002 in LE bytes: [0x02, 0x00, 0x01, 0x00] → registers [0x0200, 0x0100]
@@ -649,6 +661,7 @@ mod tests {
 
     // --- U32 round-trip ---
 
+    /// MB-R-007 — encoding then decoding a big-endian U32 recovers the value.
     #[test]
     fn ut_roundtrip_u32_big() {
         let r = reg(u32_be());
@@ -657,6 +670,7 @@ mod tests {
         assert_eq!(decoded.to_string(), "123456789");
     }
 
+    /// MB-R-007 — encoding then decoding a little-endian U32 recovers the value.
     #[test]
     fn ut_roundtrip_u32_little() {
         let r = reg(u32_le());
@@ -667,6 +681,7 @@ mod tests {
 
     // --- I32 round-trip ---
 
+    /// MB-R-007 — encoding then decoding a big-endian I32 recovers the value across its range.
     #[test]
     fn ut_roundtrip_i32_big() {
         let r = reg(i32_be());
@@ -677,6 +692,7 @@ mod tests {
         }
     }
 
+    /// MB-R-007 — encoding then decoding a little-endian I32 recovers the value across its range.
     #[test]
     fn ut_roundtrip_i32_little() {
         let r = reg(i32_le());
@@ -687,6 +703,7 @@ mod tests {
         }
     }
 
+    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     #[test]
     fn ut_encode_i32_neg_hex() {
         // "-0x01" → -1i32
@@ -698,6 +715,7 @@ mod tests {
         }
     }
 
+    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the two's-complement bit pattern.
     #[test]
     fn ut_encode_i32_hex_two_complement() {
         // "0xFFFFFFFF" → u32 all-ones as i32 = -1
@@ -711,6 +729,7 @@ mod tests {
 
     // --- F32 ---
 
+    /// MB-R-018 — a float decodes from its raw IEEE 754 bit pattern.
     #[test]
     fn ut_decode_f32_big() {
         let bits = 1.5f32.to_bits();
@@ -721,6 +740,7 @@ mod tests {
         }
     }
 
+    /// MB-R-018 — a float encodes as its raw IEEE 754 bit pattern.
     #[test]
     fn ut_encode_f32_decimal() {
         let bits = 1.5f32.to_bits();
@@ -728,6 +748,7 @@ mod tests {
         assert_eq!(reg(f32_be()).encode("1.5").unwrap(), expected);
     }
 
+    /// MB-R-018 — encoding then decoding an F32 recovers the value via its bit pattern.
     #[test]
     fn ut_roundtrip_f32_big() {
         let r = reg(f32_be());
@@ -738,6 +759,7 @@ mod tests {
         }
     }
 
+    /// MB-R-022 — a `0x` literal on a float format is taken as its IEEE 754 bit pattern.
     #[test]
     fn ut_encode_f32_hex() {
         let bits = 1.5f32.to_bits();
@@ -748,6 +770,7 @@ mod tests {
 
     // --- F64 ---
 
+    /// MB-R-018 — encoding then decoding an F64 recovers the value via its bit pattern.
     #[test]
     fn ut_roundtrip_f64_big() {
         let r = reg(f64_be());
@@ -760,6 +783,7 @@ mod tests {
 
     // --- Ascii ---
 
+    /// MB-R-019 — `Ascii` packs two characters per register.
     #[test]
     fn ut_decode_ascii_exact_fill() {
         // "ABCD" fills exactly 4 bytes (Width(2) = 2 registers = 4 bytes)
@@ -770,6 +794,7 @@ mod tests {
         }
     }
 
+    /// MB-R-020 — `Left` alignment zero-pads on the right to `2 × width` bytes.
     #[test]
     fn ut_encode_ascii_left_aligned() {
         // "AB" left-aligned in 4 bytes: [0x41, 0x42, 0x00, 0x00]
@@ -777,6 +802,7 @@ mod tests {
         assert_eq!(r.encode("AB").unwrap(), vec![0x4142u16, 0x0000u16]);
     }
 
+    /// MB-R-020 — `Right` alignment zero-pads on the left to `2 × width` bytes.
     #[test]
     fn ut_encode_ascii_right_aligned() {
         // "AB" right-aligned in 4 bytes: [0x00, 0x00, 0x41, 0x42]
@@ -784,6 +810,7 @@ mod tests {
         assert_eq!(r.encode("AB").unwrap(), vec![0x0000u16, 0x4142u16]);
     }
 
+    /// MB-R-007 — encoding then decoding an exact-fill ASCII value recovers the string.
     #[test]
     fn ut_roundtrip_ascii_exact() {
         // Exact fill avoids null-padding in round-trip
@@ -797,6 +824,7 @@ mod tests {
 
     // --- Resolution scaling ---
 
+    /// MB-R-021 — the display resolution scales the shown value but not the words on the wire.
     #[test]
     fn ut_decode_u16_with_resolution() {
         let r = reg(Format::U16((Endian::Big, Resolution(0.5), bf())));
@@ -812,6 +840,7 @@ mod tests {
         Format::U16((Endian::Big, res(), BitField { mask }))
     }
 
+    /// MB-R-015 — decoding an integer field yields `(raw & mask) >> shift`.
     #[test]
     fn ut_decode_u16_high_byte_field() {
         // mask 0xFF00 → shift 8: raw 0xAB12 reads as 0xAB.
@@ -821,6 +850,7 @@ mod tests {
         }
     }
 
+    /// MB-R-015 — a low-byte mask (shift 0) decodes as `raw & mask`.
     #[test]
     fn ut_decode_u16_low_byte_field() {
         // mask 0x00FF → shift 0: raw 0xAB12 reads as 0x12.
@@ -830,6 +860,7 @@ mod tests {
         }
     }
 
+    /// MB-R-015 — encoding a field places the value as `(value << shift) & mask`, other bits zero.
     #[test]
     fn ut_encode_u16_high_byte_field() {
         // value 0x12 placed into mask 0xFF00 → word 0x1200, other bits zero.
@@ -839,6 +870,7 @@ mod tests {
         );
     }
 
+    /// MB-R-015 — encoding then decoding a bit-field value recovers the field.
     #[test]
     fn ut_roundtrip_u16_field() {
         let r = reg(u16_be_mask(0x0FF0));
@@ -851,6 +883,7 @@ mod tests {
         }
     }
 
+    /// MB-R-014 — the full-width default mask is a no-op on encode and decode.
     #[test]
     fn ut_full_mask_is_noop() {
         // Default (full) mask encodes/decodes exactly like before.
@@ -862,6 +895,7 @@ mod tests {
         }
     }
 
+    /// MB-R-009 — a register exposes a per-word write mask selecting exactly the bits it owns.
     #[test]
     fn ut_mask_words_layout() {
         // U16 mask laid out as a single word.
@@ -881,6 +915,7 @@ mod tests {
 
     // --- Wider integer variants, both endians (decode/encode/mask) ---
 
+    /// MB-R-007 — encoding then decoding the wide integer formats recovers the value in both byte orders.
     #[test]
     fn ut_roundtrip_wide_ints() {
         let e = [Endian::Big, Endian::Little];
@@ -907,6 +942,7 @@ mod tests {
         }
     }
 
+    /// MB-R-018 — floats encode/decode via their bit pattern under little-endian byte order.
     #[test]
     fn ut_roundtrip_floats_little_endian() {
         let f32le = reg(Format::F32((Endian::Little, res())));
@@ -924,6 +960,7 @@ mod tests {
         }
     }
 
+    /// MB-R-022 — a `0x` literal on an F64 format is taken as its IEEE 754 bit pattern.
     #[test]
     fn ut_encode_f64_hex() {
         let bits = 2.5f64.to_bits();
@@ -943,6 +980,7 @@ mod tests {
         assert_eq!(r.encode("-1").unwrap(), vec![(-1i8 as u16) << 8]);
     }
 
+    /// MB-R-009 — the per-word write mask is laid out correctly across every format width.
     #[test]
     fn ut_mask_words_all_widths() {
         // U8 little-endian mask sits in the high byte.
@@ -976,6 +1014,7 @@ mod tests {
         );
     }
 
+    /// MB-R-009 — the merge `(old & !mask) | (new & mask)` preserves bits owned by sibling registers.
     #[test]
     fn ut_merge_write_preserves_sibling_bits() {
         // Two U16 regs aliasing one address: low byte and high byte.
@@ -1000,6 +1039,7 @@ mod tests {
 
     // --- Typed encode_value: equivalence with the string path ---
 
+    /// MB-R-007 — encoding a typed value produces the same words as encoding the equivalent string.
     #[test]
     fn ut_encode_value_matches_string_path_all_variants() {
         let e = [Endian::Big, Endian::Little];
@@ -1080,6 +1120,7 @@ mod tests {
         );
     }
 
+    /// MB-R-021 — the typed encode path applies the bit-field but not the resolution, matching the wire words.
     #[test]
     fn ut_encode_value_bitfield_and_resolution() {
         // Bit-field placement applies identically via the typed path.
@@ -1093,6 +1134,7 @@ mod tests {
         assert_eq!(words, encode(&format, "2048").unwrap());
     }
 
+    /// MB-R-007 — encoding a typed value then decoding recovers it.
     #[test]
     fn ut_encode_value_roundtrip_via_decode() {
         let r = reg(i32_le());
@@ -1107,6 +1149,7 @@ mod tests {
 
     // --- Bit-field mask width validation ---
 
+    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on decode.
     #[test]
     fn ut_decode_bitfield_mask_out_of_width_errors() {
         // 0x1FF on a U8 sets bit 8, outside the 8-bit width.
@@ -1120,6 +1163,7 @@ mod tests {
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
     }
 
+    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on encode.
     #[test]
     fn ut_encode_bitfield_mask_out_of_width_errors() {
         let format = Format::U8((Endian::Big, res(), BitField { mask: 0x1FF }));
@@ -1130,6 +1174,7 @@ mod tests {
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
     }
 
+    /// MB-R-016 — masks within the format width are accepted on decode and encode.
     #[test]
     fn ut_bitfield_mask_in_width_still_works() {
         // Existing in-width masks keep decoding/encoding as before.
@@ -1138,6 +1183,7 @@ mod tests {
         assert!(reg(u8_be()).decode(&[0x00FF]).is_ok());
     }
 
+    /// MB-R-008 — encoding a typed value whose type does not match the format fails with a mismatch error.
     #[test]
     fn ut_encode_value_mismatch_errors() {
         let format = u32_be();

--- a/ferrowl-codec/src/codec.rs
+++ b/ferrowl-codec/src/codec.rs
@@ -486,8 +486,8 @@ mod tests {
 
     // --- Too few bytes ---
 
-    /// MB-R-023 — decoding fails with a too-few-bytes error when fewer words than the format width are supplied.
     #[test]
+    /// MB-R-023 — decoding fails with a too-few-bytes error when fewer words than the format width are supplied.
     fn ut_decode_too_few_bytes() {
         assert!(reg(u32_be()).decode(&[0x0001]).is_err());
         assert!(
@@ -499,8 +499,8 @@ mod tests {
 
     // --- U8 decode ---
 
-    /// MB-R-012 — a big-endian U8 reads the byte from the register's low byte.
     #[test]
+    /// MB-R-012 — a big-endian U8 reads the byte from the register's low byte.
     fn ut_decode_u8_big() {
         match reg(u8_be()).decode(&[0x00FF]).unwrap() {
             Value::U8((v, _)) => assert_eq!(v, 0xFF),
@@ -508,8 +508,8 @@ mod tests {
         }
     }
 
-    /// MB-R-012 — a little-endian U8 reads the byte from the register's high byte.
     #[test]
+    /// MB-R-012 — a little-endian U8 reads the byte from the register's high byte.
     fn ut_decode_u8_little() {
         match reg(u8_le()).decode(&[0xFF00]).unwrap() {
             Value::U8((v, _)) => assert_eq!(v, 0xFF),
@@ -519,28 +519,28 @@ mod tests {
 
     // --- U8 encode ---
 
-    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (decimal input).
     #[test]
+    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (decimal input).
     fn ut_encode_u8_big_decimal() {
         assert_eq!(reg(u8_be()).encode("255").unwrap(), vec![0x00FFu16]);
     }
 
-    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (hex input).
     #[test]
+    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (hex input).
     fn ut_encode_u8_big_hex() {
         assert_eq!(reg(u8_be()).encode("0xFF").unwrap(), vec![0x00FFu16]);
     }
 
-    /// MB-R-012 — a little-endian U8 places the byte in the register's high byte.
     #[test]
+    /// MB-R-012 — a little-endian U8 places the byte in the register's high byte.
     fn ut_encode_u8_little() {
         assert_eq!(reg(u8_le()).encode("255").unwrap(), vec![0xFF00u16]);
     }
 
     // --- U8 round-trip ---
 
-    /// MB-R-007 — encoding then decoding a U8 recovers the value.
     #[test]
+    /// MB-R-007 — encoding then decoding a U8 recovers the value.
     fn ut_roundtrip_u8_big() {
         let r = reg(u8_be());
         let words = r.encode("200").unwrap();
@@ -548,8 +548,8 @@ mod tests {
         assert_eq!(decoded.to_string(), "200");
     }
 
-    /// MB-R-007 — encoding then decoding a little-endian U8 recovers the value.
     #[test]
+    /// MB-R-007 — encoding then decoding a little-endian U8 recovers the value.
     fn ut_roundtrip_u8_little() {
         let r = reg(u8_le());
         let words = r.encode("42").unwrap();
@@ -559,8 +559,8 @@ mod tests {
 
     // --- I8 decode ---
 
-    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (negative value).
     #[test]
+    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (negative value).
     fn ut_decode_i8_negative() {
         // -1i8 as u8 = 0xFF; stored in low byte of register
         match reg(i8_be()).decode(&[0x00FF]).unwrap() {
@@ -569,8 +569,8 @@ mod tests {
         }
     }
 
-    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (positive value).
     #[test]
+    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (positive value).
     fn ut_decode_i8_positive() {
         match reg(i8_be()).decode(&[0x0042]).unwrap() {
             Value::I8((v, _)) => assert_eq!(v, 66i8),
@@ -580,21 +580,21 @@ mod tests {
 
     // --- I8 encode ---
 
-    /// MB-R-022 — a signed format accepts a plain negative decimal literal.
     #[test]
+    /// MB-R-022 — a signed format accepts a plain negative decimal literal.
     fn ut_encode_i8_decimal_negative() {
         assert_eq!(reg(i8_be()).encode("-1").unwrap(), vec![-1i8 as u16]);
     }
 
-    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the bit pattern.
     #[test]
+    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the bit pattern.
     fn ut_encode_i8_hex() {
         // "0xFF" → u8 0xFF as i8 = -1
         assert_eq!(reg(i8_be()).encode("0xFF").unwrap(), vec![-1i8 as u16]);
     }
 
-    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     #[test]
+    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     fn ut_encode_i8_neg_hex() {
         // "-0x01" → -1i8
         assert_eq!(reg(i8_be()).encode("-0x01").unwrap(), vec![-1i8 as u16]);
@@ -602,8 +602,8 @@ mod tests {
 
     // --- I8 round-trip ---
 
-    /// MB-R-007 — encoding then decoding an I8 recovers the value across its range.
     #[test]
+    /// MB-R-007 — encoding then decoding an I8 recovers the value across its range.
     fn ut_roundtrip_i8() {
         let r = reg(i8_be());
         for val in [-128i8, -1, 0, 1, 127] {
@@ -615,8 +615,8 @@ mod tests {
 
     // --- U32 decode ---
 
-    /// MB-R-013 — big-endian decodes the register words' byte stream in wire order.
     #[test]
+    /// MB-R-013 — big-endian decodes the register words' byte stream in wire order.
     fn ut_decode_u32_big() {
         match reg(u32_be()).decode(&[0x0001, 0x0002]).unwrap() {
             Value::U32((v, _)) => assert_eq!(v, 0x00010002),
@@ -624,8 +624,8 @@ mod tests {
         }
     }
 
-    /// MB-R-013 — little-endian decodes the register words' byte stream fully reversed.
     #[test]
+    /// MB-R-013 — little-endian decodes the register words' byte stream fully reversed.
     fn ut_decode_u32_little() {
         // Bytes [0x01, 0x02, 0x03, 0x04] reversed = [0x04, 0x03, 0x02, 0x01]
         // parse = 0x04030201
@@ -637,8 +637,8 @@ mod tests {
 
     // --- U32 encode ---
 
-    /// MB-R-013 — big-endian encodes the value's byte stream in wire order.
     #[test]
+    /// MB-R-013 — big-endian encodes the value's byte stream in wire order.
     fn ut_encode_u32_big() {
         // 65538 = 0x00010002
         assert_eq!(
@@ -647,8 +647,8 @@ mod tests {
         );
     }
 
-    /// MB-R-022 — a `0x`-prefixed hex literal is accepted for numeric input.
     #[test]
+    /// MB-R-022 — a `0x`-prefixed hex literal is accepted for numeric input.
     fn ut_encode_u32_big_hex() {
         assert_eq!(
             reg(u32_be()).encode("0x00010002").unwrap(),
@@ -656,8 +656,8 @@ mod tests {
         );
     }
 
-    /// MB-R-013 — little-endian encodes the value's byte stream fully reversed.
     #[test]
+    /// MB-R-013 — little-endian encodes the value's byte stream fully reversed.
     fn ut_encode_u32_little() {
         // 0x00010002 in LE bytes: [0x02, 0x00, 0x01, 0x00] → registers [0x0200, 0x0100]
         assert_eq!(
@@ -668,8 +668,8 @@ mod tests {
 
     // --- U32 round-trip ---
 
-    /// MB-R-007 — encoding then decoding a big-endian U32 recovers the value.
     #[test]
+    /// MB-R-007 — encoding then decoding a big-endian U32 recovers the value.
     fn ut_roundtrip_u32_big() {
         let r = reg(u32_be());
         let words = r.encode("123456789").unwrap();
@@ -677,8 +677,8 @@ mod tests {
         assert_eq!(decoded.to_string(), "123456789");
     }
 
-    /// MB-R-007 — encoding then decoding a little-endian U32 recovers the value.
     #[test]
+    /// MB-R-007 — encoding then decoding a little-endian U32 recovers the value.
     fn ut_roundtrip_u32_little() {
         let r = reg(u32_le());
         let words = r.encode("987654321").unwrap();
@@ -688,8 +688,8 @@ mod tests {
 
     // --- I32 round-trip ---
 
-    /// MB-R-007 — encoding then decoding a big-endian I32 recovers the value across its range.
     #[test]
+    /// MB-R-007 — encoding then decoding a big-endian I32 recovers the value across its range.
     fn ut_roundtrip_i32_big() {
         let r = reg(i32_be());
         for val in [-2147483648i32, -1, 0, 1, 2147483647] {
@@ -699,8 +699,8 @@ mod tests {
         }
     }
 
-    /// MB-R-007 — encoding then decoding a little-endian I32 recovers the value across its range.
     #[test]
+    /// MB-R-007 — encoding then decoding a little-endian I32 recovers the value across its range.
     fn ut_roundtrip_i32_little() {
         let r = reg(i32_le());
         for val in [-2147483648i32, -1, 0, 1, 2147483647] {
@@ -710,8 +710,8 @@ mod tests {
         }
     }
 
-    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     #[test]
+    /// MB-R-022 — a signed format accepts a `-0x` literal as the negation of the hex bit pattern.
     fn ut_encode_i32_neg_hex() {
         // "-0x01" → -1i32
         let r = reg(i32_be());
@@ -722,8 +722,8 @@ mod tests {
         }
     }
 
-    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the two's-complement bit pattern.
     #[test]
+    /// MB-R-022 — a plain `0x` literal on a signed format is taken as the two's-complement bit pattern.
     fn ut_encode_i32_hex_two_complement() {
         // "0xFFFFFFFF" → u32 all-ones as i32 = -1
         let r = reg(i32_be());
@@ -736,8 +736,8 @@ mod tests {
 
     // --- F32 ---
 
-    /// MB-R-018 — a float decodes from its raw IEEE 754 bit pattern.
     #[test]
+    /// MB-R-018 — a float decodes from its raw IEEE 754 bit pattern.
     fn ut_decode_f32_big() {
         let bits = 1.5f32.to_bits();
         let words = vec![((bits >> 16) & 0xFFFF) as u16, (bits & 0xFFFF) as u16];
@@ -747,16 +747,16 @@ mod tests {
         }
     }
 
-    /// MB-R-018 — a float encodes as its raw IEEE 754 bit pattern.
     #[test]
+    /// MB-R-018 — a float encodes as its raw IEEE 754 bit pattern.
     fn ut_encode_f32_decimal() {
         let bits = 1.5f32.to_bits();
         let expected = vec![((bits >> 16) & 0xFFFF) as u16, (bits & 0xFFFF) as u16];
         assert_eq!(reg(f32_be()).encode("1.5").unwrap(), expected);
     }
 
-    /// MB-R-018 — encoding then decoding an F32 recovers the value via its bit pattern.
     #[test]
+    /// MB-R-018 — encoding then decoding an F32 recovers the value via its bit pattern.
     fn ut_roundtrip_f32_big() {
         let r = reg(f32_be());
         let words = r.encode("1.5").unwrap();
@@ -766,8 +766,8 @@ mod tests {
         }
     }
 
-    /// MB-R-022 — a `0x` literal on a float format is taken as its IEEE 754 bit pattern.
     #[test]
+    /// MB-R-022 — a `0x` literal on a float format is taken as its IEEE 754 bit pattern.
     fn ut_encode_f32_hex() {
         let bits = 1.5f32.to_bits();
         let hex_str = format!("0x{:08X}", bits);
@@ -777,8 +777,8 @@ mod tests {
 
     // --- F64 ---
 
-    /// MB-R-018 — encoding then decoding an F64 recovers the value via its bit pattern.
     #[test]
+    /// MB-R-018 — encoding then decoding an F64 recovers the value via its bit pattern.
     fn ut_roundtrip_f64_big() {
         let r = reg(f64_be());
         let words = r.encode("1.5").unwrap();
@@ -790,8 +790,8 @@ mod tests {
 
     // --- Ascii ---
 
-    /// MB-R-019 — `Ascii` packs two characters per register.
     #[test]
+    /// MB-R-019 — `Ascii` packs two characters per register.
     fn ut_decode_ascii_exact_fill() {
         // "ABCD" fills exactly 4 bytes (Width(2) = 2 registers = 4 bytes)
         let r = reg(Format::Ascii((Alignment::Left, Width(2))));
@@ -801,24 +801,24 @@ mod tests {
         }
     }
 
-    /// MB-R-020 — `Left` alignment zero-pads on the right to `2 × width` bytes.
     #[test]
+    /// MB-R-020 — `Left` alignment zero-pads on the right to `2 × width` bytes.
     fn ut_encode_ascii_left_aligned() {
         // "AB" left-aligned in 4 bytes: [0x41, 0x42, 0x00, 0x00]
         let r = reg(Format::Ascii((Alignment::Left, Width(2))));
         assert_eq!(r.encode("AB").unwrap(), vec![0x4142u16, 0x0000u16]);
     }
 
-    /// MB-R-020 — `Right` alignment zero-pads on the left to `2 × width` bytes.
     #[test]
+    /// MB-R-020 — `Right` alignment zero-pads on the left to `2 × width` bytes.
     fn ut_encode_ascii_right_aligned() {
         // "AB" right-aligned in 4 bytes: [0x00, 0x00, 0x41, 0x42]
         let r = reg(Format::Ascii((Alignment::Right, Width(2))));
         assert_eq!(r.encode("AB").unwrap(), vec![0x0000u16, 0x4142u16]);
     }
 
-    /// MB-R-007 — encoding then decoding an exact-fill ASCII value recovers the string.
     #[test]
+    /// MB-R-007 — encoding then decoding an exact-fill ASCII value recovers the string.
     fn ut_roundtrip_ascii_exact() {
         // Exact fill avoids null-padding in round-trip
         let r = reg(Format::Ascii((Alignment::Left, Width(2))));
@@ -831,8 +831,8 @@ mod tests {
 
     // --- Resolution scaling ---
 
-    /// MB-R-021 — the display resolution scales the shown value but not the words on the wire.
     #[test]
+    /// MB-R-021 — the display resolution scales the shown value but not the words on the wire.
     fn ut_decode_u16_with_resolution() {
         let r = reg(Format::U16((Endian::Big, Resolution(0.5), bf())));
         let words = r.encode("2048").unwrap();
@@ -847,8 +847,8 @@ mod tests {
         Format::U16((Endian::Big, res(), BitField { mask }))
     }
 
-    /// MB-R-015 — decoding an integer field yields `(raw & mask) >> shift`.
     #[test]
+    /// MB-R-015 — decoding an integer field yields `(raw & mask) >> shift`.
     fn ut_decode_u16_high_byte_field() {
         // mask 0xFF00 → shift 8: raw 0xAB12 reads as 0xAB.
         match reg(u16_be_mask(0xFF00)).decode(&[0xAB12]).unwrap() {
@@ -857,8 +857,8 @@ mod tests {
         }
     }
 
-    /// MB-R-015 — a low-byte mask (shift 0) decodes as `raw & mask`.
     #[test]
+    /// MB-R-015 — a low-byte mask (shift 0) decodes as `raw & mask`.
     fn ut_decode_u16_low_byte_field() {
         // mask 0x00FF → shift 0: raw 0xAB12 reads as 0x12.
         match reg(u16_be_mask(0x00FF)).decode(&[0xAB12]).unwrap() {
@@ -867,8 +867,8 @@ mod tests {
         }
     }
 
-    /// MB-R-015 — encoding a field places the value as `(value << shift) & mask`, other bits zero.
     #[test]
+    /// MB-R-015 — encoding a field places the value as `(value << shift) & mask`, other bits zero.
     fn ut_encode_u16_high_byte_field() {
         // value 0x12 placed into mask 0xFF00 → word 0x1200, other bits zero.
         assert_eq!(
@@ -877,8 +877,8 @@ mod tests {
         );
     }
 
-    /// MB-R-015 — encoding then decoding a bit-field value recovers the field.
     #[test]
+    /// MB-R-015 — encoding then decoding a bit-field value recovers the field.
     fn ut_roundtrip_u16_field() {
         let r = reg(u16_be_mask(0x0FF0));
         let words = r.encode("0xAB").unwrap();
@@ -890,8 +890,8 @@ mod tests {
         }
     }
 
-    /// MB-R-014 — the full-width default mask is a no-op on encode and decode.
     #[test]
+    /// MB-R-014 — the full-width default mask is a no-op on encode and decode.
     fn ut_full_mask_is_noop() {
         // Default (full) mask encodes/decodes exactly like before.
         let r = reg(u16_be_mask(u128::MAX));
@@ -902,8 +902,8 @@ mod tests {
         }
     }
 
-    /// MB-R-009 — a register exposes a per-word write mask selecting exactly the bits it owns.
     #[test]
+    /// MB-R-009 — a register exposes a per-word write mask selecting exactly the bits it owns.
     fn ut_mask_words_layout() {
         // U16 mask laid out as a single word.
         assert_eq!(reg(u16_be_mask(0xFF00)).write_mask(), vec![0xFF00u16]);
@@ -922,8 +922,8 @@ mod tests {
 
     // --- Wider integer variants, both endians (decode/encode/mask) ---
 
-    /// MB-R-007 — encoding then decoding the wide integer formats recovers the value in both byte orders.
     #[test]
+    /// MB-R-007 — encoding then decoding the wide integer formats recovers the value in both byte orders.
     fn ut_roundtrip_wide_ints() {
         let e = [Endian::Big, Endian::Little];
         for endian in e {
@@ -949,8 +949,8 @@ mod tests {
         }
     }
 
-    /// MB-R-018 — floats encode/decode via their bit pattern under little-endian byte order.
     #[test]
+    /// MB-R-018 — floats encode/decode via their bit pattern under little-endian byte order.
     fn ut_roundtrip_floats_little_endian() {
         let f32le = reg(Format::F32((Endian::Little, res())));
         let words = f32le.encode("1.5").unwrap();
@@ -967,8 +967,8 @@ mod tests {
         }
     }
 
-    /// MB-R-022 — a `0x` literal on an F64 format is taken as its IEEE 754 bit pattern.
     #[test]
+    /// MB-R-022 — a `0x` literal on an F64 format is taken as its IEEE 754 bit pattern.
     fn ut_encode_f64_hex() {
         let bits = 2.5f64.to_bits();
         let hex_str = format!("0x{:016X}", bits);
@@ -980,16 +980,16 @@ mod tests {
         }
     }
 
-    /// MB-R-012 — a little-endian I8 places the byte in the register's high byte.
     #[test]
+    /// MB-R-012 — a little-endian I8 places the byte in the register's high byte.
     fn ut_encode_i8_little_endian() {
         // I8 little-endian places the byte in the high byte of the word.
         let r = reg(Format::I8((Endian::Little, res(), bf())));
         assert_eq!(r.encode("-1").unwrap(), vec![(-1i8 as u16) << 8]);
     }
 
-    /// MB-R-009 — the per-word write mask is laid out correctly across every format width.
     #[test]
+    /// MB-R-009 — the per-word write mask is laid out correctly across every format width.
     fn ut_mask_words_all_widths() {
         // U8 little-endian mask sits in the high byte.
         assert_eq!(reg(u8_le()).write_mask(), vec![0xFF00u16]);
@@ -1022,8 +1022,8 @@ mod tests {
         );
     }
 
-    /// MB-R-009 — the merge `(old & !mask) | (new & mask)` preserves bits owned by sibling registers.
     #[test]
+    /// MB-R-009 — the merge `(old & !mask) | (new & mask)` preserves bits owned by sibling registers.
     fn ut_merge_write_preserves_sibling_bits() {
         // Two U16 regs aliasing one address: low byte and high byte.
         let low = reg(u16_be_mask(0x00FF));
@@ -1047,8 +1047,8 @@ mod tests {
 
     // --- Typed encode_value: equivalence with the string path ---
 
-    /// MB-R-007 — encoding a typed value produces the same words as encoding the equivalent string.
     #[test]
+    /// MB-R-007 — encoding a typed value produces the same words as encoding the equivalent string.
     fn ut_encode_value_matches_string_path_all_variants() {
         let e = [Endian::Big, Endian::Little];
         for endian in e {
@@ -1128,8 +1128,8 @@ mod tests {
         );
     }
 
-    /// MB-R-021 — the typed encode path applies the bit-field but not the resolution, matching the wire words.
     #[test]
+    /// MB-R-021 — the typed encode path applies the bit-field but not the resolution, matching the wire words.
     fn ut_encode_value_bitfield_and_resolution() {
         // Bit-field placement applies identically via the typed path.
         let format = u16_be_mask(0x0FF0);
@@ -1142,8 +1142,8 @@ mod tests {
         assert_eq!(words, encode(&format, "2048").unwrap());
     }
 
-    /// MB-R-007 — encoding a typed value then decoding recovers it.
     #[test]
+    /// MB-R-007 — encoding a typed value then decoding recovers it.
     fn ut_encode_value_roundtrip_via_decode() {
         let r = reg(i32_le());
         for val in [-2147483648i32, -1, 0, 1, 2147483647] {
@@ -1157,8 +1157,8 @@ mod tests {
 
     // --- Bit-field mask width validation ---
 
-    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on decode.
     #[test]
+    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on decode.
     fn ut_decode_bitfield_mask_out_of_width_errors() {
         // 0x1FF on a U8 sets bit 8, outside the 8-bit width.
         let format = Format::U8((Endian::Big, res(), BitField { mask: 0x1FF }));
@@ -1171,8 +1171,8 @@ mod tests {
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
     }
 
-    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on encode.
     #[test]
+    /// MB-R-016 — a mask setting a bit at or above the format width is rejected on encode.
     fn ut_encode_bitfield_mask_out_of_width_errors() {
         let format = Format::U8((Endian::Big, res(), BitField { mask: 0x1FF }));
         let err = encode(&format, "1").unwrap_err();
@@ -1182,8 +1182,8 @@ mod tests {
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
     }
 
-    /// MB-R-016 — masks within the format width are accepted on decode and encode.
     #[test]
+    /// MB-R-016 — masks within the format width are accepted on decode and encode.
     fn ut_bitfield_mask_in_width_still_works() {
         // Existing in-width masks keep decoding/encoding as before.
         assert!(reg(u16_be_mask(0xFF00)).decode(&[0xAB12]).is_ok());
@@ -1191,8 +1191,8 @@ mod tests {
         assert!(reg(u8_be()).decode(&[0x00FF]).is_ok());
     }
 
-    /// MB-R-008 — encoding a typed value whose type does not match the format fails with a mismatch error.
     #[test]
+    /// MB-R-008 — encoding a typed value whose type does not match the format fails with a mismatch error.
     fn ut_encode_value_mismatch_errors() {
         let format = u32_be();
         let err = encode_value(&format, &Value::U16((1, res()))).unwrap_err();

--- a/ferrowl-codec/src/codec.rs
+++ b/ferrowl-codec/src/codec.rs
@@ -499,6 +499,7 @@ mod tests {
 
     // --- U8 decode ---
 
+    /// MB-R-012 — a big-endian U8 reads the byte from the register's low byte.
     #[test]
     fn ut_decode_u8_big() {
         match reg(u8_be()).decode(&[0x00FF]).unwrap() {
@@ -507,6 +508,7 @@ mod tests {
         }
     }
 
+    /// MB-R-012 — a little-endian U8 reads the byte from the register's high byte.
     #[test]
     fn ut_decode_u8_little() {
         match reg(u8_le()).decode(&[0xFF00]).unwrap() {
@@ -517,16 +519,19 @@ mod tests {
 
     // --- U8 encode ---
 
+    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (decimal input).
     #[test]
     fn ut_encode_u8_big_decimal() {
         assert_eq!(reg(u8_be()).encode("255").unwrap(), vec![0x00FFu16]);
     }
 
+    /// MB-R-012 — a big-endian U8 places the byte in the register's low byte (hex input).
     #[test]
     fn ut_encode_u8_big_hex() {
         assert_eq!(reg(u8_be()).encode("0xFF").unwrap(), vec![0x00FFu16]);
     }
 
+    /// MB-R-012 — a little-endian U8 places the byte in the register's high byte.
     #[test]
     fn ut_encode_u8_little() {
         assert_eq!(reg(u8_le()).encode("255").unwrap(), vec![0xFF00u16]);
@@ -554,6 +559,7 @@ mod tests {
 
     // --- I8 decode ---
 
+    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (negative value).
     #[test]
     fn ut_decode_i8_negative() {
         // -1i8 as u8 = 0xFF; stored in low byte of register
@@ -563,6 +569,7 @@ mod tests {
         }
     }
 
+    /// MB-R-012 — a big-endian I8 reads the byte from the register's low byte (positive value).
     #[test]
     fn ut_decode_i8_positive() {
         match reg(i8_be()).decode(&[0x0042]).unwrap() {
@@ -973,6 +980,7 @@ mod tests {
         }
     }
 
+    /// MB-R-012 — a little-endian I8 places the byte in the register's high byte.
     #[test]
     fn ut_encode_i8_little_endian() {
         // I8 little-endian places the byte in the high byte of the word.

--- a/ferrowl-codec/src/format/alignment.rs
+++ b/ferrowl-codec/src/format/alignment.rs
@@ -26,8 +26,8 @@ impl std::fmt::Display for Alignment {
 mod tests {
     use super::Alignment;
 
-    /// MB-R-019 — `Ascii` carries an alignment of `Left` or `Right`.
     #[test]
+    /// MB-R-019 — `Ascii` carries an alignment of `Left` or `Right`.
     fn ut_alignment_display() {
         assert_eq!(Alignment::Left.to_string(), "Left");
         assert_eq!(Alignment::Right.to_string(), "Right");

--- a/ferrowl-codec/src/format/alignment.rs
+++ b/ferrowl-codec/src/format/alignment.rs
@@ -26,6 +26,7 @@ impl std::fmt::Display for Alignment {
 mod tests {
     use super::Alignment;
 
+    /// MB-R-019 — `Ascii` carries an alignment of `Left` or `Right`.
     #[test]
     fn ut_alignment_display() {
         assert_eq!(Alignment::Left.to_string(), "Left");

--- a/ferrowl-codec/src/format/bitfield.rs
+++ b/ferrowl-codec/src/format/bitfield.rs
@@ -63,9 +63,9 @@ impl std::fmt::Display for BitField {
 mod tests {
     use super::BitField;
 
+    #[test]
     /// MB-R-014 — the field shift is derived from the mask as its trailing-zero count;
     /// the default mask is the full-width no-op.
-    #[test]
     fn ut_bitfield_default_shift_is_full_display() {
         assert_eq!(BitField::default().mask, u128::MAX);
         assert!(BitField::default().is_full());
@@ -76,9 +76,9 @@ mod tests {
         assert_eq!(BitField { mask: 0xABCD }.to_string(), "0xABCD");
     }
 
+    #[test]
     /// MB-R-016 — a mask setting any bit at or above the format width is rejected; the
     /// full-width default mask always fits.
-    #[test]
     fn ut_bitfield_fits() {
         assert!(BitField { mask: 0xFF }.fits(8));
         assert!(!BitField { mask: 0x1FF }.fits(8));

--- a/ferrowl-codec/src/format/bitfield.rs
+++ b/ferrowl-codec/src/format/bitfield.rs
@@ -63,6 +63,8 @@ impl std::fmt::Display for BitField {
 mod tests {
     use super::BitField;
 
+    /// MB-R-014 — the field shift is derived from the mask as its trailing-zero count;
+    /// the default mask is the full-width no-op.
     #[test]
     fn ut_bitfield_default_shift_is_full_display() {
         assert_eq!(BitField::default().mask, u128::MAX);
@@ -74,6 +76,8 @@ mod tests {
         assert_eq!(BitField { mask: 0xABCD }.to_string(), "0xABCD");
     }
 
+    /// MB-R-016 — a mask setting any bit at or above the format width is rejected; the
+    /// full-width default mask always fits.
     #[test]
     fn ut_bitfield_fits() {
         assert!(BitField { mask: 0xFF }.fits(8));

--- a/ferrowl-codec/src/format/endian.rs
+++ b/ferrowl-codec/src/format/endian.rs
@@ -26,6 +26,7 @@ impl std::fmt::Display for Endian {
 mod tests {
     use super::Endian;
 
+    /// MB-R-013 — every integer/float format carries a byte order of `Big` or `Little`.
     #[test]
     fn ut_endian_display() {
         assert_eq!(Endian::Little.to_string(), "Little Endian");

--- a/ferrowl-codec/src/format/endian.rs
+++ b/ferrowl-codec/src/format/endian.rs
@@ -26,8 +26,8 @@ impl std::fmt::Display for Endian {
 mod tests {
     use super::Endian;
 
-    /// MB-R-013 — every integer/float format carries a byte order of `Big` or `Little`.
     #[test]
+    /// MB-R-013 — every integer/float format carries a byte order of `Big` or `Little`.
     fn ut_endian_display() {
         assert_eq!(Endian::Little.to_string(), "Little Endian");
         assert_eq!(Endian::Big.to_string(), "Big Endian");

--- a/ferrowl-codec/src/format/mod.rs
+++ b/ferrowl-codec/src/format/mod.rs
@@ -129,6 +129,7 @@ mod tests {
         BitField::default()
     }
 
+    /// MB-R-011 — per-format register widths (1/1/1/1, 2/2/2, 4/4/4, 8/8, Ascii = width).
     #[test]
     fn ut_format_width() {
         assert_eq!(Format::Ascii((Alignment::Left, Width(4))).width(), 4);
@@ -146,6 +147,7 @@ mod tests {
         assert_eq!(Format::I128((Endian::Big, res(), bf())).width(), 8);
     }
 
+    /// MB-R-011 — byte length is twice the register width.
     #[test]
     fn ut_format_length() {
         assert_eq!(Format::U8((Endian::Big, res(), bf())).length(), 2);
@@ -155,6 +157,7 @@ mod tests {
         assert_eq!(Format::Ascii((Alignment::Left, Width(3))).length(), 6);
     }
 
+    /// MB-R-017 — float (and ASCII) formats carry no bit-field; their bit-field is the no-op full mask.
     #[test]
     fn ut_format_bitfield() {
         // Integer carries its BitField; float/ASCII report the no-op default.
@@ -177,6 +180,7 @@ mod tests {
         );
     }
 
+    /// MB-R-021 — every numeric format carries a display resolution; ASCII carries none.
     #[test]
     fn ut_format_resolution() {
         let r = Resolution(0.5);
@@ -208,6 +212,7 @@ mod tests {
         );
     }
 
+    /// MB-R-021 — every numeric format variant carries a display resolution.
     #[test]
     fn ut_format_resolution_all_variants() {
         let r = Resolution(0.25);
@@ -227,6 +232,7 @@ mod tests {
         }
     }
 
+    /// MB-R-017 — every integer variant carries its bit-field; the float variant reports the no-op default.
     #[test]
     fn ut_format_bitfield_all_variants() {
         let m = BitField { mask: 0x0FF0 };
@@ -248,6 +254,7 @@ mod tests {
         assert!(Format::F64((e, res())).bitfield().is_full());
     }
 
+    /// MB-R-010 — exactly the thirteen data formats (Ascii, U8..U128, I8..I128, F32, F64) exist.
     #[test]
     fn ut_format_display_all_variants() {
         assert_eq!(

--- a/ferrowl-codec/src/format/mod.rs
+++ b/ferrowl-codec/src/format/mod.rs
@@ -129,8 +129,8 @@ mod tests {
         BitField::default()
     }
 
-    /// MB-R-011 — per-format register widths (1/1/1/1, 2/2/2, 4/4/4, 8/8, Ascii = width).
     #[test]
+    /// MB-R-011 — per-format register widths (1/1/1/1, 2/2/2, 4/4/4, 8/8, Ascii = width).
     fn ut_format_width() {
         assert_eq!(Format::Ascii((Alignment::Left, Width(4))).width(), 4);
         assert_eq!(Format::U8((Endian::Big, res(), bf())).width(), 1);
@@ -147,8 +147,8 @@ mod tests {
         assert_eq!(Format::I128((Endian::Big, res(), bf())).width(), 8);
     }
 
-    /// MB-R-011 — byte length is twice the register width.
     #[test]
+    /// MB-R-011 — byte length is twice the register width.
     fn ut_format_length() {
         assert_eq!(Format::U8((Endian::Big, res(), bf())).length(), 2);
         assert_eq!(Format::U32((Endian::Big, res(), bf())).length(), 4);
@@ -157,8 +157,8 @@ mod tests {
         assert_eq!(Format::Ascii((Alignment::Left, Width(3))).length(), 6);
     }
 
-    /// MB-R-017 — float (and ASCII) formats carry no bit-field; their bit-field is the no-op full mask.
     #[test]
+    /// MB-R-017 — float (and ASCII) formats carry no bit-field; their bit-field is the no-op full mask.
     fn ut_format_bitfield() {
         // Integer carries its BitField; float/ASCII report the no-op default.
         let bitfield = BitField { mask: 0xFF00 };
@@ -180,8 +180,8 @@ mod tests {
         );
     }
 
-    /// MB-R-021 — every numeric format carries a display resolution; ASCII carries none.
     #[test]
+    /// MB-R-021 — every numeric format carries a display resolution; ASCII carries none.
     fn ut_format_resolution() {
         let r = Resolution(0.5);
         assert!(
@@ -212,8 +212,8 @@ mod tests {
         );
     }
 
-    /// MB-R-021 — every numeric format variant carries a display resolution.
     #[test]
+    /// MB-R-021 — every numeric format variant carries a display resolution.
     fn ut_format_resolution_all_variants() {
         let r = Resolution(0.25);
         let e = Endian::Big;
@@ -232,8 +232,8 @@ mod tests {
         }
     }
 
-    /// MB-R-017 — every integer variant carries its bit-field; the float variant reports the no-op default.
     #[test]
+    /// MB-R-017 — every integer variant carries its bit-field; the float variant reports the no-op default.
     fn ut_format_bitfield_all_variants() {
         let m = BitField { mask: 0x0FF0 };
         let e = Endian::Big;
@@ -254,8 +254,8 @@ mod tests {
         assert!(Format::F64((e, res())).bitfield().is_full());
     }
 
-    /// MB-R-010 — exactly the thirteen data formats (Ascii, U8..U128, I8..I128, F32, F64) exist.
     #[test]
+    /// MB-R-010 — exactly the thirteen data formats (Ascii, U8..U128, I8..I128, F32, F64) exist.
     fn ut_format_display_all_variants() {
         assert_eq!(
             Format::Ascii((Alignment::Left, Width(2))).to_string(),

--- a/ferrowl-codec/src/format/scalar.rs
+++ b/ferrowl-codec/src/format/scalar.rs
@@ -27,6 +27,7 @@ impl std::fmt::Display for Resolution {
 mod tests {
     use super::Resolution;
 
+    /// MB-R-021 — every numeric format carries a display resolution defaulting to `1.0`.
     #[test]
     fn ut_resolution_default_and_display() {
         assert_eq!(Resolution::default().0, 1.0);

--- a/ferrowl-codec/src/format/scalar.rs
+++ b/ferrowl-codec/src/format/scalar.rs
@@ -27,8 +27,8 @@ impl std::fmt::Display for Resolution {
 mod tests {
     use super::Resolution;
 
-    /// MB-R-021 — every numeric format carries a display resolution defaulting to `1.0`.
     #[test]
+    /// MB-R-021 — every numeric format carries a display resolution defaulting to `1.0`.
     fn ut_resolution_default_and_display() {
         assert_eq!(Resolution::default().0, 1.0);
         assert_eq!(Resolution(2.5).to_string(), "2.5");

--- a/ferrowl-codec/src/kind.rs
+++ b/ferrowl-codec/src/kind.rs
@@ -33,9 +33,9 @@ impl Display for Kind {
 mod tests {
     use super::Kind;
 
+    #[test]
     /// MB-R-004 — the four Modbus register tables (coil, discrete input, holding
     /// register, input register) are exactly the values a kind can take.
-    #[test]
     fn ut_kind_display() {
         assert_eq!(Kind::Coil.to_string(), "Coil");
         assert_eq!(Kind::DiscreteInput.to_string(), "Discrete Input");

--- a/ferrowl-codec/src/kind.rs
+++ b/ferrowl-codec/src/kind.rs
@@ -33,6 +33,8 @@ impl Display for Kind {
 mod tests {
     use super::Kind;
 
+    /// MB-R-004 — the four Modbus register tables (coil, discrete input, holding
+    /// register, input register) are exactly the values a kind can take.
     #[test]
     fn ut_kind_display() {
         assert_eq!(Kind::Coil.to_string(), "Coil");

--- a/ferrowl-codec/src/lib.rs
+++ b/ferrowl-codec/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Register {
     #[builder(default = "Access::ReadWrite")]
     access: Access,
     #[getset(get = "pub")]
-    #[builder(default = "Kind::InputRegister")]
+    #[builder(default = "Kind::HoldingRegister")]
     kind: Kind,
     #[getset(get = "pub")]
     #[builder(default = "Address::Virtual")]

--- a/ferrowl-codec/src/value.rs
+++ b/ferrowl-codec/src/value.rs
@@ -172,8 +172,8 @@ mod tests {
         Resolution(1.0)
     }
 
-    /// MB-R-021 — displaying a value yields `raw × resolution`; resolution 1.0 leaves it unchanged.
     #[test]
+    /// MB-R-021 — displaying a value yields `raw × resolution`; resolution 1.0 leaves it unchanged.
     fn ut_value_as_str_no_scaling() {
         assert_eq!(Value::U8((42, res())).to_string(), "42");
         assert_eq!(Value::U16((1000, res())).to_string(), "1000");
@@ -182,8 +182,8 @@ mod tests {
         assert_eq!(Value::Ascii("hello".to_string()).to_string(), "hello");
     }
 
-    /// MB-R-021 — displaying a value applies the display resolution as `raw × resolution`.
     #[test]
+    /// MB-R-021 — displaying a value applies the display resolution as `raw × resolution`.
     fn ut_value_as_str_with_scaling() {
         // Use resolution 2.0 so that integer * 2.0 is exact in f64
         let r = Resolution(2.0);
@@ -192,8 +192,8 @@ mod tests {
         assert_eq!(Value::F32((1.5f32, r.clone())).to_string(), "3");
     }
 
-    /// MB-R-021 — the unscaled value is the raw value, with the resolution not applied.
     #[test]
+    /// MB-R-021 — the unscaled value is the raw value, with the resolution not applied.
     fn ut_value_unscaled_drops_resolution() {
         // The unscaled string is the raw value, regardless of resolution.
         let r = Resolution(2.0);
@@ -217,8 +217,8 @@ mod tests {
         assert!(!Value::U16((0, res())).is_empty());
     }
 
-    /// MB-R-025 — a value renders as raw zero-padded hex (two's complement for signed, one byte per ASCII char).
     #[test]
+    /// MB-R-025 — a value renders as raw zero-padded hex (two's complement for signed, one byte per ASCII char).
     fn ut_value_as_hex_str() {
         assert_eq!(Value::U8((0xFF, res())).as_hex_str(), "0xFF");
         assert_eq!(Value::U16((0x1234, res())).as_hex_str(), "0x1234");
@@ -231,24 +231,24 @@ mod tests {
         assert_eq!(Value::Ascii("AB".to_string()).as_hex_str(), "0x4142");
     }
 
-    /// MB-R-025 — a float renders as its IEEE 754 bit pattern in zero-padded hex.
     #[test]
+    /// MB-R-025 — a float renders as its IEEE 754 bit pattern in zero-padded hex.
     fn ut_value_as_hex_str_f32() {
         let bits = 1.5f32.to_bits();
         let expected = format!("0x{:08X}", bits);
         assert_eq!(Value::F32((1.5f32, res())).as_hex_str(), expected);
     }
 
-    /// MB-R-025 — an f64 renders as its IEEE 754 bit pattern in zero-padded hex.
     #[test]
+    /// MB-R-025 — an f64 renders as its IEEE 754 bit pattern in zero-padded hex.
     fn ut_value_as_hex_str_f64() {
         let bits = 1.5f64.to_bits();
         let expected = format!("0x{:016X}", bits);
         assert_eq!(Value::F64((1.5f64, res())).as_hex_str(), expected);
     }
 
-    /// MB-R-021 — the unscaled value displays the raw value for every variant.
     #[test]
+    /// MB-R-021 — the unscaled value displays the raw value for every variant.
     fn ut_unscaled_value_display_all_variants() {
         use super::UnscaledValue;
         assert_eq!(UnscaledValue::U8(8).to_string(), "8");
@@ -266,8 +266,8 @@ mod tests {
         assert_eq!(UnscaledValue::Ascii("hi".to_string()).to_string(), "hi");
     }
 
-    /// MB-R-021 — every numeric variant displays as `raw × resolution`.
     #[test]
+    /// MB-R-021 — every numeric variant displays as `raw × resolution`.
     fn ut_value_display_all_numeric_variants() {
         // Resolution 1.0 keeps the scaled value equal to the raw value.
         assert_eq!(Value::U32((32, res())).to_string(), "32");
@@ -278,8 +278,8 @@ mod tests {
         assert_eq!(Value::F64((2.5, res())).to_string(), "2.5");
     }
 
-    /// MB-R-021 — `unscaled` preserves the raw value and variant for every type.
     #[test]
+    /// MB-R-021 — `unscaled` preserves the raw value and variant for every type.
     fn ut_value_unscaled_all_variants() {
         use super::UnscaledValue;
         assert!(matches!(
@@ -320,8 +320,8 @@ mod tests {
         ));
     }
 
-    /// MB-R-025 — wide and signed variants render as raw zero-padded two's-complement hex.
     #[test]
+    /// MB-R-025 — wide and signed variants render as raw zero-padded two's-complement hex.
     fn ut_value_as_hex_str_remaining_variants() {
         assert_eq!(
             Value::U128((0x1, res())).as_hex_str(),

--- a/ferrowl-codec/src/value.rs
+++ b/ferrowl-codec/src/value.rs
@@ -172,6 +172,7 @@ mod tests {
         Resolution(1.0)
     }
 
+    /// MB-R-021 — displaying a value yields `raw × resolution`; resolution 1.0 leaves it unchanged.
     #[test]
     fn ut_value_as_str_no_scaling() {
         assert_eq!(Value::U8((42, res())).to_string(), "42");
@@ -181,6 +182,7 @@ mod tests {
         assert_eq!(Value::Ascii("hello".to_string()).to_string(), "hello");
     }
 
+    /// MB-R-021 — displaying a value applies the display resolution as `raw × resolution`.
     #[test]
     fn ut_value_as_str_with_scaling() {
         // Use resolution 2.0 so that integer * 2.0 is exact in f64
@@ -190,6 +192,7 @@ mod tests {
         assert_eq!(Value::F32((1.5f32, r.clone())).to_string(), "3");
     }
 
+    /// MB-R-021 — the unscaled value is the raw value, with the resolution not applied.
     #[test]
     fn ut_value_unscaled_drops_resolution() {
         // The unscaled string is the raw value, regardless of resolution.
@@ -214,6 +217,7 @@ mod tests {
         assert!(!Value::U16((0, res())).is_empty());
     }
 
+    /// MB-R-025 — a value renders as raw zero-padded hex (two's complement for signed, one byte per ASCII char).
     #[test]
     fn ut_value_as_hex_str() {
         assert_eq!(Value::U8((0xFF, res())).as_hex_str(), "0xFF");
@@ -227,6 +231,7 @@ mod tests {
         assert_eq!(Value::Ascii("AB".to_string()).as_hex_str(), "0x4142");
     }
 
+    /// MB-R-025 — a float renders as its IEEE 754 bit pattern in zero-padded hex.
     #[test]
     fn ut_value_as_hex_str_f32() {
         let bits = 1.5f32.to_bits();
@@ -234,6 +239,7 @@ mod tests {
         assert_eq!(Value::F32((1.5f32, res())).as_hex_str(), expected);
     }
 
+    /// MB-R-025 — an f64 renders as its IEEE 754 bit pattern in zero-padded hex.
     #[test]
     fn ut_value_as_hex_str_f64() {
         let bits = 1.5f64.to_bits();
@@ -241,6 +247,7 @@ mod tests {
         assert_eq!(Value::F64((1.5f64, res())).as_hex_str(), expected);
     }
 
+    /// MB-R-021 — the unscaled value displays the raw value for every variant.
     #[test]
     fn ut_unscaled_value_display_all_variants() {
         use super::UnscaledValue;
@@ -259,6 +266,7 @@ mod tests {
         assert_eq!(UnscaledValue::Ascii("hi".to_string()).to_string(), "hi");
     }
 
+    /// MB-R-021 — every numeric variant displays as `raw × resolution`.
     #[test]
     fn ut_value_display_all_numeric_variants() {
         // Resolution 1.0 keeps the scaled value equal to the raw value.
@@ -270,6 +278,7 @@ mod tests {
         assert_eq!(Value::F64((2.5, res())).to_string(), "2.5");
     }
 
+    /// MB-R-021 — `unscaled` preserves the raw value and variant for every type.
     #[test]
     fn ut_value_unscaled_all_variants() {
         use super::UnscaledValue;
@@ -311,6 +320,7 @@ mod tests {
         ));
     }
 
+    /// MB-R-025 — wide and signed variants render as raw zero-padded two's-complement hex.
     #[test]
     fn ut_value_as_hex_str_remaining_variants() {
         assert_eq!(

--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -16,6 +16,7 @@ fn int(endian: Endian) -> Format {
     Format::U16((endian, res(), BitField::default()))
 }
 
+/// MB-R-002 — an unspecified slave id defaults to 0 (with access defaulting to `ReadWrite`, MB-R-005).
 #[test]
 fn it_register_builder_applies_documented_defaults() {
     let reg = RegisterBuilder::default()
@@ -27,6 +28,7 @@ fn it_register_builder_applies_documented_defaults() {
     assert_eq!(*reg.kind(), Kind::InputRegister);
 }
 
+/// MB-R-007 — a typed U16 value round-trips through raw register words.
 #[test]
 fn it_u16_value_roundtrips_through_words() {
     let fmt = int(Endian::Big);
@@ -38,6 +40,7 @@ fn it_u16_value_roundtrips_through_words() {
     }
 }
 
+/// MB-R-013 — big- and little-endian produce different words but each decodes back to the same value.
 #[test]
 fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
     let value = Value::U32((0x0001_0002, res()));
@@ -70,6 +73,7 @@ fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
     );
 }
 
+/// MB-R-007 — a negative signed value round-trips through raw register words.
 #[test]
 fn it_signed_value_roundtrips_negative() {
     let fmt = Format::I16((Endian::Big, res(), BitField::default()));
@@ -80,6 +84,7 @@ fn it_signed_value_roundtrips_negative() {
     }
 }
 
+/// MB-R-018 — a float value round-trips through its IEEE 754 register words.
 #[test]
 fn it_float_value_roundtrips() {
     let fmt = Format::F32((Endian::Big, res()));
@@ -90,6 +95,7 @@ fn it_float_value_roundtrips() {
     }
 }
 
+/// MB-R-007 — an ASCII value round-trips through raw register words.
 #[test]
 fn it_ascii_value_roundtrips_through_string_encoding() {
     let fmt = Format::Ascii((Alignment::Left, Width(4)));
@@ -100,6 +106,7 @@ fn it_ascii_value_roundtrips_through_string_encoding() {
     }
 }
 
+/// MB-R-023 — decoding fewer words than the format width is rejected.
 #[test]
 fn it_decode_rejects_too_few_words() {
     let fmt = Format::U32((Endian::Big, res(), BitField::default()));
@@ -109,6 +116,7 @@ fn it_decode_rejects_too_few_words() {
     );
 }
 
+/// MB-R-022 — a string that is neither a decimal nor a `0x` literal fails to encode into a numeric register.
 #[test]
 fn it_encode_rejects_unparseable_string() {
     let fmt = int(Endian::Big);

--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -16,7 +16,8 @@ fn int(endian: Endian) -> Format {
     Format::U16((endian, res(), BitField::default()))
 }
 
-/// MB-R-002 — an unspecified slave id defaults to 0 (with access defaulting to `ReadWrite`, MB-R-005).
+/// MB-R-002 — an unspecified slave id defaults to 0 (access defaults to `ReadWrite`, MB-R-005;
+/// kind defaults to holding register, MB-R-097).
 #[test]
 fn it_register_builder_applies_documented_defaults() {
     let reg = RegisterBuilder::default()
@@ -25,7 +26,7 @@ fn it_register_builder_applies_documented_defaults() {
         .expect("only `format` is required to build a Register");
     assert_eq!(*reg.slave_id(), 0);
     assert_eq!(*reg.access(), Access::ReadWrite);
-    assert_eq!(*reg.kind(), Kind::InputRegister);
+    assert_eq!(*reg.kind(), Kind::HoldingRegister);
 }
 
 /// MB-R-007 — a typed U16 value round-trips through raw register words.

--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -16,9 +16,9 @@ fn int(endian: Endian) -> Format {
     Format::U16((endian, res(), BitField::default()))
 }
 
+#[test]
 /// MB-R-002 — an unspecified slave id defaults to 0 (access defaults to `ReadWrite`, MB-R-005;
 /// kind defaults to holding register, MB-R-097).
-#[test]
 fn it_register_builder_applies_documented_defaults() {
     let reg = RegisterBuilder::default()
         .format(int(Endian::Big))
@@ -29,8 +29,8 @@ fn it_register_builder_applies_documented_defaults() {
     assert_eq!(*reg.kind(), Kind::HoldingRegister);
 }
 
-/// MB-R-007 — a typed U16 value round-trips through raw register words.
 #[test]
+/// MB-R-007 — a typed U16 value round-trips through raw register words.
 fn it_u16_value_roundtrips_through_words() {
     let fmt = int(Endian::Big);
     let words = encode_value(&fmt, &Value::U16((300, res()))).expect("300 fits a u16 register");
@@ -41,8 +41,8 @@ fn it_u16_value_roundtrips_through_words() {
     }
 }
 
-/// MB-R-013 — big- and little-endian produce different words but each decodes back to the same value.
 #[test]
+/// MB-R-013 — big- and little-endian produce different words but each decodes back to the same value.
 fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
     let value = Value::U32((0x0001_0002, res()));
     let be = encode_value(
@@ -74,8 +74,8 @@ fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
     );
 }
 
-/// MB-R-007 — a negative signed value round-trips through raw register words.
 #[test]
+/// MB-R-007 — a negative signed value round-trips through raw register words.
 fn it_signed_value_roundtrips_negative() {
     let fmt = Format::I16((Endian::Big, res(), BitField::default()));
     let words = encode_value(&fmt, &Value::I16((-5, res()))).expect("encodes -5");
@@ -85,8 +85,8 @@ fn it_signed_value_roundtrips_negative() {
     }
 }
 
-/// MB-R-018 — a float value round-trips through its IEEE 754 register words.
 #[test]
+/// MB-R-018 — a float value round-trips through its IEEE 754 register words.
 fn it_float_value_roundtrips() {
     let fmt = Format::F32((Endian::Big, res()));
     let words = encode_value(&fmt, &Value::F32((1.5, res()))).expect("encodes 1.5");
@@ -96,8 +96,8 @@ fn it_float_value_roundtrips() {
     }
 }
 
-/// MB-R-007 — an ASCII value round-trips through raw register words.
 #[test]
+/// MB-R-007 — an ASCII value round-trips through raw register words.
 fn it_ascii_value_roundtrips_through_string_encoding() {
     let fmt = Format::Ascii((Alignment::Left, Width(4)));
     let words = encode(&fmt, "Hi").expect("ASCII text encodes into 4 registers");
@@ -107,8 +107,8 @@ fn it_ascii_value_roundtrips_through_string_encoding() {
     }
 }
 
-/// MB-R-023 — decoding fewer words than the format width is rejected.
 #[test]
+/// MB-R-023 — decoding fewer words than the format width is rejected.
 fn it_decode_rejects_too_few_words() {
     let fmt = Format::U32((Endian::Big, res(), BitField::default()));
     assert!(
@@ -117,8 +117,8 @@ fn it_decode_rejects_too_few_words() {
     );
 }
 
-/// MB-R-022 — a string that is neither a decimal nor a `0x` literal fails to encode into a numeric register.
 #[test]
+/// MB-R-022 — a string that is neither a decimal nor a `0x` literal fails to encode into a numeric register.
 fn it_encode_rejects_unparseable_string() {
     let fmt = int(Endian::Big);
     assert!(

--- a/ferrowl-lua/src/context.rs
+++ b/ferrowl-lua/src/context.rs
@@ -168,6 +168,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-003 — a script is compiled into a callable function at load time; invalid Lua fails the load.
     fn ut_load_script_rejects_invalid_lua() {
         let mut ctx = Context::<String>::default();
         assert!(
@@ -177,6 +178,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-005 — loading a second script under an existing name is rejected; no silent overwrite.
     fn ut_load_script_rejects_duplicate_key() {
         let mut ctx = Context::<String>::default();
         assert!(ctx.load_script(key("a"), "local x = 1").is_ok());
@@ -192,6 +194,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-032 — a runtime error raised by a script is surfaced rather than swallowed.
     fn ut_call_runs_script_and_surfaces_runtime_error() {
         let mut ctx = Context::<String>::default();
         ctx.load_script(key("ok"), "local x = 1 + 1").unwrap();
@@ -202,6 +205,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-007 — io/os/package and the base dynamic-code loaders are removed from the globals (seen as nil).
     fn ut_sandbox_denies_filesystem_shell_and_dynamic_loading() {
         // A script in a config is untrusted input; the sandbox must not give it the filesystem,
         // the shell, or a way to pull in more code. Each of these globals must be absent.
@@ -229,6 +233,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-006 — the pure-computation stdlib subset (string/table/math/…) stays reachable.
     fn ut_sandbox_keeps_pure_computation_libraries() {
         let mut ctx = Context::<String>::default();
         ctx.enable_stdlib().unwrap();
@@ -242,6 +247,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-032 — one script's error is collected and does not stop the others in the context.
     fn ut_call_all_collects_errors() {
         let mut ctx = Context::<String>::default();
         ctx.load_script(key("ok"), "local x = 1").unwrap();
@@ -251,6 +257,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-014 — refresh runs a script at most once per interval, skipping one that ran more recently.
     fn ut_refresh_skips_recently_executed_script() {
         let mut ctx = Context::<String>::default();
         // A failing script that would error if executed.

--- a/ferrowl-lua/src/module/log.rs
+++ b/ferrowl-lua/src/module/log.rs
@@ -69,6 +69,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-031 — a line logged via C_Log is routed to the host's module log sink.
     fn ut_log_routes_to_sink() {
         let sink = VecSink::default();
         let log = Log::init(sink.clone());

--- a/ferrowl-lua/src/module/module_dir.rs
+++ b/ferrowl-lua/src/module/module_dir.rs
@@ -272,6 +272,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — C_Module enumerates the session's other modules by name.
     fn ut_list_returns_sorted_names() {
         let dir = Arc::new(MockDirectory::default());
         dir.insert(
@@ -304,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — resolving an unknown module name raises rather than returning a null handle.
     fn ut_get_unknown_module_raises() {
         let dir = Arc::new(MockDirectory::default());
         let module = ModuleDir::init(dir as Arc<dyn ModuleDirectory>);
@@ -318,6 +320,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — a resolved C_Module handle reports its target's kind and role.
     fn ut_type_and_role_return_host_values() {
         let dir = Arc::new(MockDirectory::default());
         dir.insert(
@@ -345,6 +348,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — C_Module hands out a C_Register-shaped accessor only for a modbus module; others raise.
     fn ut_register_on_non_modbus_raises() {
         let dir = Arc::new(MockDirectory::default());
         dir.insert(
@@ -369,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — C_Module hands out a C_OCPP-shaped accessor only for an ocpp module; others raise.
     fn ut_ocpp_on_non_ocpp_raises() {
         let dir = Arc::new(MockDirectory::default());
         dir.insert(
@@ -390,6 +395,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — the session sim reaches a modbus module's register state through C_Module.
     fn ut_register_roundtrip_through_directory() {
         let rw = MockReadWrite::default();
         let dir = Arc::new(MockDirectory::default());
@@ -423,6 +429,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — the session sim reaches an ocpp module's state and actions through C_Module.
     fn ut_ocpp_roundtrip_through_directory() {
         let handle = MockOcppHandle::default();
         let dir = Arc::new(MockDirectory::default());
@@ -469,6 +476,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — a C_Module handle re-resolves by name each call, so a removed module goes stale.
     fn ut_handle_becomes_stale_after_removal() {
         let dir = Arc::new(MockDirectory::default());
         dir.insert(

--- a/ferrowl-lua/src/module/ocpp/mod.rs
+++ b/ferrowl-lua/src/module/ocpp/mod.rs
@@ -201,6 +201,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-027 — C_OCPP Get/Set round-trip a state field and an action dispatches with its override arg.
     fn ut_get_set_roundtrip_and_dispatch() {
         let handle = MockHandle::default();
         let mut ctx = ContextBuilder::<String>::default()
@@ -323,6 +324,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-027 — client C_OCPP: bare Get/Set/action hit CS level, Connector(id) scopes to a connector.
     fn ut_client_bare_is_cs_connector_is_scoped() {
         let host = ClientHost::default();
         let mut ctx = ContextBuilder::<String>::default()
@@ -415,6 +417,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-021 — server C_OCPP enumerates stations/connectors and routes Get/Set/action by identity.
     fn ut_server_enumerates_and_routes_by_identity() {
         let host = ServerHost::fixture();
         let mut ctx = ContextBuilder::<String>::default()
@@ -472,6 +475,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-032 — a malformed OCPP override table surfaces as a runtime error rather than being coerced.
     fn ut_malformed_override_table_propagates_error() {
         let handle = MockHandle::default();
         let mut ctx = ContextBuilder::<String>::default()

--- a/ferrowl-lua/src/module/test.rs
+++ b/ferrowl-lua/src/module/test.rs
@@ -49,11 +49,13 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-018 — C_Test is registered under the Lua global name `C_Test`.
     fn ut_module_name() {
         assert_eq!(<Test as Module>::module(), "C_Test");
     }
 
     #[test]
+    /// SC-R-038 — Assert with a true condition returns with no effect.
     fn ut_assert_true_passes() {
         let lua = lua_with_test();
         lua.load(r#"C_Test:Assert(true, "should not fire")"#)
@@ -62,6 +64,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-038 — every non-nil, non-false value (including numbers and strings) is truthy and passes.
     fn ut_assert_truthy_value_passes() {
         let lua = lua_with_test();
         lua.load(r#"C_Test:Assert(1, "should not fire")"#)
@@ -73,6 +76,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-038 — Assert with `false` raises `assertion failed: <msg>`.
     fn ut_assert_false_raises() {
         let lua = lua_with_test();
         let err = lua
@@ -83,6 +87,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-038 — Assert with `nil` (Lua-falsy) raises `assertion failed: <msg>`.
     fn ut_assert_nil_raises() {
         let lua = lua_with_test();
         let err = lua
@@ -93,6 +98,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-038 — Fail always raises `assertion failed: <msg>`.
     fn ut_fail_always_raises() {
         let lua = lua_with_test();
         let err = lua.load(r#"C_Test:Fail("nope")"#).exec().unwrap_err();

--- a/ferrowl-lua/src/script.rs
+++ b/ferrowl-lua/src/script.rs
@@ -42,6 +42,7 @@ mod tests {
     use mlua::Lua;
 
     #[test]
+    /// SC-R-003 — a compiled script is invoked with no args; a successful call is Ok, a failing one Err.
     fn ut_script() {
         let lua = Lua::new();
 

--- a/ferrowl-lua/tests/modules.rs
+++ b/ferrowl-lua/tests/modules.rs
@@ -104,6 +104,7 @@ fn build_context() -> Context<String> {
 }
 
 #[test]
+/// SC-R-027 — a register read returns its natural Lua type and a host read error propagates as a Lua error.
 fn ut_modules_run_via_call() {
     let mut ctx = build_context();
     ctx.call(&"time".to_string()).unwrap();
@@ -125,6 +126,7 @@ fn ut_call_all_ok_when_no_script_errors() {
 }
 
 #[test]
+/// SC-R-014 — refresh_all runs each script once per interval, skipping any that ran within the window.
 fn ut_refresh_all_runs_then_throttles() {
     let mut ctx = build_context();
     // First pass with a zero window runs everything successfully.
@@ -134,6 +136,7 @@ fn ut_refresh_all_runs_then_throttles() {
 }
 
 #[test]
+/// SC-R-032 — a script error during refresh_all is collected without stopping the pass.
 fn ut_refresh_all_collects_errors() {
     let mut ctx = ContextBuilder::<String>::default()
         .with_script("boom".to_string(), "error('x')")
@@ -165,6 +168,7 @@ impl LogSink for VecSink {
 }
 
 #[test]
+/// SC-R-031 — C_Log:Info output is routed to the host's module log sink.
 fn ut_c_log_info_routes_to_host_sink() {
     let sink = VecSink::default();
     let mut ctx = ContextBuilder::<String>::default()
@@ -178,6 +182,7 @@ fn ut_c_log_info_routes_to_host_sink() {
 }
 
 #[test]
+/// SC-R-033 — a Lua syntax error at load makes context construction fail (all-or-nothing per context).
 fn ut_builder_propagates_script_error() {
     // Invalid Lua makes the builder carry the error through to build().
     let result = ContextBuilder::<String>::default()

--- a/ferrowl-lua/tests/print.rs
+++ b/ferrowl-lua/tests/print.rs
@@ -20,6 +20,7 @@ impl LogSink for VecSink {
 }
 
 #[test]
+/// SC-R-030 — print converts each arg with tostring and joins them with tab characters.
 fn ut_print_joins_args_with_tabs() {
     let sink = VecSink::default();
     let mut ctx = ContextBuilder::<String>::default()
@@ -33,6 +34,7 @@ fn ut_print_joins_args_with_tabs() {
 }
 
 #[test]
+/// SC-R-030 — print with no args emits a single empty log line.
 fn ut_print_no_args_is_empty_line() {
     let sink = VecSink::default();
     let mut ctx = ContextBuilder::<String>::default()
@@ -46,6 +48,7 @@ fn ut_print_no_args_is_empty_line() {
 }
 
 #[test]
+/// SC-R-030 — print honors a value's __tostring metamethod when converting it.
 fn ut_print_honors_tostring_metamethod() {
     let sink = VecSink::default();
     let mut ctx = ContextBuilder::<String>::default()
@@ -65,6 +68,7 @@ fn ut_print_honors_tostring_metamethod() {
 }
 
 #[test]
+/// SC-R-030 — print is redirected to the host sink (never stdout), regardless of builder call order.
 fn ut_with_print_sink_before_stdlib_still_redirects() {
     // Empirically, `enable_stdlib`'s `load_std_libs(ALL_SAFE)` does not reload `base` (`print` is
     // untouched), so the override survives regardless of call order. Verified here so a future

--- a/ferrowl-modbus/src/client_core.rs
+++ b/ferrowl-modbus/src/client_core.rs
@@ -553,6 +553,7 @@ mod tests {
         tokio::time::error::Elapsed,
     >;
 
+    /// MB-R-042 — coil/discrete-input reads map to one word per bit: `1` for set, `0` for clear.
     #[test]
     fn ut_bits_to_words_maps_true_false_to_one_zero() {
         assert_eq!(
@@ -561,6 +562,7 @@ mod tests {
         );
     }
 
+    /// MB-R-042 — an empty coil/discrete read maps to no words.
     #[test]
     fn ut_bits_to_words_empty_is_empty() {
         assert_eq!(ClientCore::bits_to_words(vec![]), Vec::<u16>::new());
@@ -572,6 +574,7 @@ mod tests {
         assert_eq!(ClientCore::classify(res).unwrap(), 42);
     }
 
+    /// MB-R-043 — a read returning a Modbus exception is classified as an exception (retried, not a disconnect).
     #[test]
     fn ut_classify_exception_maps_to_modbus_exception() {
         let res: ReadResult<u16> = Ok(Ok(Err(ExceptionCode::IllegalDataAddress)));
@@ -582,6 +585,7 @@ mod tests {
         ));
     }
 
+    /// MB-R-045 — a transport error is classified as an error (disconnects the client).
     #[test]
     fn ut_classify_transport_error_maps_to_modbus_error() {
         let io_err = std::io::Error::other("boom");
@@ -591,6 +595,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-045 — a timed-out read is classified as a timeout (disconnects the client).
     async fn ut_classify_elapsed_maps_to_modbus_timeout() {
         // A zero-duration timeout against a never-resolving future always elapses immediately,
         // giving a real `Elapsed` without needing any transport.
@@ -602,6 +607,7 @@ mod tests {
         assert!(matches!(e, ModbusError::Timeout(_)));
     }
 
+    /// MB-R-042 — a successful coil read is mapped through to one word per bit.
     #[test]
     fn ut_classify_maps_bits_through_to_words_on_success() {
         // Same classify() call the ReadCoils/ReadDiscreteInputs arms make, chained with

--- a/ferrowl-modbus/src/client_core.rs
+++ b/ferrowl-modbus/src/client_core.rs
@@ -553,8 +553,8 @@ mod tests {
         tokio::time::error::Elapsed,
     >;
 
-    /// MB-R-042 — coil/discrete-input reads map to one word per bit: `1` for set, `0` for clear.
     #[test]
+    /// MB-R-042 — coil/discrete-input reads map to one word per bit: `1` for set, `0` for clear.
     fn ut_bits_to_words_maps_true_false_to_one_zero() {
         assert_eq!(
             ClientCore::bits_to_words(vec![true, false, true, true]),
@@ -562,8 +562,8 @@ mod tests {
         );
     }
 
-    /// MB-R-042 — an empty coil/discrete read maps to no words.
     #[test]
+    /// MB-R-042 — an empty coil/discrete read maps to no words.
     fn ut_bits_to_words_empty_is_empty() {
         assert_eq!(ClientCore::bits_to_words(vec![]), Vec::<u16>::new());
     }
@@ -574,8 +574,8 @@ mod tests {
         assert_eq!(ClientCore::classify(res).unwrap(), 42);
     }
 
-    /// MB-R-043 — a read returning a Modbus exception is classified as an exception (retried, not a disconnect).
     #[test]
+    /// MB-R-043 — a read returning a Modbus exception is classified as an exception (retried, not a disconnect).
     fn ut_classify_exception_maps_to_modbus_exception() {
         let res: ReadResult<u16> = Ok(Ok(Err(ExceptionCode::IllegalDataAddress)));
         let e = ClientCore::classify(res).unwrap_err();
@@ -585,8 +585,8 @@ mod tests {
         ));
     }
 
-    /// MB-R-045 — a transport error is classified as an error (disconnects the client).
     #[test]
+    /// MB-R-045 — a transport error is classified as an error (disconnects the client).
     fn ut_classify_transport_error_maps_to_modbus_error() {
         let io_err = std::io::Error::other("boom");
         let res: ReadResult<u16> = Ok(Err(tokio_modbus::Error::Transport(io_err)));
@@ -607,8 +607,8 @@ mod tests {
         assert!(matches!(e, ModbusError::Timeout(_)));
     }
 
-    /// MB-R-042 — a successful coil read is mapped through to one word per bit.
     #[test]
+    /// MB-R-042 — a successful coil read is mapped through to one word per bit.
     fn ut_classify_maps_bits_through_to_words_on_success() {
         // Same classify() call the ReadCoils/ReadDiscreteInputs arms make, chained with
         // `.map(Self::bits_to_words)` as `read()` does.

--- a/ferrowl-modbus/src/common.rs
+++ b/ferrowl-modbus/src/common.rs
@@ -60,18 +60,21 @@ mod tests {
     use crate::LogFn;
     use std::future::Future;
 
+    /// MB-R-072 — unset serial parameters leave the library's own default in place.
     #[test]
     fn ut_serial_config_valid_minimal() {
         // No optional fields set: builder construction must succeed.
         assert!(serial_config_from("/dev/null", 9600, None, None, None).is_ok());
     }
 
+    /// MB-R-073 — valid `data_bits`/`stop_bits`/`parity` values are accepted.
     #[test]
     fn ut_serial_config_valid_full() {
         let r = serial_config_from("/dev/null", 19200, Some(8), Some(1), Some("even"));
         assert!(r.is_ok());
     }
 
+    /// MB-R-073 — `parity` accepts `even`/`odd`/`none` case-insensitively.
     #[test]
     fn ut_serial_config_parity_case_insensitive() {
         // Parity is lower-cased before matching, so mixed case is accepted.
@@ -79,6 +82,7 @@ mod tests {
         assert!(serial_config_from("/dev/null", 9600, None, None, Some("None")).is_ok());
     }
 
+    /// MB-R-073 — a `data_bits` value other than 5/6/7/8 fails with a serial configuration error.
     #[test]
     fn ut_serial_config_rejects_bad_data_bits() {
         let e = serial_config_from("/dev/null", 9600, Some(9), None, None).unwrap_err();
@@ -86,6 +90,7 @@ mod tests {
         assert!(e.to_string().contains("data bits"));
     }
 
+    /// MB-R-073 — a `stop_bits` value other than 1/2 fails with a serial configuration error.
     #[test]
     fn ut_serial_config_rejects_bad_stop_bits() {
         let e = serial_config_from("/dev/null", 9600, None, Some(3), None).unwrap_err();
@@ -93,6 +98,7 @@ mod tests {
         assert!(e.to_string().contains("stop bits"));
     }
 
+    /// MB-R-073 — a `parity` value other than even/odd/none fails with a serial configuration error.
     #[test]
     fn ut_serial_config_rejects_bad_parity() {
         let e = serial_config_from("/dev/null", 9600, None, None, Some("bogus")).unwrap_err();
@@ -100,6 +106,7 @@ mod tests {
         assert!(e.to_string().contains("parity"));
     }
 
+    /// MB-R-073 — `data_bits` accepts exactly 5, 6, 7, and 8.
     #[test]
     fn ut_serial_config_accepts_all_data_bit_widths() {
         for bits in [5u8, 6, 7, 8] {
@@ -107,6 +114,7 @@ mod tests {
         }
     }
 
+    /// MB-R-073 — `stop_bits` accepts exactly 1 and 2.
     #[test]
     fn ut_serial_config_accepts_both_stop_bits() {
         assert!(serial_config_from("/dev/null", 9600, None, Some(1), None).is_ok());

--- a/ferrowl-modbus/src/common.rs
+++ b/ferrowl-modbus/src/common.rs
@@ -60,62 +60,62 @@ mod tests {
     use crate::LogFn;
     use std::future::Future;
 
-    /// MB-R-072 — unset serial parameters leave the library's own default in place.
     #[test]
+    /// MB-R-072 — unset serial parameters leave the library's own default in place.
     fn ut_serial_config_valid_minimal() {
         // No optional fields set: builder construction must succeed.
         assert!(serial_config_from("/dev/null", 9600, None, None, None).is_ok());
     }
 
-    /// MB-R-073 — valid `data_bits`/`stop_bits`/`parity` values are accepted.
     #[test]
+    /// MB-R-073 — valid `data_bits`/`stop_bits`/`parity` values are accepted.
     fn ut_serial_config_valid_full() {
         let r = serial_config_from("/dev/null", 19200, Some(8), Some(1), Some("even"));
         assert!(r.is_ok());
     }
 
-    /// MB-R-073 — `parity` accepts `even`/`odd`/`none` case-insensitively.
     #[test]
+    /// MB-R-073 — `parity` accepts `even`/`odd`/`none` case-insensitively.
     fn ut_serial_config_parity_case_insensitive() {
         // Parity is lower-cased before matching, so mixed case is accepted.
         assert!(serial_config_from("/dev/null", 9600, None, None, Some("ODD")).is_ok());
         assert!(serial_config_from("/dev/null", 9600, None, None, Some("None")).is_ok());
     }
 
-    /// MB-R-073 — a `data_bits` value other than 5/6/7/8 fails with a serial configuration error.
     #[test]
+    /// MB-R-073 — a `data_bits` value other than 5/6/7/8 fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_data_bits() {
         let e = serial_config_from("/dev/null", 9600, Some(9), None, None).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("data bits"));
     }
 
-    /// MB-R-073 — a `stop_bits` value other than 1/2 fails with a serial configuration error.
     #[test]
+    /// MB-R-073 — a `stop_bits` value other than 1/2 fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_stop_bits() {
         let e = serial_config_from("/dev/null", 9600, None, Some(3), None).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("stop bits"));
     }
 
-    /// MB-R-073 — a `parity` value other than even/odd/none fails with a serial configuration error.
     #[test]
+    /// MB-R-073 — a `parity` value other than even/odd/none fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_parity() {
         let e = serial_config_from("/dev/null", 9600, None, None, Some("bogus")).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("parity"));
     }
 
-    /// MB-R-073 — `data_bits` accepts exactly 5, 6, 7, and 8.
     #[test]
+    /// MB-R-073 — `data_bits` accepts exactly 5, 6, 7, and 8.
     fn ut_serial_config_accepts_all_data_bit_widths() {
         for bits in [5u8, 6, 7, 8] {
             assert!(serial_config_from("/dev/null", 9600, Some(bits), None, None).is_ok());
         }
     }
 
-    /// MB-R-073 — `stop_bits` accepts exactly 1 and 2.
     #[test]
+    /// MB-R-073 — `stop_bits` accepts exactly 1 and 2.
     fn ut_serial_config_accepts_both_stop_bits() {
         assert!(serial_config_from("/dev/null", 9600, None, Some(1), None).is_ok());
         assert!(serial_config_from("/dev/null", 9600, None, Some(2), None).is_ok());

--- a/ferrowl-modbus/src/key.rs
+++ b/ferrowl-modbus/src/key.rs
@@ -73,12 +73,14 @@ mod tests {
         assert_eq!(key.id, sk);
     }
 
+    /// MB-R-026 — the default device key is the (slave id, register table) pair.
     #[test]
     fn ut_key_default_is_slave_kind_default() {
         let key = Key::<SlaveKey>::default();
         assert_eq!(key.id, SlaveKey::default());
     }
 
+    /// MB-R-027 — coil-family function codes derive the coil register table.
     #[test]
     fn ut_slave_kind_from_slave_fn_coil() {
         let sk = SlaveKey::from_slave_fn(3, FunctionCode::ReadCoils);

--- a/ferrowl-modbus/src/key.rs
+++ b/ferrowl-modbus/src/key.rs
@@ -73,15 +73,15 @@ mod tests {
         assert_eq!(key.id, sk);
     }
 
-    /// MB-R-026 — the default device key is the (slave id, register table) pair.
     #[test]
+    /// MB-R-026 — the default device key is the (slave id, register table) pair.
     fn ut_key_default_is_slave_kind_default() {
         let key = Key::<SlaveKey>::default();
         assert_eq!(key.id, SlaveKey::default());
     }
 
-    /// MB-R-027 — coil-family function codes derive the coil register table.
     #[test]
+    /// MB-R-027 — coil-family function codes derive the coil register table.
     fn ut_slave_kind_from_slave_fn_coil() {
         let sk = SlaveKey::from_slave_fn(3, FunctionCode::ReadCoils);
         assert_eq!(sk.slave_id, 3);

--- a/ferrowl-modbus/src/rtu/mod.rs
+++ b/ferrowl-modbus/src/rtu/mod.rs
@@ -70,6 +70,7 @@ fn default_reconnect() -> bool {
 mod tests {
     use super::*;
 
+    /// MB-R-050 — reconnect is enabled by default when absent from the config.
     #[test]
     fn ut_config_serde_defaults_reconnect_true_when_absent() {
         let json = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0}"#;
@@ -77,6 +78,7 @@ mod tests {
         assert!(cfg.reconnect);
     }
 
+    /// MB-R-055 — an explicit `reconnect: false` disables reconnect.
     #[test]
     fn ut_config_serde_respects_explicit_reconnect_false() {
         let json = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0,"reconnect":false}"#;

--- a/ferrowl-modbus/src/rtu/mod.rs
+++ b/ferrowl-modbus/src/rtu/mod.rs
@@ -70,16 +70,16 @@ fn default_reconnect() -> bool {
 mod tests {
     use super::*;
 
-    /// MB-R-050 — reconnect is enabled by default when absent from the config.
     #[test]
+    /// MB-R-050 — reconnect is enabled by default when absent from the config.
     fn ut_config_serde_defaults_reconnect_true_when_absent() {
         let json = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0}"#;
         let cfg: Config = serde_json::from_str(json).unwrap();
         assert!(cfg.reconnect);
     }
 
-    /// MB-R-055 — an explicit `reconnect: false` disables reconnect.
     #[test]
+    /// MB-R-055 — an explicit `reconnect: false` disables reconnect.
     fn ut_config_serde_respects_explicit_reconnect_false() {
         let json = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0,"reconnect":false}"#;
         let cfg: Config = serde_json::from_str(json).unwrap();

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -543,6 +543,7 @@ mod tests {
     // `tokio_modbus`'s `process()` loop just `.await`s, this must succeed on a current-thread
     // runtime with no dedicated worker threads to bridge onto.
     #[tokio::test]
+    /// MB-R-057 — the server answers an inbound request directly from the shared store.
     async fn ut_server_call_works_on_current_thread_runtime() {
         use tokio_modbus::server::Service;
 
@@ -561,6 +562,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-057 — a holding-register read is answered from the values stored in the shared store.
     async fn ut_handle_read_holding_returns_seeded_values() {
         let mem = seeded_memory(&[10, 20]);
         let (log, _) = recording_log();
@@ -572,6 +574,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a read against a slave with no declared regions is answered with `IllegalDataAddress`.
     async fn ut_handle_read_unknown_slave_is_illegal_data_address() {
         let mem = seeded_memory(&[10, 20]);
         let (log, _) = recording_log();
@@ -589,6 +592,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-058 — a write-single-register request is answered and its value persisted in the store.
     async fn ut_handle_write_single_register_persists() {
         let mem = seeded_memory(&[]);
         let (log, _) = recording_log();
@@ -608,6 +612,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-067 — a TCP (verbose) server logs the per-request outcome; without verbose only the "received" line.
     async fn ut_handle_verbose_logs_outcome_quiet_when_off() {
         let mem = seeded_memory(&[1, 2]);
 
@@ -654,6 +659,7 @@ mod tests {
     // ---- WriteMultipleCoils: regression for the hard-coded range length bug ----
 
     #[tokio::test]
+    /// MB-R-062 — a multi-coil write is answered with the address written and the number of values written.
     async fn ut_write_multiple_coils_persists_every_bit() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 8, &[]);
         let (log, _) = recording_log();
@@ -679,6 +685,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a multi-coil write overrunning the declared region is answered with `IllegalDataAddress`.
     async fn ut_write_multiple_coils_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 8, &[]);
         let (log, _) = recording_log();
@@ -698,6 +705,7 @@ mod tests {
     // ---- Coil / discrete-input reads ----
 
     #[tokio::test]
+    /// MB-R-061 — a coil read reports each stored word as set when it is non-zero.
     async fn ut_read_coils_returns_seeded_bits() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[1, 0, 1, 0]);
         let (log, _) = recording_log();
@@ -708,6 +716,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a coil read outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_read_coils_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
@@ -718,6 +727,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-058 — the server answers read-discrete-inputs from the stored bits.
     async fn ut_read_discrete_inputs_returns_seeded_bits() {
         let mem = seeded(RegKind::DiscreteInput, CellType::Coil, 3, &[0, 1, 1]);
         let (log, _) = recording_log();
@@ -729,6 +739,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a discrete-input read against an undeclared slave is answered with `IllegalDataAddress`.
     async fn ut_read_discrete_inputs_unknown_slave_is_illegal_data_address() {
         let mem = seeded(RegKind::DiscreteInput, CellType::Coil, 3, &[]);
         let (log, _) = recording_log();
@@ -742,6 +753,7 @@ mod tests {
     // ---- Register reads ----
 
     #[tokio::test]
+    /// MB-R-057 — an input-register read is answered from the values stored in the shared store.
     async fn ut_read_input_registers_returns_seeded_values() {
         let mem = seeded(RegKind::InputRegister, CellType::Register, 3, &[7, 8, 9]);
         let (log, _) = recording_log();
@@ -753,6 +765,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — an input-register read outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_read_input_registers_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::InputRegister, CellType::Register, 3, &[]);
         let (log, _) = recording_log();
@@ -764,6 +777,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a holding-register read outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_read_holding_registers_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
@@ -782,6 +796,7 @@ mod tests {
     // ---- Single writes ----
 
     #[tokio::test]
+    /// MB-R-061 — a coil write stores a set coil, observable on read-back.
     async fn ut_write_single_coil_persists() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
@@ -797,6 +812,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a single-coil write outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_write_single_coil_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
@@ -808,6 +824,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a single-register write outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_write_single_register_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
@@ -826,6 +843,7 @@ mod tests {
     // ---- WriteMultipleRegisters ----
 
     #[tokio::test]
+    /// MB-R-062 — a multi-register write is answered with the address written and the number of values written.
     async fn ut_write_multiple_registers_persists_all() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 8, &[]);
         let (log, _) = recording_log();
@@ -852,6 +870,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-060 — a multi-register write outside the declared region is answered with `IllegalDataAddress`.
     async fn ut_write_multiple_registers_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
@@ -870,6 +889,7 @@ mod tests {
     // ---- ReadWriteMultipleRegisters (reads and writes the same holding region) ----
 
     #[tokio::test]
+    /// MB-R-063 — a read/write-multiple request applies the write and returns the values read before it.
     async fn ut_read_write_multiple_registers_writes_then_returns_read() {
         let mem = seeded(
             RegKind::HoldingRegister,
@@ -902,6 +922,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-064 — a read/write-multiple whose write range is not writable is answered `IllegalDataAddress` and applies no write.
     async fn ut_read_write_multiple_registers_out_of_range_is_illegal_data_address() {
         let mem = seeded(
             RegKind::HoldingRegister,
@@ -925,6 +946,7 @@ mod tests {
     // ---- Unsupported function codes ----
 
     #[tokio::test]
+    /// MB-R-059 — report-server-id is rejected with `IllegalFunction`.
     async fn ut_report_server_id_is_illegal_function() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
@@ -937,6 +959,7 @@ mod tests {
     // ---- Verbose logging: every arm's success/failure log branch ----
 
     #[tokio::test]
+    /// MB-R-067 — a TCP (verbose) server logs a success outcome for every supported request.
     async fn ut_verbose_logs_success_for_every_request() {
         macro_rules! ok {
             ($mem:expr, $req:expr) => {{
@@ -991,6 +1014,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-067 — a TCP (verbose) server logs a failure outcome for every rejected request.
     async fn ut_verbose_logs_failure_for_every_request() {
         macro_rules! fail {
             ($mem:expr, $req:expr) => {{
@@ -1048,6 +1072,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-059 — mask-write-register, read-device-identification, and custom function codes are rejected with `IllegalFunction`.
     async fn ut_unsupported_function_codes_are_illegal() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -135,6 +135,8 @@ fn client_mem() -> Mem {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-035 — the client polls every read operation and writes each result into the shared store
+/// (and accepts write commands, MB-R-046, and terminates gracefully, MB-R-049).
 async fn tcp_client_polls_server_and_executes_commands() {
     let port = free_port();
     let srv_mem = server_mem();
@@ -262,6 +264,8 @@ async fn tcp_client_polls_server_and_executes_commands() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-043 — Modbus exceptions do not disconnect the client; it retries then skips the operation
+/// (and rejected write commands are logged without disconnecting, MB-R-047).
 async fn tcp_client_handles_server_rejections() {
     let port = free_port();
     // Server with no registered regions: every request for slave 1 is rejected.
@@ -312,6 +316,7 @@ async fn tcp_client_handles_server_rejections() {
 }
 
 #[tokio::test]
+/// MB-R-068 — a TCP client connect attempt to a port with no listener fails.
 async fn tcp_client_connect_refused_is_error() {
     // Nothing is listening on this port, so the connect fails.
     let port = free_port();
@@ -319,6 +324,7 @@ async fn tcp_client_connect_refused_is_error() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-071 — failure to bind the TCP listen address fails the server's start and surfaces the error.
 async fn tcp_server_bind_conflict_is_error() {
     let port = free_port();
     // Occupy the port so the server's bind fails.
@@ -331,6 +337,7 @@ async fn tcp_server_bind_conflict_is_error() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-055 — with reconnect disabled, a failed connect ends the client task with that error.
 async fn tcp_client_reconnect_false_dies_on_refused_connect() {
     // No listener; with reconnect off the spawned task's join result carries the connect error
     // instead of retrying forever.
@@ -358,6 +365,7 @@ async fn tcp_client_reconnect_false_dies_on_refused_connect() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-050 — with reconnect enabled, a refused connect is retried after a backoff and connects once a listener appears.
 async fn tcp_client_reconnect_true_connects_once_a_listener_appears() {
     // Nothing is listening yet: the client's first connect attempt fails. With reconnect on it
     // keeps retrying in the background; once a server starts on the port, it should connect and
@@ -415,6 +423,7 @@ async fn tcp_client_reconnect_true_connects_once_a_listener_appears() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-053 — Terminate aborts a reconnect backoff wait immediately and ends the client task with success.
 async fn tcp_client_terminate_during_backoff_exits_promptly() {
     // No listener, so the client sits in its reconnect backoff (up to 1s initially). Sending
     // Terminate must abort that wait immediately rather than sleeping it out.

--- a/ferrowl-ocpp/src/action/macros.rs
+++ b/ferrowl-ocpp/src/action/macros.rs
@@ -137,9 +137,9 @@ macro_rules! define_ocpp_version {
         // doc comment — this exact drift bit 24 v2.0.1 actions previously).
         #[cfg(test)]
         mod ut_validate_flags {
+            #[test]
             /// OC-R-008 — each action's validate flag matches whether its request type actually derives `Validate`,
             /// so the version's validation rules are applied to exactly the actions that have them.
-            #[test]
             fn ut_validate_flag_matches_request_type() {
                 $(
                     assert_eq!(

--- a/ferrowl-ocpp/src/action/macros.rs
+++ b/ferrowl-ocpp/src/action/macros.rs
@@ -137,6 +137,8 @@ macro_rules! define_ocpp_version {
         // doc comment — this exact drift bit 24 v2.0.1 actions previously).
         #[cfg(test)]
         mod ut_validate_flags {
+            /// OC-R-008 — each action's validate flag matches whether its request type actually derives `Validate`,
+            /// so the version's validation rules are applied to exactly the actions that have them.
             #[test]
             fn ut_validate_flag_matches_request_type() {
                 $(

--- a/ferrowl-ocpp/src/action/v1_6.rs
+++ b/ferrowl-ocpp/src/action/v1_6.rs
@@ -78,16 +78,16 @@ mod tests {
         })
     }
 
-    /// OC-R-004 — the 1.6 version declares the fixed subprotocol token `ocpp1.6` and maps actions to their wire names.
     #[test]
+    /// OC-R-004 — the 1.6 version declares the fixed subprotocol token `ocpp1.6` and maps actions to their wire names.
     fn ut_action_name_matches_wire() {
         let a = Action::BootNotification(boot_req("M"));
         assert_eq!(V1_6::action_name(&a), "BootNotification");
         assert_eq!(V1_6::subprotocol(), "ocpp1.6");
     }
 
-    /// OC-R-006 — an action's request type is retrievable by its wire action name: encoding then decoding by name round-trips.
     #[test]
+    /// OC-R-006 — an action's request type is retrievable by its wire action name: encoding then decoding by name round-trips.
     fn ut_call_encode_decode_round_trip() {
         let action = Action::BootNotification(boot_req("Model-1"));
         let payload = V1_6::encode_action(&action).unwrap();
@@ -95,8 +95,8 @@ mod tests {
         assert_eq!(action, decoded);
     }
 
-    /// OC-R-018 — a CallResult carries no action name, so the reply is decoded using the originating action's response type.
     #[test]
+    /// OC-R-018 — a CallResult carries no action name, so the reply is decoded using the originating action's response type.
     fn ut_decode_result_uses_originating_action() {
         let action = Action::BootNotification(boot_req("M"));
         let resp_json = serde_json::json!({
@@ -108,8 +108,8 @@ mod tests {
         assert!(matches!(resp, Response::BootNotification(_)));
     }
 
-    /// OC-R-002 — the 1.6 action table declares exactly 28 actions (with a Default-derived template per name, OC-R-006).
     #[test]
+    /// OC-R-002 — the 1.6 action table declares exactly 28 actions (with a Default-derived template per name, OC-R-006).
     fn ut_introspection() {
         // Full set is 28 actions; CS-originated subset is the 10 a charging station sends.
         assert_eq!(V1_6::action_names().len(), 28);
@@ -127,8 +127,8 @@ mod tests {
         assert!(V1_6::default_action("NoSuchAction").is_none());
     }
 
-    /// OC-R-003 — CS- and CSMS-originated sets partition the table (disjoint and complete); each CSMS action carries a connector scope (OC-R-005).
     #[test]
+    /// OC-R-003 — CS- and CSMS-originated sets partition the table (disjoint and complete); each CSMS action carries a connector scope (OC-R-005).
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
         let cs: std::collections::HashSet<_> = V1_6::cs_actions().iter().copied().collect();
@@ -154,8 +154,8 @@ mod tests {
         assert_eq!(scope("RemoteStartTransaction"), Optional);
     }
 
-    /// OC-R-026 — decoding a Call naming an action the version does not have yields an unknown-action error (answered NotImplemented).
     #[test]
+    /// OC-R-026 — decoding a Call naming an action the version does not have yields an unknown-action error (answered NotImplemented).
     fn ut_unknown_action_errors() {
         assert!(matches!(
             V1_6::decode_call("NoSuchAction", serde_json::json!({})),
@@ -163,8 +163,8 @@ mod tests {
         ));
     }
 
-    /// OC-R-008 — the version's request-validation rules reject an out-of-spec field and accept a valid one.
     #[test]
+    /// OC-R-008 — the version's request-validation rules reject an out-of-spec field and accept a valid one.
     fn ut_validate_rejects_oversized_field() {
         let bad = Action::BootNotification(boot_req(&"x".repeat(21)));
         assert!(V1_6::validate(&bad).is_err());

--- a/ferrowl-ocpp/src/action/v1_6.rs
+++ b/ferrowl-ocpp/src/action/v1_6.rs
@@ -78,6 +78,7 @@ mod tests {
         })
     }
 
+    /// OC-R-004 — the 1.6 version declares the fixed subprotocol token `ocpp1.6` and maps actions to their wire names.
     #[test]
     fn ut_action_name_matches_wire() {
         let a = Action::BootNotification(boot_req("M"));
@@ -85,6 +86,7 @@ mod tests {
         assert_eq!(V1_6::subprotocol(), "ocpp1.6");
     }
 
+    /// OC-R-006 — an action's request type is retrievable by its wire action name: encoding then decoding by name round-trips.
     #[test]
     fn ut_call_encode_decode_round_trip() {
         let action = Action::BootNotification(boot_req("Model-1"));
@@ -93,6 +95,7 @@ mod tests {
         assert_eq!(action, decoded);
     }
 
+    /// OC-R-018 — a CallResult carries no action name, so the reply is decoded using the originating action's response type.
     #[test]
     fn ut_decode_result_uses_originating_action() {
         let action = Action::BootNotification(boot_req("M"));
@@ -105,6 +108,7 @@ mod tests {
         assert!(matches!(resp, Response::BootNotification(_)));
     }
 
+    /// OC-R-002 — the 1.6 action table declares exactly 28 actions (with a Default-derived template per name, OC-R-006).
     #[test]
     fn ut_introspection() {
         // Full set is 28 actions; CS-originated subset is the 10 a charging station sends.
@@ -123,6 +127,7 @@ mod tests {
         assert!(V1_6::default_action("NoSuchAction").is_none());
     }
 
+    /// OC-R-003 — CS- and CSMS-originated sets partition the table (disjoint and complete); each CSMS action carries a connector scope (OC-R-005).
     #[test]
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
@@ -149,6 +154,7 @@ mod tests {
         assert_eq!(scope("RemoteStartTransaction"), Optional);
     }
 
+    /// OC-R-026 — decoding a Call naming an action the version does not have yields an unknown-action error (answered NotImplemented).
     #[test]
     fn ut_unknown_action_errors() {
         assert!(matches!(
@@ -157,6 +163,7 @@ mod tests {
         ));
     }
 
+    /// OC-R-008 — the version's request-validation rules reject an out-of-spec field and accept a valid one.
     #[test]
     fn ut_validate_rejects_oversized_field() {
         let bad = Action::BootNotification(boot_req(&"x".repeat(21)));

--- a/ferrowl-ocpp/src/action/v2_0_1.rs
+++ b/ferrowl-ocpp/src/action/v2_0_1.rs
@@ -132,8 +132,8 @@ mod tests {
     use super::*;
     use crate::action::Version;
 
-    /// OC-R-003 — the 2.0.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     #[test]
+    /// OC-R-003 — the 2.0.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
         let cs: std::collections::HashSet<_> = V2_0_1::cs_actions().iter().copied().collect();
@@ -158,8 +158,8 @@ mod tests {
         assert_eq!(scope("ClearCache"), None);
     }
 
-    /// OC-R-006 — a 2.0.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     #[test]
+    /// OC-R-006 — a 2.0.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     fn ut_round_trip_boot_notification() {
         use ::rust_ocpp::v2_0_1::datatypes::charging_station::ChargingStationType;
         use ::rust_ocpp::v2_0_1::enumerations::boot_reason::BootReasonEnumType;
@@ -191,8 +191,8 @@ mod tests {
         assert_eq!(decoded, response);
     }
 
-    /// OC-R-006 — a 2.0.1 MeterValues action encodes and decodes by its wire action name.
     #[test]
+    /// OC-R-006 — a 2.0.1 MeterValues action encodes and decodes by its wire action name.
     fn ut_round_trip_meter_values() {
         use ::rust_ocpp::v2_0_1::datatypes::meter_value::MeterValueType;
         use ::rust_ocpp::v2_0_1::datatypes::sampled_value::SampledValueType;
@@ -214,8 +214,8 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
-    /// OC-R-006 — a 2.0.1 Authorize action validates then encodes/decodes by its wire action name.
     #[test]
+    /// OC-R-006 — a 2.0.1 Authorize action validates then encodes/decodes by its wire action name.
     fn ut_round_trip_authorize() {
         use ::rust_ocpp::v2_0_1::datatypes::id_token::IdTokenType;
         use ::rust_ocpp::v2_0_1::enumerations::id_token::IdTokenEnumType;
@@ -236,8 +236,8 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
-    /// OC-R-008 — the 2.0.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     #[test]
+    /// OC-R-008 — the 2.0.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     fn ut_validate_rejects_authorize_certificate_too_long() {
         use ::rust_ocpp::v2_0_1::datatypes::id_token::IdTokenType;
         use ::rust_ocpp::v2_0_1::messages::authorize::AuthorizeRequest;
@@ -252,8 +252,8 @@ mod tests {
         assert!(V2_0_1::validate(&action).is_err());
     }
 
-    /// OC-R-008 — the 2.0.1 validation rules reject a DataTransfer whose vendor id exceeds its length cap.
     #[test]
+    /// OC-R-008 — the 2.0.1 validation rules reject a DataTransfer whose vendor id exceeds its length cap.
     fn ut_validate_rejects_datatransfer_vendor_id_too_long() {
         use ::rust_ocpp::v2_0_1::messages::datatransfer::DataTransferRequest;
 

--- a/ferrowl-ocpp/src/action/v2_0_1.rs
+++ b/ferrowl-ocpp/src/action/v2_0_1.rs
@@ -132,6 +132,7 @@ mod tests {
     use super::*;
     use crate::action::Version;
 
+    /// OC-R-003 — the 2.0.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     #[test]
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
@@ -157,6 +158,7 @@ mod tests {
         assert_eq!(scope("ClearCache"), None);
     }
 
+    /// OC-R-006 — a 2.0.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     #[test]
     fn ut_round_trip_boot_notification() {
         use ::rust_ocpp::v2_0_1::datatypes::charging_station::ChargingStationType;
@@ -189,6 +191,7 @@ mod tests {
         assert_eq!(decoded, response);
     }
 
+    /// OC-R-006 — a 2.0.1 MeterValues action encodes and decodes by its wire action name.
     #[test]
     fn ut_round_trip_meter_values() {
         use ::rust_ocpp::v2_0_1::datatypes::meter_value::MeterValueType;
@@ -211,6 +214,7 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
+    /// OC-R-006 — a 2.0.1 Authorize action validates then encodes/decodes by its wire action name.
     #[test]
     fn ut_round_trip_authorize() {
         use ::rust_ocpp::v2_0_1::datatypes::id_token::IdTokenType;
@@ -232,6 +236,7 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
+    /// OC-R-008 — the 2.0.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     #[test]
     fn ut_validate_rejects_authorize_certificate_too_long() {
         use ::rust_ocpp::v2_0_1::datatypes::id_token::IdTokenType;
@@ -247,6 +252,7 @@ mod tests {
         assert!(V2_0_1::validate(&action).is_err());
     }
 
+    /// OC-R-008 — the 2.0.1 validation rules reject a DataTransfer whose vendor id exceeds its length cap.
     #[test]
     fn ut_validate_rejects_datatransfer_vendor_id_too_long() {
         use ::rust_ocpp::v2_0_1::messages::datatransfer::DataTransferRequest;

--- a/ferrowl-ocpp/src/action/v2_1.rs
+++ b/ferrowl-ocpp/src/action/v2_1.rs
@@ -182,11 +182,13 @@ mod tests {
     use super::*;
     use crate::action::Version;
 
+    /// OC-R-004 — the 2.1 version declares the fixed subprotocol token `ocpp2.1`.
     #[test]
     fn ut_subprotocol() {
         assert_eq!(V2_1::subprotocol(), "ocpp2.1");
     }
 
+    /// OC-R-003 — the 2.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     #[test]
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
@@ -212,6 +214,7 @@ mod tests {
         assert_eq!(scope("SetDERControl"), None);
     }
 
+    /// OC-R-006 — a 2.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     #[test]
     fn ut_round_trip_boot_notification() {
         use ::rust_ocpp::v2_1::datatypes::charging_station::ChargingStationType;
@@ -244,6 +247,7 @@ mod tests {
         assert_eq!(decoded, response);
     }
 
+    /// OC-R-006 — a 2.1 Authorize action validates then encodes/decodes by its wire action name.
     #[test]
     fn ut_round_trip_authorize() {
         use ::rust_ocpp::v2_1::datatypes::id_token::IdTokenType;
@@ -264,6 +268,7 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
+    /// OC-R-006 — a 2.1 MeterValues action validates then encodes/decodes by its wire action name.
     #[test]
     fn ut_round_trip_meter_values() {
         use ::rust_ocpp::v2_1::datatypes::meter_value::MeterValueType;
@@ -287,6 +292,7 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
+    /// OC-R-008 — the 2.1 validation rules reject a MeterValues with an empty meter-value list.
     #[test]
     fn ut_validate_rejects_meter_values_empty_meter_value() {
         use ::rust_ocpp::v2_1::messages::meter_values::MeterValuesRequest;
@@ -302,6 +308,7 @@ mod tests {
         assert!(V2_1::validate(&action).is_err());
     }
 
+    /// OC-R-008 — the 2.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     #[test]
     fn ut_validate_rejects_authorize_certificate_too_long() {
         use ::rust_ocpp::v2_1::datatypes::id_token::IdTokenType;

--- a/ferrowl-ocpp/src/action/v2_1.rs
+++ b/ferrowl-ocpp/src/action/v2_1.rs
@@ -182,14 +182,14 @@ mod tests {
     use super::*;
     use crate::action::Version;
 
-    /// OC-R-004 — the 2.1 version declares the fixed subprotocol token `ocpp2.1`.
     #[test]
+    /// OC-R-004 — the 2.1 version declares the fixed subprotocol token `ocpp2.1`.
     fn ut_subprotocol() {
         assert_eq!(V2_1::subprotocol(), "ocpp2.1");
     }
 
-    /// OC-R-003 — the 2.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     #[test]
+    /// OC-R-003 — the 2.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;
         let cs: std::collections::HashSet<_> = V2_1::cs_actions().iter().copied().collect();
@@ -214,8 +214,8 @@ mod tests {
         assert_eq!(scope("SetDERControl"), None);
     }
 
-    /// OC-R-006 — a 2.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     #[test]
+    /// OC-R-006 — a 2.1 action encodes and decodes by wire name, and its response decodes via the originating action (OC-R-018).
     fn ut_round_trip_boot_notification() {
         use ::rust_ocpp::v2_1::datatypes::charging_station::ChargingStationType;
         use ::rust_ocpp::v2_1::enumerations::boot_reason::BootReasonEnumType;
@@ -247,8 +247,8 @@ mod tests {
         assert_eq!(decoded, response);
     }
 
-    /// OC-R-006 — a 2.1 Authorize action validates then encodes/decodes by its wire action name.
     #[test]
+    /// OC-R-006 — a 2.1 Authorize action validates then encodes/decodes by its wire action name.
     fn ut_round_trip_authorize() {
         use ::rust_ocpp::v2_1::datatypes::id_token::IdTokenType;
         use ::rust_ocpp::v2_1::messages::authorize::AuthorizeRequest;
@@ -268,8 +268,8 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
-    /// OC-R-006 — a 2.1 MeterValues action validates then encodes/decodes by its wire action name.
     #[test]
+    /// OC-R-006 — a 2.1 MeterValues action validates then encodes/decodes by its wire action name.
     fn ut_round_trip_meter_values() {
         use ::rust_ocpp::v2_1::datatypes::meter_value::MeterValueType;
         use ::rust_ocpp::v2_1::datatypes::sampled_value::SampledValueType;
@@ -292,8 +292,8 @@ mod tests {
         assert_eq!(decoded, action);
     }
 
-    /// OC-R-008 — the 2.1 validation rules reject a MeterValues with an empty meter-value list.
     #[test]
+    /// OC-R-008 — the 2.1 validation rules reject a MeterValues with an empty meter-value list.
     fn ut_validate_rejects_meter_values_empty_meter_value() {
         use ::rust_ocpp::v2_1::messages::meter_values::MeterValuesRequest;
 
@@ -308,8 +308,8 @@ mod tests {
         assert!(V2_1::validate(&action).is_err());
     }
 
-    /// OC-R-008 — the 2.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     #[test]
+    /// OC-R-008 — the 2.1 validation rules reject an Authorize whose certificate exceeds its length cap.
     fn ut_validate_rejects_authorize_certificate_too_long() {
         use ::rust_ocpp::v2_1::datatypes::id_token::IdTokenType;
         use ::rust_ocpp::v2_1::messages::authorize::AuthorizeRequest;

--- a/ferrowl-ocpp/src/correlation.rs
+++ b/ferrowl-ocpp/src/correlation.rs
@@ -63,6 +63,7 @@ mod tests {
     use crate::ocppj::CallErrorCode;
 
     #[tokio::test]
+    /// OC-R-017 — a registered outbound Call is completed by the matching inbound reply, keyed by unique id.
     async fn ut_register_complete() {
         let p = PendingCalls::new();
         let id = UniqueId("a".into());
@@ -73,6 +74,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-019 — completing an id that matches no pending entry is discarded silently (no panic).
     async fn ut_complete_unknown_id_is_noop() {
         let p = PendingCalls::new();
         // Must not panic.
@@ -80,6 +82,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-022 — on teardown every pending outbound Call is failed with a rejection, so no caller waits forever.
     async fn ut_fail_all_notifies_waiters() {
         let p = PendingCalls::new();
         let rx = p.register(UniqueId("x".into()));

--- a/ferrowl-ocpp/src/ocppj/codec.rs
+++ b/ferrowl-ocpp/src/ocppj/codec.rs
@@ -119,8 +119,8 @@ mod tests {
         }
     }
 
-    /// OC-R-009 — a Call encodes/decodes as the `[2, uniqueId, action, payload]` text envelope.
     #[test]
+    /// OC-R-009 — a Call encodes/decodes as the `[2, uniqueId, action, payload]` text envelope.
     fn ut_call_round_trip() {
         let msg = OcppJMessage::Call {
             id: UniqueId("abc".into()),
@@ -130,8 +130,8 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
-    /// OC-R-009 — a CallResult encodes/decodes as the `[3, uniqueId, payload]` text envelope.
     #[test]
+    /// OC-R-009 — a CallResult encodes/decodes as the `[3, uniqueId, payload]` text envelope.
     fn ut_call_result_round_trip() {
         let msg = OcppJMessage::CallResult {
             id: UniqueId("xyz".into()),
@@ -140,8 +140,8 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
-    /// OC-R-009 — a CallError encodes/decodes as the `[4, uniqueId, errorCode, errorDescription, errorDetails]` text envelope.
     #[test]
+    /// OC-R-009 — a CallError encodes/decodes as the `[4, uniqueId, errorCode, errorDescription, errorDetails]` text envelope.
     fn ut_call_error_round_trip() {
         let msg = OcppJMessage::CallError {
             id: UniqueId("e1".into()),
@@ -152,14 +152,14 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
-    /// OC-R-010 — a frame that is not a JSON array is rejected.
     #[test]
+    /// OC-R-010 — a frame that is not a JSON array is rejected.
     fn ut_reject_non_array() {
         assert!(matches!(decode("{}"), Err(FramingError::NotAnArray)));
     }
 
-    /// OC-R-010 — a frame with an unknown message-type id is rejected.
     #[test]
+    /// OC-R-010 — a frame with an unknown message-type id is rejected.
     fn ut_reject_unknown_type() {
         assert!(matches!(
             decode("[9, \"id\", \"x\", {}]"),
@@ -167,8 +167,8 @@ mod tests {
         ));
     }
 
-    /// OC-R-010 — a frame with the wrong element count for its message type is rejected.
     #[test]
+    /// OC-R-010 — a frame with the wrong element count for its message type is rejected.
     fn ut_reject_bad_arity() {
         assert!(matches!(
             decode("[2, \"id\"]"),
@@ -176,8 +176,8 @@ mod tests {
         ));
     }
 
-    /// OC-R-098 — a malformed but identifiable Call (type 2, string id) yields its id so it can be answered with a CallError.
     #[test]
+    /// OC-R-098 — a malformed but identifiable Call (type 2, string id) yields its id so it can be answered with a CallError.
     fn ut_recover_call_id_from_malformed_call() {
         // Short-arity Call, and a Call whose action isn't a string: both rejected by `decode`,
         // both still owed a CallError, so the id must come back.
@@ -191,9 +191,9 @@ mod tests {
         );
     }
 
+    #[test]
     /// OC-R-099 — an unrecoverable id (non-JSON, non-array, no type-2, non-string id) yields nothing; a malformed
     /// CallResult/CallError is never answerable either (OC-R-100).
-    #[test]
     fn ut_recover_call_id_gives_up_when_unanswerable() {
         assert_eq!(recover_call_id("not json"), None);
         assert_eq!(recover_call_id("{\"a\": 1}"), None); // not an array

--- a/ferrowl-ocpp/src/ocppj/codec.rs
+++ b/ferrowl-ocpp/src/ocppj/codec.rs
@@ -119,6 +119,7 @@ mod tests {
         }
     }
 
+    /// OC-R-009 — a Call encodes/decodes as the `[2, uniqueId, action, payload]` text envelope.
     #[test]
     fn ut_call_round_trip() {
         let msg = OcppJMessage::Call {
@@ -129,6 +130,7 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
+    /// OC-R-009 — a CallResult encodes/decodes as the `[3, uniqueId, payload]` text envelope.
     #[test]
     fn ut_call_result_round_trip() {
         let msg = OcppJMessage::CallResult {
@@ -138,6 +140,7 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
+    /// OC-R-009 — a CallError encodes/decodes as the `[4, uniqueId, errorCode, errorDescription, errorDetails]` text envelope.
     #[test]
     fn ut_call_error_round_trip() {
         let msg = OcppJMessage::CallError {
@@ -149,11 +152,13 @@ mod tests {
         assert_eq!(msg, round_trip(&msg));
     }
 
+    /// OC-R-010 — a frame that is not a JSON array is rejected.
     #[test]
     fn ut_reject_non_array() {
         assert!(matches!(decode("{}"), Err(FramingError::NotAnArray)));
     }
 
+    /// OC-R-010 — a frame with an unknown message-type id is rejected.
     #[test]
     fn ut_reject_unknown_type() {
         assert!(matches!(
@@ -162,6 +167,7 @@ mod tests {
         ));
     }
 
+    /// OC-R-010 — a frame with the wrong element count for its message type is rejected.
     #[test]
     fn ut_reject_bad_arity() {
         assert!(matches!(
@@ -170,6 +176,7 @@ mod tests {
         ));
     }
 
+    /// OC-R-098 — a malformed but identifiable Call (type 2, string id) yields its id so it can be answered with a CallError.
     #[test]
     fn ut_recover_call_id_from_malformed_call() {
         // Short-arity Call, and a Call whose action isn't a string: both rejected by `decode`,
@@ -184,6 +191,8 @@ mod tests {
         );
     }
 
+    /// OC-R-099 — an unrecoverable id (non-JSON, non-array, no type-2, non-string id) yields nothing; a malformed
+    /// CallResult/CallError is never answerable either (OC-R-100).
     #[test]
     fn ut_recover_call_id_gives_up_when_unanswerable() {
         assert_eq!(recover_call_id("not json"), None);

--- a/ferrowl-ocpp/src/security.rs
+++ b/ferrowl-ocpp/src/security.rs
@@ -340,9 +340,9 @@ mod tests {
         (cert.pem(), key.serialize_pem())
     }
 
+    #[test]
     /// OC-R-041 — a well-formed certificate and key load, pinning the happy path the negative
     /// cases below are measured against.
-    #[test]
     fn ut_load_certs_and_key_roundtrip() {
         let (cert_pem, key_pem) = cert_and_key_pem();
         let cert_path = temp_pem("roundtrip-cert", &cert_pem);
@@ -351,9 +351,9 @@ mod tests {
         load_private_key(&key_path).expect("key should load");
     }
 
+    #[test]
     /// OC-R-041 — failing to open a certificate file is a TLS error, not a panic or a silent
     /// empty chain.
-    #[test]
     fn ut_load_certs_missing_file_is_tls_error() {
         let missing = temp_pem("missing-cert", "");
         std::fs::remove_file(&missing).unwrap();
@@ -363,9 +363,9 @@ mod tests {
         ));
     }
 
+    #[test]
     /// OC-R-041 — a readable file with no certificate section fails as NoCertificates rather than
     /// being accepted as an empty chain.
-    #[test]
     fn ut_load_certs_without_certificate_section_is_no_certificates() {
         let (_cert, key_pem) = cert_and_key_pem();
         let path = temp_pem("key-only", &key_pem);
@@ -375,8 +375,8 @@ mod tests {
         ));
     }
 
-    /// OC-R-041 — failing to find a private key in a readable file is NoPrivateKey.
     #[test]
+    /// OC-R-041 — failing to find a private key in a readable file is NoPrivateKey.
     fn ut_load_private_key_without_key_section_is_no_private_key() {
         let (cert_pem, _key) = cert_and_key_pem();
         let path = temp_pem("cert-only", &cert_pem);

--- a/ferrowl-ocpp/tests/ws_loopback_security.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_security.rs
@@ -81,6 +81,7 @@ fn write_pem(label: &str, pem: &str) -> String {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-030 — a CS with Basic Auth sends the `Authorization: Basic` header and the CSMS accepts matching credentials.
 async fn basic_auth_accepts_matching_credentials() {
     let auth = BasicAuth {
         username: "cp001".to_owned(),
@@ -117,6 +118,7 @@ async fn basic_auth_accepts_matching_credentials() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-031 — a CSMS rejects an upgrade whose Basic Auth credentials do not match, answering 401.
 async fn basic_auth_rejects_mismatched_credentials() {
     let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
         host: "127.0.0.1".to_owned(),
@@ -154,6 +156,7 @@ async fn basic_auth_rejects_mismatched_credentials() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-031 — a CSMS rejects an upgrade with no `Authorization` header, answering 401.
 async fn basic_auth_rejects_missing_credentials() {
     let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
         host: "127.0.0.1".to_owned(),
@@ -188,6 +191,7 @@ async fn basic_auth_rejects_missing_credentials() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-034 — a CS trusts a certificate supplied via `ca_file`, completing a TLS loopback to the CSMS.
 async fn tls_loopback_over_self_signed_cert() {
     let key_pair = rcgen::KeyPair::generate().expect("keypair generation failed");
     let cert = rcgen::CertificateParams::new(vec!["127.0.0.1".to_owned()])
@@ -239,6 +243,7 @@ async fn tls_loopback_over_self_signed_cert() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-034 — a CS rejects a server certificate not trusted by the webpki roots or its configured `ca_file`.
 async fn tls_loopback_rejects_untrusted_cert() {
     let key_pair = rcgen::KeyPair::generate().expect("keypair generation failed");
     let cert = rcgen::CertificateParams::new(vec!["127.0.0.1".to_owned()])
@@ -292,6 +297,7 @@ async fn tls_loopback_rejects_untrusted_cert() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-036 — a CS with `insecure_skip_verify` accepts any server certificate and connects.
 async fn self_signed_csms_with_skip_verify_client_connects() {
     let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
         host: "127.0.0.1".to_owned(),
@@ -332,6 +338,7 @@ async fn self_signed_csms_with_skip_verify_client_connects() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-036 — without `insecure_skip_verify`, a CS rejects an untrusted self-signed CSMS certificate.
 async fn self_signed_csms_without_skip_verify_client_rejects() {
     let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
         host: "127.0.0.1".to_owned(),
@@ -372,6 +379,7 @@ async fn self_signed_csms_without_skip_verify_client_rejects() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-031 — Basic Auth credential checking still applies when layered over a self-signed TLS connection.
 async fn basic_auth_over_self_signed_tls_checks_credentials() {
     let auth = BasicAuth {
         username: "cp001".to_owned(),
@@ -439,6 +447,7 @@ async fn basic_auth_over_self_signed_tls_checks_credentials() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// OC-R-040 — `require_client_cert` combined with a self-signed CSMS certificate fails the server's start.
 async fn self_signed_with_require_client_cert_is_rejected_at_build() {
     let result = csms::ServerBuilder::<V1_6>::new(csms::Config {
         host: "127.0.0.1".to_owned(),

--- a/ferrowl-ocpp/tests/ws_loopback_v16.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v16.rs
@@ -95,6 +95,7 @@ async fn first_connection(server: &csms::Server<V1_6>) -> csms::ConnectionId {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-014 — the 1.6 connection is full-duplex: CS and CSMS each originate Calls on the same socket.
 async fn cs_calls_csms_and_csms_calls_cs() {
     let server = start_server().await;
     let url = format!("ws://{}/ocpp/CS001", server.local_addr());
@@ -176,6 +177,7 @@ async fn cs_calls_csms_and_csms_calls_cs() {
 /// it unanswered strands the peer until its own call timeout fires. Driven over a raw websocket,
 /// since the typed client cannot produce a malformed frame.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-098 — a malformed but identifiable inbound Call is answered with a CallError carrying its recovered id.
 async fn malformed_call_with_recoverable_id_gets_call_error() {
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message;

--- a/ferrowl-ocpp/tests/ws_loopback_v201.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v201.rs
@@ -93,6 +93,7 @@ async fn first_connection(server: &csms::Server<V2_0_1>) -> csms::ConnectionId {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-014 — the 2.0.1 connection is full-duplex: CS and CSMS each originate Calls on the same socket.
 async fn cs_calls_csms_and_csms_calls_cs() {
     let server = start_server().await;
     let url = format!("ws://{}/ocpp/CS001", server.local_addr());

--- a/ferrowl-ocpp/tests/ws_loopback_v21.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v21.rs
@@ -93,6 +93,7 @@ async fn first_connection(server: &csms::Server<V2_1>) -> csms::ConnectionId {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-014 — the 2.1 connection is full-duplex: CS and CSMS each originate Calls on the same socket.
 async fn cs_calls_csms_and_csms_calls_cs() {
     let server = start_server().await;
     let url = format!("ws://{}/ocpp/CS001", server.local_addr());

--- a/ferrowl-store/src/cell.rs
+++ b/ferrowl-store/src/cell.rs
@@ -137,6 +137,7 @@ impl<'a> ValueRange<'a> {
 mod tests {
     use super::{Cell, CellKind, CellType, ValueRange};
 
+    /// MB-R-030 — a cell carries both a cell type and an access direction (read/write/read-write).
     #[test]
     fn ut_value_default() {
         assert_eq!(
@@ -153,6 +154,7 @@ mod tests {
         );
     }
 
+    /// MB-R-030 — a value-initialized cell preserves its cell type and access direction.
     #[test]
     fn ut_value_from_u16() {
         assert_eq!(
@@ -178,6 +180,7 @@ mod tests {
         assert_eq!(range.range.end, 120);
     }
 
+    /// MB-R-030 — a region's declared kind exposes its underlying cell type independent of access direction.
     #[test]
     fn ut_kind_get_type() {
         assert_eq!(CellKind::Read(CellType::Coil).cell_type(), CellType::Coil);

--- a/ferrowl-store/src/cell.rs
+++ b/ferrowl-store/src/cell.rs
@@ -137,8 +137,8 @@ impl<'a> ValueRange<'a> {
 mod tests {
     use super::{Cell, CellKind, CellType, ValueRange};
 
-    /// MB-R-030 — a cell carries both a cell type and an access direction (read/write/read-write).
     #[test]
+    /// MB-R-030 — a cell carries both a cell type and an access direction (read/write/read-write).
     fn ut_value_default() {
         assert_eq!(
             Cell::default(&CellKind::Read(CellType::Coil)),
@@ -154,8 +154,8 @@ mod tests {
         );
     }
 
-    /// MB-R-030 — a value-initialized cell preserves its cell type and access direction.
     #[test]
+    /// MB-R-030 — a value-initialized cell preserves its cell type and access direction.
     fn ut_value_from_u16() {
         assert_eq!(
             Cell::from_u16(&CellKind::Read(CellType::Coil), 1),
@@ -180,8 +180,8 @@ mod tests {
         assert_eq!(range.range.end, 120);
     }
 
-    /// MB-R-030 — a region's declared kind exposes its underlying cell type independent of access direction.
     #[test]
+    /// MB-R-030 — a region's declared kind exposes its underlying cell type independent of access direction.
     fn ut_kind_get_type() {
         assert_eq!(CellKind::Read(CellType::Coil).cell_type(), CellType::Coil);
         assert_eq!(

--- a/ferrowl-store/src/memory.rs
+++ b/ferrowl-store/src/memory.rs
@@ -291,8 +291,8 @@ where
 mod tests {
     use crate::{Cell, CellKind, CellType, Memory, MemoryError, range::Range};
 
-    /// MB-R-030 — a default cell carries its cell type and access direction, zero-initialized.
     #[test]
+    /// MB-R-030 — a default cell carries its cell type and access direction, zero-initialized.
     fn ut_memory() {
         assert_eq!(
             Cell::default(&CellKind::Read(CellType::Coil)),
@@ -308,8 +308,8 @@ mod tests {
         );
     }
 
-    /// MB-R-095 — declaring an overlapping same-type range merges into one region spanning the union.
     #[test]
+    /// MB-R-095 — declaring an overlapping same-type range merges into one region spanning the union.
     fn ut_memory_add_ranges_1() {
         let mut memory = Memory::default();
         memory.add_ranges(1, &CellKind::Read(CellType::Coil), &[Range::new(0, 10)]);
@@ -321,8 +321,8 @@ mod tests {
         assert!(slices.get(&Range::new(0, 15)).is_some());
     }
 
-    /// MB-R-095 — a contained overlapping range merges into the existing region, not a new one.
     #[test]
+    /// MB-R-095 — a contained overlapping range merges into the existing region, not a new one.
     fn ut_memory_add_ranges_2() {
         let mut memory = Memory::default();
         memory.add_ranges(1, &CellKind::Read(CellType::Coil), &[Range::new(0, 10)]);
@@ -334,8 +334,8 @@ mod tests {
         assert!(slices.get(&Range::new(0, 10)).is_some());
     }
 
-    /// MB-R-095 — a bridging range merges all intersecting regions, preserving stored values and zero-initializing newly covered addresses.
     #[test]
+    /// MB-R-095 — a bridging range merges all intersecting regions, preserving stored values and zero-initializing newly covered addresses.
     fn ut_memory_add_ranges_bridging_two_slices_merges_all() {
         let kind = CellKind::ReadWrite(CellType::Register);
         let mut memory = Memory::default();
@@ -366,8 +366,8 @@ mod tests {
         );
     }
 
-    /// MB-R-095 — a range overlapping from below merges into a single region spanning the union.
     #[test]
+    /// MB-R-095 — a range overlapping from below merges into a single region spanning the union.
     fn ut_memory_add_ranges_3() {
         let mut memory = Memory::default();
         memory.add_ranges(1, &CellKind::Read(CellType::Coil), &[Range::new(10, 10)]);
@@ -379,8 +379,8 @@ mod tests {
         assert!(slices.get(&Range::new(5, 15)).is_some());
     }
 
-    /// MB-R-096 — disjoint declared regions stay separate; no address is covered by more than one.
     #[test]
+    /// MB-R-096 — disjoint declared regions stay separate; no address is covered by more than one.
     fn ut_memory_add_ranges_4() {
         let mut memory = Memory::default();
         memory.add_ranges(1, &CellKind::Read(CellType::Coil), &[Range::new(15, 10)]);
@@ -393,8 +393,8 @@ mod tests {
         assert!(slices.get(&Range::new(5, 5)).is_some());
     }
 
-    /// MB-R-029 — a write then read succeeds on addresses fully covered by a declared region.
     #[test]
+    /// MB-R-029 — a write then read succeeds on addresses fully covered by a declared region.
     fn ut_memory_write_read_combined() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -414,8 +414,8 @@ mod tests {
         assert_eq!(result.unwrap(), values);
     }
 
-    /// MB-R-029 — a write/read of a sub-range fully inside a declared region succeeds.
     #[test]
+    /// MB-R-029 — a write/read of a sub-range fully inside a declared region succeeds.
     fn ut_memory_write_read_partial_range() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -435,8 +435,8 @@ mod tests {
         assert_eq!(result.unwrap(), values);
     }
 
-    /// MB-R-033 — a checked write fails when the supplied value count does not equal the range length.
     #[test]
+    /// MB-R-033 — a checked write fails when the supplied value count does not equal the range length.
     fn ut_memory_write_wrong_length() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -455,8 +455,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked write fails when the key is unregistered.
     #[test]
+    /// MB-R-033 — a checked write fails when the key is unregistered.
     fn ut_memory_write_unknown_key() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -472,8 +472,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked read fails when the key is unregistered.
     #[test]
+    /// MB-R-033 — a checked read fails when the key is unregistered.
     fn ut_memory_read_unknown_key() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]);
@@ -484,8 +484,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked write fails when the addressed cell is not writable as the requested cell type.
     #[test]
+    /// MB-R-033 — a checked write fails when the addressed cell is not writable as the requested cell type.
     fn ut_memory_writable_wrong_type() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -500,8 +500,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked read fails when the addressed cell is not readable as the requested cell type.
     #[test]
+    /// MB-R-033 — a checked read fails when the addressed cell is not readable as the requested cell type.
     fn ut_memory_readable_wrong_type() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -516,8 +516,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked write fails on a read-only cell.
     #[test]
+    /// MB-R-033 — a checked write fails on a read-only cell.
     fn ut_memory_readonly_not_writable() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]);
@@ -528,8 +528,8 @@ mod tests {
         );
     }
 
-    /// MB-R-033 — a checked read fails on a write-only cell.
     #[test]
+    /// MB-R-033 — a checked read fails on a write-only cell.
     fn ut_memory_writeonly_not_readable() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]);
@@ -548,8 +548,8 @@ mod tests {
         assert!(!memory.slices.contains_key(&1u8));
     }
 
-    /// MB-R-031 — a write region overlapping a read cell of the same type widens it to read/write.
     #[test]
+    /// MB-R-031 — a write region overlapping a read cell of the same type widens it to read/write.
     fn ut_memory_widen_read_then_write() {
         // Read cell + overlapping Write of same type -> ReadWrite.
         let mut memory: Memory<u8> = Memory::default();
@@ -575,8 +575,8 @@ mod tests {
         );
     }
 
-    /// MB-R-031 — a read region overlapping a write cell of the same type widens it to read/write.
     #[test]
+    /// MB-R-031 — a read region overlapping a write cell of the same type widens it to read/write.
     fn ut_memory_widen_write_then_read() {
         // Write cell + overlapping Read of same type -> ReadWrite.
         let mut memory: Memory<u8> = Memory::default();
@@ -594,8 +594,8 @@ mod tests {
         );
     }
 
-    /// MB-R-031 — a same-type same-access overlap merges without changing the access direction.
     #[test]
+    /// MB-R-031 — a same-type same-access overlap merges without changing the access direction.
     fn ut_memory_widen_write_then_write_noop() {
         // Write cell + overlapping Write of same type -> unchanged, still write-only.
         let mut memory: Memory<u8> = Memory::default();
@@ -613,8 +613,8 @@ mod tests {
         );
     }
 
-    /// MB-R-031 — a read/write region overlapping a read/write cell of the same type is a no-op merge.
     #[test]
+    /// MB-R-031 — a read/write region overlapping a read/write cell of the same type is a no-op merge.
     fn ut_memory_widen_readwrite_then_readwrite_noop() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -639,8 +639,8 @@ mod tests {
         );
     }
 
-    /// MB-R-032 — declaring a range overlapping a cell of incompatible cell type fails.
     #[test]
+    /// MB-R-032 — declaring a range overlapping a cell of incompatible cell type fails.
     fn ut_memory_widen_incompatible_read_cell() {
         // Read cell + overlapping incompatible access (wrong type) -> false.
         let mut memory: Memory<u8> = Memory::default();
@@ -652,8 +652,8 @@ mod tests {
         ));
     }
 
-    /// MB-R-032 — declaring a range overlapping a write cell of incompatible cell type fails.
     #[test]
+    /// MB-R-032 — declaring a range overlapping a write cell of incompatible cell type fails.
     fn ut_memory_widen_incompatible_write_cell() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(1u8, &CellKind::Write(CellType::Coil), &[Range::new(0, 5)]);
@@ -664,8 +664,8 @@ mod tests {
         ));
     }
 
-    /// MB-R-032 — a multi-range declaration with a later incompatible overlap leaves the store entirely unchanged.
     #[test]
+    /// MB-R-032 — a multi-range declaration with a later incompatible overlap leaves the store entirely unchanged.
     fn ut_memory_add_ranges_partial_failure_leaves_map_untouched() {
         // Multi-range call: range1 merges cleanly, range2 hits an incompatible
         // overlap. The whole call must fail atomically -- range1's merge must
@@ -700,8 +700,8 @@ mod tests {
         );
     }
 
-    /// MB-R-032 — a three-range declaration failing on the third range commits none of the earlier merges.
     #[test]
+    /// MB-R-032 — a three-range declaration failing on the third range commits none of the earlier merges.
     fn ut_memory_add_ranges_partial_failure_third_range_leaves_map_untouched() {
         // Three ranges in one call: range1 and range2 each merge cleanly
         // against separate pre-existing slices (range2 merging against a
@@ -742,8 +742,8 @@ mod tests {
         );
     }
 
-    /// MB-R-032 — declaring a non-read/write range overlapping a read/write cell fails as an incompatible access combination.
     #[test]
+    /// MB-R-032 — declaring a non-read/write range overlapping a read/write cell fails as an incompatible access combination.
     fn ut_memory_widen_incompatible_readwrite_cell() {
         // ReadWrite cell + non-ReadWrite overlapping access -> false.
         let mut memory: Memory<u8> = Memory::default();
@@ -755,8 +755,8 @@ mod tests {
         assert!(!memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]));
     }
 
-    /// MB-R-034 — unchecked read/write ignore per-cell access direction but still require declared coverage.
     #[test]
+    /// MB-R-034 — unchecked read/write ignore per-cell access direction but still require declared coverage.
     fn ut_memory_write_read_unchecked() {
         let mut memory: Memory<u8> = Memory::default();
         memory.add_ranges(
@@ -781,8 +781,8 @@ mod tests {
         assert!(memory.read_unchecked(9u8, &Range::new(0, 5)).is_none());
     }
 
-    /// MB-R-029 — a read/write spanning multiple adjacent declared regions succeeds across them.
     #[test]
+    /// MB-R-029 — a read/write spanning multiple adjacent declared regions succeeds across them.
     fn ut_memory_walk_multiple_slices() {
         // Two adjacent but non-overlapping slices: a read/write spanning both
         // walks each slice in turn.

--- a/ferrowl-store/src/memory.rs
+++ b/ferrowl-store/src/memory.rs
@@ -291,6 +291,7 @@ where
 mod tests {
     use crate::{Cell, CellKind, CellType, Memory, MemoryError, range::Range};
 
+    /// MB-R-030 — a default cell carries its cell type and access direction, zero-initialized.
     #[test]
     fn ut_memory() {
         assert_eq!(
@@ -307,6 +308,7 @@ mod tests {
         );
     }
 
+    /// MB-R-095 — declaring an overlapping same-type range merges into one region spanning the union.
     #[test]
     fn ut_memory_add_ranges_1() {
         let mut memory = Memory::default();
@@ -319,6 +321,7 @@ mod tests {
         assert!(slices.get(&Range::new(0, 15)).is_some());
     }
 
+    /// MB-R-095 — a contained overlapping range merges into the existing region, not a new one.
     #[test]
     fn ut_memory_add_ranges_2() {
         let mut memory = Memory::default();
@@ -331,6 +334,7 @@ mod tests {
         assert!(slices.get(&Range::new(0, 10)).is_some());
     }
 
+    /// MB-R-095 — a bridging range merges all intersecting regions, preserving stored values and zero-initializing newly covered addresses.
     #[test]
     fn ut_memory_add_ranges_bridging_two_slices_merges_all() {
         let kind = CellKind::ReadWrite(CellType::Register);
@@ -362,6 +366,7 @@ mod tests {
         );
     }
 
+    /// MB-R-095 — a range overlapping from below merges into a single region spanning the union.
     #[test]
     fn ut_memory_add_ranges_3() {
         let mut memory = Memory::default();
@@ -374,6 +379,7 @@ mod tests {
         assert!(slices.get(&Range::new(5, 15)).is_some());
     }
 
+    /// MB-R-096 — disjoint declared regions stay separate; no address is covered by more than one.
     #[test]
     fn ut_memory_add_ranges_4() {
         let mut memory = Memory::default();
@@ -387,6 +393,7 @@ mod tests {
         assert!(slices.get(&Range::new(5, 5)).is_some());
     }
 
+    /// MB-R-029 — a write then read succeeds on addresses fully covered by a declared region.
     #[test]
     fn ut_memory_write_read_combined() {
         let mut memory: Memory<u8> = Memory::default();
@@ -407,6 +414,7 @@ mod tests {
         assert_eq!(result.unwrap(), values);
     }
 
+    /// MB-R-029 — a write/read of a sub-range fully inside a declared region succeeds.
     #[test]
     fn ut_memory_write_read_partial_range() {
         let mut memory: Memory<u8> = Memory::default();
@@ -427,6 +435,7 @@ mod tests {
         assert_eq!(result.unwrap(), values);
     }
 
+    /// MB-R-033 — a checked write fails when the supplied value count does not equal the range length.
     #[test]
     fn ut_memory_write_wrong_length() {
         let mut memory: Memory<u8> = Memory::default();
@@ -446,6 +455,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked write fails when the key is unregistered.
     #[test]
     fn ut_memory_write_unknown_key() {
         let mut memory: Memory<u8> = Memory::default();
@@ -462,6 +472,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked read fails when the key is unregistered.
     #[test]
     fn ut_memory_read_unknown_key() {
         let mut memory: Memory<u8> = Memory::default();
@@ -473,6 +484,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked write fails when the addressed cell is not writable as the requested cell type.
     #[test]
     fn ut_memory_writable_wrong_type() {
         let mut memory: Memory<u8> = Memory::default();
@@ -488,6 +500,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked read fails when the addressed cell is not readable as the requested cell type.
     #[test]
     fn ut_memory_readable_wrong_type() {
         let mut memory: Memory<u8> = Memory::default();
@@ -503,6 +516,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked write fails on a read-only cell.
     #[test]
     fn ut_memory_readonly_not_writable() {
         let mut memory: Memory<u8> = Memory::default();
@@ -514,6 +528,7 @@ mod tests {
         );
     }
 
+    /// MB-R-033 — a checked read fails on a write-only cell.
     #[test]
     fn ut_memory_writeonly_not_readable() {
         let mut memory: Memory<u8> = Memory::default();
@@ -533,6 +548,7 @@ mod tests {
         assert!(!memory.slices.contains_key(&1u8));
     }
 
+    /// MB-R-031 — a write region overlapping a read cell of the same type widens it to read/write.
     #[test]
     fn ut_memory_widen_read_then_write() {
         // Read cell + overlapping Write of same type -> ReadWrite.
@@ -559,6 +575,7 @@ mod tests {
         );
     }
 
+    /// MB-R-031 — a read region overlapping a write cell of the same type widens it to read/write.
     #[test]
     fn ut_memory_widen_write_then_read() {
         // Write cell + overlapping Read of same type -> ReadWrite.
@@ -577,6 +594,7 @@ mod tests {
         );
     }
 
+    /// MB-R-031 — a same-type same-access overlap merges without changing the access direction.
     #[test]
     fn ut_memory_widen_write_then_write_noop() {
         // Write cell + overlapping Write of same type -> unchanged, still write-only.
@@ -595,6 +613,7 @@ mod tests {
         );
     }
 
+    /// MB-R-031 — a read/write region overlapping a read/write cell of the same type is a no-op merge.
     #[test]
     fn ut_memory_widen_readwrite_then_readwrite_noop() {
         let mut memory: Memory<u8> = Memory::default();
@@ -620,6 +639,7 @@ mod tests {
         );
     }
 
+    /// MB-R-032 — declaring a range overlapping a cell of incompatible cell type fails.
     #[test]
     fn ut_memory_widen_incompatible_read_cell() {
         // Read cell + overlapping incompatible access (wrong type) -> false.
@@ -632,6 +652,7 @@ mod tests {
         ));
     }
 
+    /// MB-R-032 — declaring a range overlapping a write cell of incompatible cell type fails.
     #[test]
     fn ut_memory_widen_incompatible_write_cell() {
         let mut memory: Memory<u8> = Memory::default();
@@ -643,6 +664,7 @@ mod tests {
         ));
     }
 
+    /// MB-R-032 — a multi-range declaration with a later incompatible overlap leaves the store entirely unchanged.
     #[test]
     fn ut_memory_add_ranges_partial_failure_leaves_map_untouched() {
         // Multi-range call: range1 merges cleanly, range2 hits an incompatible
@@ -678,6 +700,7 @@ mod tests {
         );
     }
 
+    /// MB-R-032 — a three-range declaration failing on the third range commits none of the earlier merges.
     #[test]
     fn ut_memory_add_ranges_partial_failure_third_range_leaves_map_untouched() {
         // Three ranges in one call: range1 and range2 each merge cleanly
@@ -719,6 +742,7 @@ mod tests {
         );
     }
 
+    /// MB-R-032 — declaring a non-read/write range overlapping a read/write cell fails as an incompatible access combination.
     #[test]
     fn ut_memory_widen_incompatible_readwrite_cell() {
         // ReadWrite cell + non-ReadWrite overlapping access -> false.
@@ -731,6 +755,7 @@ mod tests {
         assert!(!memory.add_ranges(1u8, &CellKind::Read(CellType::Coil), &[Range::new(0, 5)]));
     }
 
+    /// MB-R-034 — unchecked read/write ignore per-cell access direction but still require declared coverage.
     #[test]
     fn ut_memory_write_read_unchecked() {
         let mut memory: Memory<u8> = Memory::default();
@@ -756,6 +781,7 @@ mod tests {
         assert!(memory.read_unchecked(9u8, &Range::new(0, 5)).is_none());
     }
 
+    /// MB-R-029 — a read/write spanning multiple adjacent declared regions succeeds across them.
     #[test]
     fn ut_memory_walk_multiple_slices() {
         // Two adjacent but non-overlapping slices: a read/write spanning both

--- a/ferrowl-store/src/range.rs
+++ b/ferrowl-store/src/range.rs
@@ -256,8 +256,8 @@ mod tests {
         assert_eq!(format!("{}", Range::new(0, 0)), "[0, 0)");
     }
 
-    /// MB-R-028 — a range whose end precedes its start is rejected on deserialization.
     #[test]
+    /// MB-R-028 — a range whose end precedes its start is rejected on deserialization.
     fn ut_range_deserialize_invalid_end_lt_start() {
         let json = r#"{"start": 10, "end": 5}"#;
         let result = serde_json::from_str::<Range>(json);

--- a/ferrowl-store/src/range.rs
+++ b/ferrowl-store/src/range.rs
@@ -256,6 +256,7 @@ mod tests {
         assert_eq!(format!("{}", Range::new(0, 0)), "[0, 0)");
     }
 
+    /// MB-R-028 — a range whose end precedes its start is rejected on deserialization.
     #[test]
     fn ut_range_deserialize_invalid_end_lt_start() {
         let json = r#"{"start": 10, "end": 5}"#;

--- a/ferrowl-store/src/slice.rs
+++ b/ferrowl-store/src/slice.rs
@@ -213,8 +213,8 @@ mod tests {
         }
     }
 
-    /// MB-R-095 — extending a region with adjacent ranges merges them into one contiguous region.
     #[test]
+    /// MB-R-095 — extending a region with adjacent ranges merges them into one contiguous region.
     fn ut_slice_extend() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
         assert_eq!(slice.buffer.len(), 45);
@@ -258,8 +258,8 @@ mod tests {
         }
     }
 
-    /// MB-R-033 — a range is writable only where its cells accept writes of the requested cell type.
     #[test]
+    /// MB-R-033 — a range is writable only where its cells accept writes of the requested cell type.
     fn ut_slice_writable() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
         assert!(slice.extend(&CellKind::Write(CellType::Coil), &Range::new(168, 32)));
@@ -272,8 +272,8 @@ mod tests {
         assert!(slice.writable(&CellType::Coil, &Range::new(270, 10)));
     }
 
-    /// MB-R-033 — a checked write succeeds on writable cells and fails out of range or on the wrong type.
     #[test]
+    /// MB-R-033 — a checked write succeeds on writable cells and fails out of range or on the wrong type.
     fn ut_slice_write() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
         assert!(slice.extend(&CellKind::Write(CellType::Coil), &Range::new(168, 32)));
@@ -325,8 +325,8 @@ mod tests {
         assert!(!slice.writable(&CellType::Register, &Range::new(190, 20)));
     }
 
-    /// MB-R-033 — a range is readable only where its cells accept reads of the requested cell type.
     #[test]
+    /// MB-R-033 — a range is readable only where its cells accept reads of the requested cell type.
     fn ut_slice_readable() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
         assert!(slice.extend(&CellKind::Write(CellType::Coil), &Range::new(168, 32)));
@@ -339,8 +339,8 @@ mod tests {
         assert!(slice.readable(&CellType::Coil, &Range::new(270, 10)));
     }
 
-    /// MB-R-033 — a checked read returns readable cells and fails out of range.
     #[test]
+    /// MB-R-033 — a checked read returns readable cells and fails out of range.
     fn ut_slice_read() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
         assert!(slice.extend(&CellKind::Write(CellType::Coil), &Range::new(168, 32)));
@@ -410,8 +410,8 @@ mod tests {
         assert!(slice.read(&Range::new(500, 20)).is_none());
     }
 
-    /// MB-R-096 — a non-adjacent extend is a no-op, so regions never merge into an overlapping span.
     #[test]
+    /// MB-R-096 — a non-adjacent extend is a no-op, so regions never merge into an overlapping span.
     fn ut_slice_extend_non_adjacent() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(100, 10));
         // Range neither ends at start nor starts at end -> no-op, returns false.
@@ -420,8 +420,8 @@ mod tests {
         assert_eq!(slice.range, Range::new(100, 10));
     }
 
-    /// MB-R-034 — an unchecked write forces values into read/write/read-only cells alike, within coverage.
     #[test]
+    /// MB-R-034 — an unchecked write forces values into read/write/read-only cells alike, within coverage.
     fn ut_slice_write_unchecked() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(0, 5));
         slice.extend(&CellKind::Write(CellType::Coil), &Range::new(5, 3));
@@ -438,8 +438,8 @@ mod tests {
         assert!(!slice.write_unchecked(&Range::new(0, 5), &[1, 2, 3]));
     }
 
-    /// MB-R-034 — an unchecked read returns the stored value of write-only cells.
     #[test]
+    /// MB-R-034 — an unchecked read returns the stored value of write-only cells.
     fn ut_slice_read_unchecked() {
         let mut slice = Slice::from_range(&CellKind::Write(CellType::Register), Range::new(0, 4));
         // Write-only cells are unreadable via read() but read_unchecked returns stored values.
@@ -454,8 +454,8 @@ mod tests {
         assert!(slice.read_unchecked(&Range::new(0, 99)).is_none());
     }
 
-    /// MB-R-029 — addresses outside the declared region are neither readable nor writable.
     #[test]
+    /// MB-R-029 — addresses outside the declared region are neither readable nor writable.
     fn ut_slice_readable_out_of_range() {
         let slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(10, 5));
         assert!(!slice.readable(&CellType::Coil, &Range::new(0, 5)));

--- a/ferrowl-store/src/slice.rs
+++ b/ferrowl-store/src/slice.rs
@@ -213,6 +213,7 @@ mod tests {
         }
     }
 
+    /// MB-R-095 — extending a region with adjacent ranges merges them into one contiguous region.
     #[test]
     fn ut_slice_extend() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
@@ -257,6 +258,7 @@ mod tests {
         }
     }
 
+    /// MB-R-033 — a range is writable only where its cells accept writes of the requested cell type.
     #[test]
     fn ut_slice_writable() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
@@ -270,6 +272,7 @@ mod tests {
         assert!(slice.writable(&CellType::Coil, &Range::new(270, 10)));
     }
 
+    /// MB-R-033 — a checked write succeeds on writable cells and fails out of range or on the wrong type.
     #[test]
     fn ut_slice_write() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
@@ -322,6 +325,7 @@ mod tests {
         assert!(!slice.writable(&CellType::Register, &Range::new(190, 20)));
     }
 
+    /// MB-R-033 — a range is readable only where its cells accept reads of the requested cell type.
     #[test]
     fn ut_slice_readable() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
@@ -335,6 +339,7 @@ mod tests {
         assert!(slice.readable(&CellType::Coil, &Range::new(270, 10)));
     }
 
+    /// MB-R-033 — a checked read returns readable cells and fails out of range.
     #[test]
     fn ut_slice_read() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(123, 45));
@@ -405,6 +410,7 @@ mod tests {
         assert!(slice.read(&Range::new(500, 20)).is_none());
     }
 
+    /// MB-R-096 — a non-adjacent extend is a no-op, so regions never merge into an overlapping span.
     #[test]
     fn ut_slice_extend_non_adjacent() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(100, 10));
@@ -414,6 +420,7 @@ mod tests {
         assert_eq!(slice.range, Range::new(100, 10));
     }
 
+    /// MB-R-034 — an unchecked write forces values into read/write/read-only cells alike, within coverage.
     #[test]
     fn ut_slice_write_unchecked() {
         let mut slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(0, 5));
@@ -431,6 +438,7 @@ mod tests {
         assert!(!slice.write_unchecked(&Range::new(0, 5), &[1, 2, 3]));
     }
 
+    /// MB-R-034 — an unchecked read returns the stored value of write-only cells.
     #[test]
     fn ut_slice_read_unchecked() {
         let mut slice = Slice::from_range(&CellKind::Write(CellType::Register), Range::new(0, 4));
@@ -446,6 +454,7 @@ mod tests {
         assert!(slice.read_unchecked(&Range::new(0, 99)).is_none());
     }
 
+    /// MB-R-029 — addresses outside the declared region are neither readable nor writable.
     #[test]
     fn ut_slice_readable_out_of_range() {
         let slice = Slice::from_range(&CellKind::Read(CellType::Coil), Range::new(10, 5));

--- a/ferrowl-store/tests/memory_api.rs
+++ b/ferrowl-store/tests/memory_api.rs
@@ -8,8 +8,8 @@ fn mem() -> Memory<u8> {
     Memory::default()
 }
 
-/// MB-R-029 — reads and writes succeed on addresses fully covered by a declared region.
 #[test]
+/// MB-R-029 — reads and writes succeed on addresses fully covered by a declared region.
 fn it_declared_readwrite_region_roundtrips_values() {
     let mut m = mem();
     assert!(m.add_ranges(
@@ -25,8 +25,8 @@ fn it_declared_readwrite_region_roundtrips_values() {
     assert_eq!(got, vec![10, 20, 30, 40]);
 }
 
-/// MB-R-033 — a checked read on an unregistered key fails with `UnknownKey`.
 #[test]
+/// MB-R-033 — a checked read on an unregistered key fails with `UnknownKey`.
 fn it_read_on_unregistered_key_is_unknown_key() {
     let m = mem();
     let err = m
@@ -35,8 +35,8 @@ fn it_read_on_unregistered_key_is_unknown_key() {
     assert_eq!(err, MemoryError::UnknownKey);
 }
 
-/// MB-R-033 — a checked write whose value count differs from the range length fails with `LengthMismatch`.
 #[test]
+/// MB-R-033 — a checked write whose value count differs from the range length fails with `LengthMismatch`.
 fn it_write_with_wrong_length_is_length_mismatch() {
     let mut m = mem();
     m.add_ranges(
@@ -56,8 +56,8 @@ fn it_write_with_wrong_length_is_length_mismatch() {
     );
 }
 
-/// MB-R-033 — a checked write to a read-only region fails with `AddressNotWritable`.
 #[test]
+/// MB-R-033 — a checked write to a read-only region fails with `AddressNotWritable`.
 fn it_write_to_read_only_region_is_not_writable() {
     let mut m = mem();
     m.add_ranges(1, &CellKind::Read(CellType::Register), &[Range::new(0, 2)]);
@@ -67,8 +67,8 @@ fn it_write_to_read_only_region_is_not_writable() {
     assert_eq!(err, MemoryError::AddressNotWritable);
 }
 
-/// MB-R-033 — a checked read from a write-only region fails with `AddressNotReadable`.
 #[test]
+/// MB-R-033 — a checked read from a write-only region fails with `AddressNotReadable`.
 fn it_read_from_write_only_region_is_not_readable() {
     let mut m = mem();
     m.add_ranges(1, &CellKind::Write(CellType::Register), &[Range::new(0, 2)]);
@@ -78,8 +78,8 @@ fn it_read_from_write_only_region_is_not_readable() {
     assert_eq!(err, MemoryError::AddressNotReadable);
 }
 
-/// MB-R-031 — a write range overlapping a read region of the same type widens it to read/write.
 #[test]
+/// MB-R-031 — a write range overlapping a read region of the same type widens it to read/write.
 fn it_overlapping_read_and_write_ranges_widen_to_readwrite() {
     let mut m = mem();
     assert!(m.add_ranges(1, &CellKind::Read(CellType::Register), &[Range::new(0, 4)]));
@@ -93,8 +93,8 @@ fn it_overlapping_read_and_write_ranges_widen_to_readwrite() {
     assert_eq!(got, vec![5, 6, 7, 8]);
 }
 
-/// MB-R-032 — an incompatible cell-type overlap is rejected and leaves the store's memory unchanged.
 #[test]
+/// MB-R-032 — an incompatible cell-type overlap is rejected and leaves the store's memory unchanged.
 fn it_incompatible_cell_type_overlap_is_rejected_and_leaves_memory_unchanged() {
     let mut m = mem();
     assert!(m.add_ranges(

--- a/ferrowl-store/tests/memory_api.rs
+++ b/ferrowl-store/tests/memory_api.rs
@@ -8,6 +8,7 @@ fn mem() -> Memory<u8> {
     Memory::default()
 }
 
+/// MB-R-029 — reads and writes succeed on addresses fully covered by a declared region.
 #[test]
 fn it_declared_readwrite_region_roundtrips_values() {
     let mut m = mem();
@@ -24,6 +25,7 @@ fn it_declared_readwrite_region_roundtrips_values() {
     assert_eq!(got, vec![10, 20, 30, 40]);
 }
 
+/// MB-R-033 — a checked read on an unregistered key fails with `UnknownKey`.
 #[test]
 fn it_read_on_unregistered_key_is_unknown_key() {
     let m = mem();
@@ -33,6 +35,7 @@ fn it_read_on_unregistered_key_is_unknown_key() {
     assert_eq!(err, MemoryError::UnknownKey);
 }
 
+/// MB-R-033 — a checked write whose value count differs from the range length fails with `LengthMismatch`.
 #[test]
 fn it_write_with_wrong_length_is_length_mismatch() {
     let mut m = mem();
@@ -53,6 +56,7 @@ fn it_write_with_wrong_length_is_length_mismatch() {
     );
 }
 
+/// MB-R-033 — a checked write to a read-only region fails with `AddressNotWritable`.
 #[test]
 fn it_write_to_read_only_region_is_not_writable() {
     let mut m = mem();
@@ -63,6 +67,7 @@ fn it_write_to_read_only_region_is_not_writable() {
     assert_eq!(err, MemoryError::AddressNotWritable);
 }
 
+/// MB-R-033 — a checked read from a write-only region fails with `AddressNotReadable`.
 #[test]
 fn it_read_from_write_only_region_is_not_readable() {
     let mut m = mem();
@@ -73,6 +78,7 @@ fn it_read_from_write_only_region_is_not_readable() {
     assert_eq!(err, MemoryError::AddressNotReadable);
 }
 
+/// MB-R-031 — a write range overlapping a read region of the same type widens it to read/write.
 #[test]
 fn it_overlapping_read_and_write_ranges_widen_to_readwrite() {
     let mut m = mem();
@@ -87,6 +93,7 @@ fn it_overlapping_read_and_write_ranges_widen_to_readwrite() {
     assert_eq!(got, vec![5, 6, 7, 8]);
 }
 
+/// MB-R-032 — an incompatible cell-type overlap is rejected and leaves the store's memory unchanged.
 #[test]
 fn it_incompatible_cell_type_overlap_is_rejected_and_leaves_memory_unchanged() {
     let mut m = mem();

--- a/ferrowl-syntax/src/format/json.rs
+++ b/ferrowl-syntax/src/format/json.rs
@@ -265,12 +265,14 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-033 — the JSON formatter pretty-prints messy but valid JSON.
     fn ut_pretty_prints_messy_valid_json() {
         let out = format(r#"{"b":1,"a":[1,2]}"#).unwrap();
         assert_eq!(out, "{\n  \"b\": 1,\n  \"a\": [\n    1,\n    2\n  ]\n}");
     }
 
     #[test]
+    /// UI-R-033 — the JSON formatter is idempotent.
     fn ut_idempotent() {
         let once = format(r#"{"b":1,"a":[1,2],"c":{}}"#).unwrap();
         let twice = format(&once).unwrap();
@@ -278,6 +280,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — the JSON formatter declines (returns None) on invalid JSON, leaving the buffer unchanged.
     fn ut_invalid_json_returns_none() {
         assert!(format("{\"a\": ").is_none());
         assert!(format("{\"a\" 1}").is_none());
@@ -286,16 +289,19 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — the JSON formatter declines on partial JSON.
     fn ut_partial_json_returns_none() {
         assert!(format(r#"{"a": 1"#).is_none());
     }
 
     #[test]
+    /// UI-R-033 — the JSON formatter declines when trailing garbage follows valid JSON.
     fn ut_trailing_garbage_returns_none() {
         assert!(format(r#"{"a": 1} garbage"#).is_none());
     }
 
     #[test]
+    /// UI-R-033 — escaped quotes and unicode survive JSON reformatting verbatim.
     fn ut_escaped_quotes_and_unicode_survive_verbatim() {
         let input = "{\"a\":\"x\\\"y\\u00e9zé\"}";
         let out = format(input).unwrap();
@@ -303,18 +309,21 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — empty objects/arrays format without error.
     fn ut_empty_containers() {
         let out = format(r#"{"a": [], "b": {}}"#).unwrap();
         assert_eq!(out, "{\n  \"a\": [],\n  \"b\": {}\n}");
     }
 
     #[test]
+    /// UI-R-033 — numbers are copied verbatim through the JSON formatter.
     fn ut_numbers_copied_verbatim() {
         let out = format(r#"[1.50, -3e10]"#).unwrap();
         assert_eq!(out, "[\n  1.50,\n  -3e10\n]");
     }
 
     #[test]
+    /// UI-R-033 — formatted JSON carries no trailing newline.
     fn ut_no_trailing_newline() {
         let out = format(r#"{"a": 1}"#).unwrap();
         assert!(!out.ends_with('\n'));

--- a/ferrowl-syntax/src/format/lua.rs
+++ b/ferrowl-syntax/src/format/lua.rs
@@ -89,6 +89,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-033 — the Lua formatter reindents nested function/if/for blocks four spaces per level.
     fn ut_nested_function_if_for_blocks_reindent() {
         let src = "function foo()\nfor i=1,10 do\nif i>5 then\nprint(i)\nend\nend\nend";
         let expected = "function foo()\n    for i=1,10 do\n        if i>5 then\n            print(i)\n        end\n    end\nend";
@@ -96,6 +97,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — elseif/else are reindented to the parent block depth.
     fn ut_elseif_and_else_sit_at_parent_depth() {
         let src = "if x then\na()\nelseif y then\nb()\nelse\nc()\nend";
         let expected = "if x then\n    a()\nelseif y then\n    b()\nelse\n    c()\nend";
@@ -103,6 +105,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — the formatter leaves long-string interior lines byte-for-byte unchanged.
     fn ut_long_string_interior_lines_byte_untouched() {
         let src = "local s = [[\n    keep me exactly    \nend]]";
         let expected = "local s = [[\n    keep me exactly    \nend]]";
@@ -110,6 +113,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — an `end` inside a string does not change reindent depth.
     fn ut_end_inside_string_does_not_dedent() {
         let src = "function foo()\nlocal s = \"end\"\nend";
         let expected = "function foo()\n    local s = \"end\"\nend";
@@ -117,6 +121,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — repeat/until blocks reindent correctly.
     fn ut_repeat_until_blocks() {
         let src = "repeat\nx()\nuntil done";
         let expected = "repeat\n    x()\nuntil done";
@@ -124,6 +129,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — blank lines are normalized to empty by the formatter.
     fn ut_blank_lines_become_empty() {
         let src = "function foo()\n\nend";
         let expected = "function foo()\n\nend";
@@ -131,6 +137,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — the Lua formatter is idempotent.
     fn ut_idempotent() {
         let src = "function foo()\n  for i=1,10 do\n      print(i)\n end\nend";
         let once = format(src);
@@ -139,12 +146,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — the Lua formatter always returns output, even for un-parseable input.
     fn ut_always_returns_something_for_garbage() {
         let src = "]==] unterminated [==[";
         let _ = format(src);
     }
 
     #[test]
+    /// UI-R-033 — multi-line call parentheses do not double-indent.
     fn ut_multiline_call_parens_do_not_double_indent() {
         // Regression: `(` used to be tracked as a block opener alongside `function`,
         // doubling the indent depth for continuation lines inside a multi-line signature.

--- a/ferrowl-syntax/src/indent.rs
+++ b/ferrowl-syntax/src/indent.rs
@@ -56,6 +56,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-032 — a Lua block opener yields a positive block-balance delta so the next line indents.
     fn ut_lua_openers_indent_next_line() {
         assert_eq!(indent_delta(Language::Lua, "function foo()"), 1);
         assert_eq!(indent_delta(Language::Lua, "if x then"), 1);
@@ -65,6 +66,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — a balanced or plain line yields a zero indent delta.
     fn ut_lua_balanced_and_plain_lines_are_flat() {
         assert_eq!(indent_delta(Language::Lua, "print(x)"), 0);
         assert_eq!(indent_delta(Language::Lua, "if x then y() end"), 0);
@@ -72,6 +74,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — a leading closer affects the current line, not the next line's delta.
     fn ut_lua_leading_closer_does_not_dedent_next_line() {
         assert_eq!(indent_delta(Language::Lua, "end"), 0);
         assert_eq!(indent_delta(Language::Lua, "until done"), 0);
@@ -79,17 +82,20 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — else/elseif produce a body-indenting delta.
     fn ut_lua_else_and_elseif_indent_their_body() {
         assert_eq!(indent_delta(Language::Lua, "else"), 1);
         assert_eq!(indent_delta(Language::Lua, "elseif y then"), 1);
     }
 
     #[test]
+    /// UI-R-032 — a mid-line closer yields a negative delta so the next line dedents.
     fn ut_lua_mid_line_closer_dedents_next_line() {
         assert_eq!(indent_delta(Language::Lua, "x() end"), -1);
     }
 
     #[test]
+    /// UI-R-032 — block words inside strings do not affect the indent delta.
     fn ut_lua_keywords_in_strings_do_not_count() {
         assert_eq!(
             indent_delta(Language::Lua, "local s = \"function do then\""),
@@ -99,6 +105,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — JSON braces/brackets drive the indent delta.
     fn ut_json_braces_and_brackets() {
         assert_eq!(indent_delta(Language::Json, "{"), 1);
         assert_eq!(indent_delta(Language::Json, "\"a\": ["), 1);

--- a/ferrowl-syntax/src/lang/json.rs
+++ b/ferrowl-syntax/src/lang/json.rs
@@ -86,6 +86,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — JSON highlight spans are sorted, non-overlapping, and character-indexed.
     fn ut_spans_sorted_non_overlapping() {
         let spans = spans_for(r#"{"key": "value", "n": 1.5e-3}"#);
         for w in spans.windows(2) {
@@ -95,6 +96,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — a string in key position takes the JSON Key kind, a value string the String kind.
     fn ut_key_vs_value_string() {
         let spans = spans_for(r#"{"key": "value"}"#);
         let strings: Vec<_> = spans
@@ -107,6 +109,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — an escaped quote does not split a JSON string span.
     fn ut_escaped_quote_does_not_terminate_string() {
         let spans = spans_for(r#""a\"b""#);
         let strings: Vec<_> = spans
@@ -117,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — exponent and negative numerals are Number-kind spans.
     fn ut_numbers_exponent_and_negative() {
         let spans = spans_for(r#"[1e10, -3.5]"#);
         let nums: Vec<_> = spans.iter().filter(|s| s.2 == SyntaxKind::Number).collect();
@@ -124,6 +128,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — true/false/null map to the Literal kind.
     fn ut_literals() {
         let spans = spans_for("[true, false, null]");
         let lits: Vec<_> = spans
@@ -134,6 +139,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — malformed JSON never panics and span indices stay in range.
     fn ut_garbage_input_does_not_panic() {
         let cases = [
             "\"abc",
@@ -154,6 +160,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — a multi-byte JSON string is one character-indexed span.
     fn ut_non_ascii_string_value() {
         let line = r#"{"msg": "café"}"#;
         let spans = spans_for(line);
@@ -172,6 +179,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — emoji content keeps JSON span indices character-based and in range.
     fn ut_emoji_in_json_string() {
         let line = r#"{"emoji": "🚀 🌟"}"#;
         let spans = spans_for(line);

--- a/ferrowl-syntax/src/lang/lua.rs
+++ b/ferrowl-syntax/src/lang/lua.rs
@@ -269,6 +269,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — highlight spans are sorted by start, non-overlapping, and use character indices.
     fn ut_spans_sorted_non_overlapping() {
         let spans = spans_for("local x = 1 + foo -- comment");
         for w in spans.windows(2) {
@@ -278,6 +279,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-038 — a Lua long string is highlighted across line boundaries via carry-over state.
     fn ut_long_string_carries_across_lines() {
         let (spans1, state1) =
             top_highlight_line(Language::Lua, "local s = [==[", LineState::default());
@@ -294,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-038 — a Lua long comment is highlighted across line boundaries via carry-over state.
     fn ut_long_comment_carries_across_lines() {
         let (_spans1, state1) =
             top_highlight_line(Language::Lua, "--[[ start", LineState::default());
@@ -308,6 +311,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-038 — carry-over tracks the long-bracket level so a wrong-level closer does not end the construct.
     fn ut_long_bracket_level_mismatch_does_not_close_early() {
         let (_spans1, state1) =
             top_highlight_line(Language::Lua, "local s = [=[", LineState::default());
@@ -324,6 +328,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — an escaped quote inside a string does not split the string span.
     fn ut_escaped_quote_does_not_terminate_string() {
         let spans = spans_for(r#"local s = "a\"b""#);
         let strings: Vec<_> = spans.iter().filter(|s| s.2 == SyntaxKind::String).collect();
@@ -331,6 +336,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — hex and exponent numerals are one Number-kind span each.
     fn ut_numbers_hex_and_exponent() {
         let spans = spans_for("local a = 0x1F local b = 1e10");
         let nums: Vec<_> = spans.iter().filter(|s| s.2 == SyntaxKind::Number).collect();
@@ -338,6 +344,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — keywords and literals map to their distinct highlight kinds.
     fn ut_keywords_vs_literals() {
         let spans = spans_for("if true then return nil end");
         let kinds: Vec<_> = spans.iter().map(|s| s.2).collect();
@@ -346,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — an identifier in object/method position takes the Object/Function kind.
     fn ut_object_and_method_position() {
         // `C_Register:Set(1)` — object before the `:`, method after it.
         let spans = spans_for("C_Register:Set(1)");
@@ -358,6 +366,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — field-access chains and call sugar resolve to Object/Function kinds.
     fn ut_field_chain_and_call_positions() {
         // `a.b.c` — everything before the last access is an object; `c` stays plain.
         let spans = spans_for("a.b.c");
@@ -372,6 +381,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-039 — `..` concat and `::` labels do not produce Object/Function kinds.
     fn ut_concat_and_labels_are_not_access() {
         // `..` is concat, `::` is a label marker — neither makes an object/function.
         let spans = spans_for("a .. b ::lbl::");
@@ -383,6 +393,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — malformed input never panics and every span index stays within the line.
     fn ut_garbage_input_does_not_panic() {
         let cases = [
             "\"abc",
@@ -404,6 +415,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — spans use character indices, so a multi-byte identifier is one in-range span.
     fn ut_non_ascii_identifier() {
         let line = "local café = 1";
         let spans = spans_for(line);
@@ -417,6 +429,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — a string span over multi-byte content is delimited by character indices.
     fn ut_non_ascii_string_content() {
         let line = r#"local msg = "café 日本語""#;
         let spans = spans_for(line);
@@ -434,6 +447,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-037 — emoji (multi-byte) content keeps span indices character-based and in range.
     fn ut_emoji_in_string_and_unrecognized() {
         let line = r#"s = "hello 🚀""#;
         let spans = spans_for(line);

--- a/ferrowl-syntax/tests/format_and_indent.rs
+++ b/ferrowl-syntax/tests/format_and_indent.rs
@@ -5,6 +5,7 @@
 use ferrowl_syntax::{Language, format, indent_delta};
 
 #[test]
+/// UI-R-033 — format declines on invalid JSON so the buffer is left unchanged.
 fn it_format_returns_none_for_invalid_json() {
     assert_eq!(
         format(Language::Json, "{ not valid json "),
@@ -14,6 +15,7 @@ fn it_format_returns_none_for_invalid_json() {
 }
 
 #[test]
+/// UI-R-033 — format reformats valid JSON and is idempotent.
 fn it_format_reformats_valid_json_and_is_idempotent() {
     let once =
         format(Language::Json, "{\"b\":2,\"a\":[1,2]}").expect("valid JSON reformats to Some");
@@ -23,18 +25,21 @@ fn it_format_reformats_valid_json_and_is_idempotent() {
 }
 
 #[test]
+/// UI-R-033 — the Lua formatter always returns a formatted buffer.
 fn it_format_lua_always_returns_some() {
     // Lua re-indenting never rejects: the caller always gets a buffer back.
     assert!(format(Language::Lua, "local x=1\nif x then\nprint(x)\nend").is_some());
 }
 
 #[test]
+/// UI-R-032 — a Lua opener's indent delta deepens the next line.
 fn it_indent_delta_lua_opener_deepens_next_line() {
     assert_eq!(indent_delta(Language::Lua, "function foo()"), 1);
     assert_eq!(indent_delta(Language::Lua, "if cond then"), 1);
 }
 
 #[test]
+/// UI-R-032 — a leading closer does not shift the next line's indent.
 fn it_indent_delta_leading_closer_does_not_shift_next_line() {
     // A leading closer dedents its own line, not the following one, so its net delta is zero.
     assert_eq!(indent_delta(Language::Lua, "end"), 0);
@@ -42,12 +47,14 @@ fn it_indent_delta_leading_closer_does_not_shift_next_line() {
 }
 
 #[test]
+/// UI-R-032 — a JSON open bracket's indent delta deepens the next line.
 fn it_indent_delta_json_open_bracket_deepens() {
     assert_eq!(indent_delta(Language::Json, "{"), 1);
     assert_eq!(indent_delta(Language::Json, "["), 1);
 }
 
 #[test]
+/// UI-R-032 — indent delta ignores block words appearing inside strings.
 fn it_indent_delta_ignores_block_words_inside_strings() {
     // The lexers classify `if`/`then`/`end` inside a string literal as string text, so they
     // must not count as block openers/closers.

--- a/ferrowl-ui-derive/tests/focus.rs
+++ b/ferrowl-ui-derive/tests/focus.rs
@@ -55,6 +55,7 @@ fn make_app() -> TestApp {
 }
 
 #[test]
+/// UI-R-049 — focus_next advances focus to the next focusable field.
 fn ut_focus_next_advances() {
     let mut app = make_app();
     // starts at First, moves to Second
@@ -63,6 +64,7 @@ fn ut_focus_next_advances() {
 }
 
 #[test]
+/// UI-R-049 — focus_next wraps from the last field back to the first.
 fn ut_focus_next_wraps_around() {
     let mut app = make_app();
     app.focus_next(); // → Second
@@ -72,6 +74,7 @@ fn ut_focus_next_wraps_around() {
 }
 
 #[test]
+/// UI-R-049 — focus_previous wraps from the first field to the last.
 fn ut_focus_previous_wraps_backward() {
     let mut app = make_app();
     // at First, previous wraps to Third
@@ -80,6 +83,7 @@ fn ut_focus_previous_wraps_backward() {
 }
 
 #[test]
+/// UI-R-049 — focus_previous reverses a focus_next step.
 fn ut_focus_previous_reverses_next() {
     let mut app = make_app();
     app.focus_next(); // → Second
@@ -88,6 +92,7 @@ fn ut_focus_previous_reverses_next() {
 }
 
 #[test]
+/// UI-R-049 — exactly one field is focused after a focus step; the prior one is cleared.
 fn ut_exactly_one_widget_focused_after_switch() {
     let mut app = make_app();
     app.focus_next(); // → Second
@@ -104,6 +109,7 @@ fn ut_exactly_one_widget_focused_after_switch() {
 }
 
 #[test]
+/// UI-R-049 — a focusable container routes key events to its currently-focused field.
 fn ut_handle_events_routes_to_focused_widget() {
     use crossterm::event::{KeyCode, KeyModifiers};
     use ferrowl_ui::traits::HandleEvents;
@@ -148,6 +154,7 @@ fn make_gated(second_enabled: bool, start: GatedAppFocus) -> GatedApp {
 }
 
 #[test]
+/// UI-R-049 — the focus cycle skips a field whose enabling condition is false.
 fn ut_focus_next_skips_disabled_gated_widget() {
     let mut app = make_gated(false, GatedAppFocus::First);
     app.focus_next(); // First → (Second disabled, skipped) → Third
@@ -156,6 +163,7 @@ fn ut_focus_next_skips_disabled_gated_widget() {
 }
 
 #[test]
+/// UI-R-049 — the focus cycle lands on a gated field when its condition is true.
 fn ut_focus_next_lands_on_enabled_gated_widget() {
     let mut app = make_gated(true, GatedAppFocus::First);
     app.focus_next(); // First → Second (enabled)
@@ -164,6 +172,7 @@ fn ut_focus_next_lands_on_enabled_gated_widget() {
 }
 
 #[test]
+/// UI-R-049 — reverse focus cycle also skips a disabled gated field.
 fn ut_focus_previous_skips_disabled_gated_widget() {
     let mut app = make_gated(false, GatedAppFocus::Third);
     app.focus_previous(); // Third → (Second disabled, skipped) → First
@@ -174,6 +183,7 @@ fn ut_focus_previous_skips_disabled_gated_widget() {
 // --- whole-view SetFocus / IsFocus -----------------------------------------
 
 #[test]
+/// UI-R-049 — focusing the container focuses its first eligible field and reports focused.
 fn ut_set_focused_true_focuses_first_and_reports_focused() {
     let mut app = make_app(); // view unfocused, nothing focused
     assert!(!app.is_focused());
@@ -185,6 +195,7 @@ fn ut_set_focused_true_focuses_first_and_reports_focused() {
 }
 
 #[test]
+/// UI-R-049 — unfocusing the container clears every field's focus.
 fn ut_set_focused_false_clears_all_widgets() {
     let mut app = make_app();
     app.set_focused(true);
@@ -199,6 +210,7 @@ fn ut_set_focused_false_clears_all_widgets() {
 }
 
 #[test]
+/// UI-R-049 — re-focusing the container restores the previously-focused field.
 fn ut_set_focused_restores_prior_pane() {
     let mut app = make_app();
     app.set_focused(true);
@@ -210,6 +222,7 @@ fn ut_set_focused_restores_prior_pane() {
 }
 
 #[test]
+/// UI-R-049 — if the remembered field is now ineligible, focus falls back to the first eligible field.
 fn ut_set_focused_falls_back_to_first_eligible_when_remembered_ineligible() {
     // Remembered pane is the gated Second, but it is disabled → enable lands on the first
     // eligible pane in declaration order (First).
@@ -220,6 +233,7 @@ fn ut_set_focused_falls_back_to_first_eligible_when_remembered_ineligible() {
 }
 
 #[test]
+/// UI-R-049 — a remembered gated field that is still eligible is kept on re-focus.
 fn ut_set_focused_keeps_remembered_eligible_gated_pane() {
     // Remembered Second is eligible (enabled) → kept on enable.
     let mut app = make_gated(true, GatedAppFocus::Second);

--- a/ferrowl-ui-derive/tests/overlay.rs
+++ b/ferrowl-ui-derive/tests/overlay.rs
@@ -54,6 +54,7 @@ fn route(o: &mut Overlay, code: KeyCode) -> OverlayRoute {
 // --- Structural ------------------------------------------------------------
 
 #[test]
+/// UI-R-021 — an overlay reports active for any variant other than None.
 fn ut_is_active() {
     assert!(!Overlay::None.is_active());
     assert!(Overlay::Edit(Editor { step: 0 }).is_active());
@@ -61,6 +62,7 @@ fn ut_is_active() {
 }
 
 #[test]
+/// UI-R-021 — taking an overlay yields its payload and resets the slot to None.
 fn ut_take_leaves_none() {
     let mut o = Overlay::Edit(Editor { step: 3 });
     let taken = o.take();
@@ -69,6 +71,7 @@ fn ut_take_leaves_none() {
 }
 
 #[test]
+/// UI-R-021 — closing an overlay resets it to None.
 fn ut_close_resets_to_none() {
     let mut o = Overlay::SetupV(Setup { step: 1 });
     o.close();
@@ -78,6 +81,7 @@ fn ut_close_resets_to_none() {
 // --- esc_close -------------------------------------------------------------
 
 #[test]
+/// UI-R-022 — Esc requests close on an overlay variant that opted into esc_close.
 fn ut_esc_closes_esc_close_variant() {
     let mut o = Overlay::Edit(Editor { step: 0 });
     assert_eq!(route(&mut o, KeyCode::Esc), OverlayRoute::Closed);
@@ -89,6 +93,7 @@ fn ut_esc_closes_esc_close_variant() {
 }
 
 #[test]
+/// UI-R-022 — Esc is unhandled (propagates) on a variant that did not opt into esc_close.
 fn ut_esc_unhandled_without_esc_close() {
     // SetupV is focus_cycle only; Plain is untagged. Neither closes on Esc.
     let mut o = Overlay::SetupV(Setup { step: 0 });
@@ -103,6 +108,7 @@ fn ut_esc_unhandled_without_esc_close() {
 // --- focus_cycle -----------------------------------------------------------
 
 #[test]
+/// UI-R-022 — Tab advances the overlay's field focus.
 fn ut_tab_cycles_focus_forward() {
     let mut o = Overlay::Edit(Editor { step: 0 });
     assert_eq!(route(&mut o, KeyCode::Tab), OverlayRoute::Cycled);
@@ -110,6 +116,7 @@ fn ut_tab_cycles_focus_forward() {
 }
 
 #[test]
+/// UI-R-022 — Shift+Tab/BackTab retreats the overlay's field focus.
 fn ut_backtab_cycles_focus_backward() {
     let mut o = Overlay::SetupV(Setup { step: 0 });
     assert_eq!(o.route_keys(NONE, KeyCode::BackTab), OverlayRoute::Cycled);
@@ -123,6 +130,7 @@ fn ut_backtab_cycles_focus_backward() {
 }
 
 #[test]
+/// UI-R-022 — Tab is unhandled on a variant without a focus cycle.
 fn ut_tab_unhandled_without_focus_cycle() {
     let mut o = Overlay::Conf(Confirm);
     assert_eq!(route(&mut o, KeyCode::Tab), OverlayRoute::Unhandled);
@@ -131,6 +139,7 @@ fn ut_tab_unhandled_without_focus_cycle() {
 // --- fall-through ----------------------------------------------------------
 
 #[test]
+/// UI-R-022 — keys other than the dialog defaults fall through as unhandled.
 fn ut_other_keys_unhandled() {
     let mut o = Overlay::Edit(Editor { step: 0 });
     assert_eq!(route(&mut o, KeyCode::Enter), OverlayRoute::Unhandled);
@@ -140,6 +149,7 @@ fn ut_other_keys_unhandled() {
 }
 
 #[test]
+/// UI-R-021 — an inactive (None) overlay consumes no keys.
 fn ut_none_is_unhandled() {
     let mut o = Overlay::None;
     assert_eq!(route(&mut o, KeyCode::Esc), OverlayRoute::Unhandled);

--- a/ferrowl-ui/src/state/button.rs
+++ b/ferrowl-ui/src/state/button.rs
@@ -69,6 +69,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-047 — a button consumes no keys, returning Unhandled so the key propagates.
     fn ut_button_state_never_consumes_keys() {
         let mut s = ButtonState::default();
         let r = s.handle_events(KeyModifiers::NONE, KeyCode::Enter);

--- a/ferrowl-ui/src/state/code_input_field.rs
+++ b/ferrowl-ui/src/state/code_input_field.rs
@@ -926,6 +926,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — plain editor: printable keys insert and Backspace deletes.
     fn type_and_delete() {
         let mut s = state();
         type_char(&mut s, 'a');
@@ -948,6 +949,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Backspace deletes the character before the cursor mid-line.
     fn backspace_mid_line() {
         let mut s = state();
         type_char(&mut s, 'a');
@@ -960,6 +962,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Backspace at column zero merges the line into the previous one.
     fn backspace_merges_lines() {
         let mut s = state();
         type_char(&mut s, 'a');
@@ -975,6 +978,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Delete removes the character under the cursor.
     fn delete_forward() {
         let mut s = state();
         type_char(&mut s, 'a');
@@ -992,6 +996,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Delete at end of line merges the next line up.
     fn delete_merges_next_line() {
         let mut s = state();
         type_char(&mut s, 'a');
@@ -1019,6 +1024,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Up/Down navigate lines and clamp the column to a shorter line.
     fn up_down_navigate_and_clamp_to_shorter_line() {
         let mut s = state();
         s.set_content("longline\nx");
@@ -1033,6 +1039,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Up on the first line and Down on the last are no-ops.
     fn up_at_first_line_and_down_at_last_are_noops() {
         let mut s = state();
         s.set_content("a\nb");
@@ -1045,6 +1052,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Left at column zero wraps to the end of the previous line.
     fn left_wraps_to_previous_line_end() {
         let mut s = state();
         s.set_content("ab\ncd");
@@ -1057,6 +1065,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Right at end of line wraps to the start of the next line.
     fn right_wraps_to_next_line_start() {
         let mut s = state();
         s.set_content("ab\ncd");
@@ -1068,6 +1077,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — Enter splits the line at the cursor.
     fn enter_splits_line_at_cursor() {
         let mut s = state();
         s.set_content("abcd");
@@ -1080,6 +1090,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-035 — editor cursor/edit positions are character-based across multi-byte text.
     fn multibyte_chars_count_by_character() {
         let mut s = state();
         type_char(&mut s, 'é');
@@ -1098,6 +1109,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-036 — a disabled editor ignores mutating keys.
     fn disabled_state_ignores_keys() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1110,6 +1122,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — in the plain editor two spaces at the same position within the bound expand to a four-space indent.
     fn double_space_expands_to_four_within_threshold() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1123,6 +1136,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — an intervening key cancels the pending double-space expansion.
     fn intervening_key_between_spaces_cancels_expansion() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1138,6 +1152,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — with space-indent off, two spaces insert plain spaces.
     fn space_indent_disabled_inserts_plain_spaces() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1151,6 +1166,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — the double-space expansion also works mid-line.
     fn double_space_expansion_mid_line() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1166,6 +1182,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — four rapid spaces expand to two four-space indents.
     fn four_rapid_space_presses_yield_eight_spaces() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1181,6 +1198,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — losing focus reformats the buffer through the language formatter.
     fn blur_formats_messy_json() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1196,6 +1214,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — when the formatter declines (invalid JSON), the buffer is left unchanged on blur.
     fn blur_leaves_invalid_json_unchanged() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1208,6 +1227,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — a disabled field never reformats on blur.
     fn disabled_field_never_formats_on_blur() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1221,6 +1241,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — gaining focus never reformats the buffer.
     fn gaining_focus_never_formats() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1234,6 +1255,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — Enter after a Lua opener auto-indents the new line by the block-balance delta.
     fn enter_auto_indents_after_lua_opener() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1247,6 +1269,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — Enter on a plain line inherits its leading indentation.
     fn enter_inherits_indent_on_plain_line() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1260,6 +1283,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — Enter after a closing line does not add indentation.
     fn enter_does_not_indent_after_closing_line() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1273,6 +1297,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — Enter auto-indents JSON and carries the closing tail to a dedented line.
     fn enter_auto_indents_json_and_carries_tail() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1288,6 +1313,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — without a language set, Enter adds no automatic indent.
     fn enter_without_language_does_not_indent() {
         let mut s = state();
         s.set_content("    x {");
@@ -1297,6 +1323,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-033 — losing focus reindents Lua through the formatter.
     fn blur_reindents_lua() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)
@@ -1319,6 +1346,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — the vim-modal editor starts in Normal mode.
     fn vim_defaults_to_normal_mode() {
         let s = vim_state();
         assert_eq!(s.vim_mode(), VimMode::Normal);
@@ -1326,6 +1354,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-029 — h/l do not wrap across lines and clamp to the last character in Normal mode.
     fn h_l_do_not_wrap_and_clamp_to_last_char() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1340,6 +1369,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-029 — j/k keep the block cursor clamped to a shorter line's last column.
     fn j_k_clamp_to_shorter_line() {
         let mut s = vim_state();
         s.set_content("longline\nx");
@@ -1352,6 +1382,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — 0 and $ motions move to the first/last column.
     fn zero_and_dollar_motions() {
         let mut s = vim_state();
         s.set_content("hello");
@@ -1362,6 +1393,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — w/b/e word motions handle punctuation runs and line crossing.
     fn w_b_e_handle_punctuation_and_line_crossing() {
         let mut s = vim_state();
         s.set_content("foo.bar\nbaz");
@@ -1382,6 +1414,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — gg jumps to the first line and G to the last.
     fn gg_and_g_capital_motions() {
         let mut s = vim_state();
         s.set_content("a\nb\nc");
@@ -1397,6 +1430,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a pending g/d operator is canceled by an unrelated key.
     fn pending_g_and_d_canceled_by_other_key() {
         let mut s = vim_state();
         s.set_content("a\nb\nc");
@@ -1410,6 +1444,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — x deletes the character under the cursor into the register.
     fn x_deletes_char_under_cursor() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1419,6 +1454,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — dd deletes the line into the register; deleting the last line leaves it empty.
     fn dd_deletes_line_last_line_becomes_empty() {
         let mut s = vim_state();
         s.set_content("a\nb");
@@ -1435,6 +1471,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — yy yanks linewise and p/P paste the line below/above.
     fn yy_and_p_linewise_paste_below_and_above() {
         let mut s = vim_state();
         s.set_content("a\nb");
@@ -1457,6 +1494,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — a charwise yank pastes after the cursor.
     fn charwise_yank_and_paste_after_cursor() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1470,6 +1508,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — a charwise visual yank spans lines into the register.
     fn visual_charwise_yank_across_lines() {
         let mut s = vim_state();
         s.set_content("abc\ndef");
@@ -1490,6 +1529,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — V enters linewise visual and y yanks the selected lines.
     fn visual_linewise_v_and_y() {
         let mut s = vim_state();
         s.set_content("a\nb\nc");
@@ -1505,6 +1545,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — a visual delete removes the selection into the register, joining lines.
     fn visual_delete_joins_lines() {
         let mut s = vim_state();
         s.set_content("abc\ndef");
@@ -1519,6 +1560,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-031 — u provides single-level undo, swapping the buffer with its pre-edit snapshot.
     fn undo_toggles_one_edit_and_one_insert_session() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1540,6 +1582,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — i/a/I/A/o/O enter Insert mode at their documented cursor positions.
     fn insert_entry_positions() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1564,6 +1607,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — o opens a line below with Lua auto-indent.
     fn o_opens_line_below_with_lua_auto_indent() {
         let mut s = CodeInputFieldStateBuilder::default()
             .language(Some(ferrowl_syntax::Language::Lua))
@@ -1577,6 +1621,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-032 — O opens a line above at the same indent.
     fn shift_o_opens_line_above_same_indent() {
         let mut s = vim_state();
         s.set_content("  abc");
@@ -1587,6 +1632,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — Esc from Insert returns to Normal and moves the cursor left onto a character.
     fn esc_from_insert_moves_cursor_left() {
         let mut s = vim_state();
         s.set_content("abc");
@@ -1597,6 +1643,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — Esc in Normal mode is left unhandled so it reaches the dialog.
     fn esc_in_normal_is_unhandled() {
         let mut s = vim_state();
         let r = s.handle_events(KeyModifiers::NONE, KeyCode::Esc);
@@ -1604,6 +1651,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — Tab in Insert mode inserts four spaces.
     fn tab_inserts_four_spaces_in_insert_mode() {
         let mut s = vim_state();
         s.set_content("ab");
@@ -1615,6 +1663,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — Shift+Tab removes up to four leading spaces.
     fn backtab_dedents_partial_indent() {
         let mut s = vim_state();
         s.set_content("  abc");
@@ -1626,6 +1675,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — Shift+BackTab dedents in Insert mode.
     fn backtab_with_shift_modifier_dedents_in_insert_mode() {
         // Crossterm actually delivers BackTab with the SHIFT modifier set
         // (see ferrowl/src/app/overlay.rs and ferrowl/src/dialog/scripts.rs),
@@ -1641,6 +1691,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-034 — Tab/Shift+Tab are unhandled in Normal mode (Insert-only indent keys).
     fn tab_and_backtab_unhandled_in_normal_mode() {
         let mut s = vim_state();
         let r = s.handle_events(KeyModifiers::NONE, KeyCode::Tab);
@@ -1652,6 +1703,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-036 — a disabled editor permits motion and visual yank but ignores edits.
     fn disabled_field_allows_motion_and_visual_yank_but_not_edits() {
         let mut s = CodeInputFieldStateBuilder::default()
             .disabled(true)
@@ -1679,6 +1731,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a plain character in Normal mode is consumed as a command, not inserted.
     fn plain_char_in_normal_mode_is_consumed_not_inserted() {
         let mut s = vim_state();
         let r = key(&mut s, 'z');
@@ -1687,6 +1740,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — the editor reports a label for each vim mode.
     fn mode_label_values() {
         let mut s = vim_state();
         assert_eq!(s.mode_label(), Some("NORMAL"));
@@ -1710,6 +1764,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a visual selection range normalizes when the anchor is after the cursor.
     fn selection_range_normalizes_when_anchor_after_cursor() {
         let mut s = vim_state();
         s.set_content("abcdef");
@@ -1720,6 +1775,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-027 — in the plain single-mode profile, printable keys insert immediately.
     fn vim_false_legacy_chars_insert_immediately() {
         let mut s = CodeInputFieldStateBuilder::default()
             .vim(false)

--- a/ferrowl-ui/src/state/input_field.rs
+++ b/ferrowl-ui/src/state/input_field.rs
@@ -183,6 +183,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — printable keys insert at the cursor and advance it.
     fn typing_appends_and_advances_cursor() {
         let mut s = field();
         type_str(&mut s, "abc");
@@ -191,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — insertion happens at the cursor, mid-string.
     fn insert_at_cursor_mid_string() {
         let mut s = field();
         type_str(&mut s, "ac");
@@ -201,6 +203,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Backspace at the start of the input is a no-op.
     fn backspace_at_start_is_noop() {
         let mut s = field();
         type_str(&mut s, "ab");
@@ -211,6 +214,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Delete removes the character under the cursor.
     fn delete_removes_char_under_cursor() {
         let mut s = field();
         type_str(&mut s, "abc");
@@ -221,6 +225,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Home/End move the cursor to the input bounds.
     fn home_and_end_move_cursor_to_bounds() {
         let mut s = field();
         type_str(&mut s, "hello");
@@ -231,6 +236,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Left/Right move the cursor and clamp at the bounds.
     fn left_right_clamp_at_bounds() {
         let mut s = field();
         type_str(&mut s, "ab");
@@ -243,6 +249,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — editing is character-based: Backspace removes one multi-byte character.
     fn multibyte_backspace_removes_one_character() {
         let mut s = field();
         type_str(&mut s, "aé语");
@@ -253,6 +260,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Ctrl+F autofills from the placeholder when the field is empty.
     fn ctrl_f_fills_empty_field_from_autofill() {
         let mut s = InputFieldStateBuilder::default()
             .autofill(Some("default".to_string()))
@@ -264,6 +272,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Ctrl+F does not overwrite a non-empty field.
     fn ctrl_f_does_not_overwrite_non_empty_field() {
         let mut s = InputFieldStateBuilder::default()
             .autofill(Some("default".to_string()))
@@ -275,6 +284,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — Ctrl+D clears the input.
     fn ctrl_d_clears_the_input() {
         let mut s = field();
         type_str(&mut s, "abc");
@@ -284,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — a disabled input ignores typing.
     fn disabled_field_ignores_typing() {
         let mut s = InputFieldStateBuilder::default()
             .disabled(true)
@@ -294,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — a per-field filter rejects disallowed characters.
     fn allowed_for_filters_disallowed_chars() {
         let mut s = InputFieldStateBuilder::default()
             .allowed_for::<u32>()
@@ -305,6 +317,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — a focused input consumes a filtered-out printable key so it never leaks to app shortcuts.
     fn rejected_char_still_returns_consumed() {
         let mut s = InputFieldStateBuilder::default()
             .allowed_for::<u32>()
@@ -316,6 +329,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the per-field filter does not gate Ctrl+F autofill.
     fn allowed_filter_does_not_affect_autofill() {
         let mut s = InputFieldStateBuilder::default()
             .allowed_for::<u32>()
@@ -327,6 +341,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the per-field filter does not gate Ctrl+D, Backspace/Delete, or navigation.
     fn allowed_filter_does_not_affect_ctrl_d_backspace_delete_navigation() {
         let mut s = InputFieldStateBuilder::default()
             .allowed_for::<u32>()
@@ -359,6 +374,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — a Shift-modified printable still passes through the per-field filter.
     fn shift_modified_char_respects_allowed_filter() {
         let mut s = InputFieldStateBuilder::default()
             .allowed_for::<u32>()

--- a/ferrowl-ui/src/state/selection.rs
+++ b/ferrowl-ui/src/state/selection.rs
@@ -152,6 +152,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — j/Down moves the selection down; a selection list wraps at the end.
     fn move_down_advances_then_wraps() {
         let mut s = sel(3);
         assert_eq!(s.selection(), 0);
@@ -164,6 +165,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — k/Up moves the selection up; a selection list wraps to the bottom.
     fn move_up_wraps_to_bottom() {
         let mut s = sel(3);
         s.move_up(); // from 0 wraps to last
@@ -173,6 +175,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — selection navigation is a safe no-op on an empty list.
     fn empty_values_navigation_is_noop_without_panic() {
         let mut s = sel(0);
         s.move_down();
@@ -182,6 +185,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — h/l move the horizontal item; leftward clamps at zero.
     fn move_left_does_not_underflow_at_zero() {
         let mut s = sel(3);
         s.move_left();
@@ -193,6 +197,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — j/k/arrow keys dispatch selection navigation; an unrelated key is left unhandled.
     fn handle_events_dispatches_navigation() {
         let mut s = sel(3);
         s.handle_events(KeyModifiers::NONE, KeyCode::Char('j'));

--- a/ferrowl-ui/src/state/suggest_input.rs
+++ b/ferrowl-ui/src/state/suggest_input.rs
@@ -271,6 +271,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — typing opens the completion popup when the provider returns matches.
     fn typing_opens_popup_on_match() {
         let mut s = state();
         type_str(&mut s, "a");
@@ -279,6 +280,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — the popup stays closed when the provider returns no matches.
     fn typing_keeps_popup_closed_without_match() {
         let mut s = state();
         type_str(&mut s, "z");
@@ -286,6 +288,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — while open, Up/Down move the highlighted suggestion.
     fn up_down_wrap_around() {
         let mut s = state();
         type_str(&mut s, "a");
@@ -297,6 +300,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — Enter accepts the highlighted (non-partial) suggestion and closes the popup.
     fn enter_accepts_selected_and_moves_cursor_to_end() {
         let mut s = state();
         type_str(&mut s, "a");
@@ -309,6 +313,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — accepting a partial suggestion re-queries and keeps the popup open.
     fn accepting_partial_suggestion_requeries_and_stays_open() {
         let mut s = state();
         type_str(&mut s, "d");
@@ -320,6 +325,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — Esc dismisses the open popup without changing the text.
     fn esc_closes_popup_only_and_is_consumed_while_open() {
         let mut s = state();
         type_str(&mut s, "a");
@@ -330,6 +336,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — while closed, the popup's keys pass through as Unhandled.
     fn navigation_keys_unhandled_while_closed() {
         let mut s = state();
         for code in [
@@ -345,6 +352,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — losing focus closes the completion popup.
     fn set_focused_false_closes_popup() {
         let mut s = state();
         type_str(&mut s, "a");

--- a/ferrowl-ui/src/state/table.rs
+++ b/ferrowl-ui/src/state/table.rs
@@ -273,11 +273,13 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — a table starts with its first row selected.
     fn starts_with_first_row_selected() {
         assert_eq!(selected(&table(3)), Some(0));
     }
 
     #[test]
+    /// UI-R-013 — j/Down moves the row selection down and clamps at the last row (no wrap).
     fn move_down_advances_and_clamps_at_bottom() {
         let mut s = table(3);
         s.move_down();
@@ -289,6 +291,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — k/Up moves the row selection up and clamps at the first row.
     fn move_up_retreats_and_clamps_at_top() {
         let mut s = table(3);
         s.move_to_bottom();
@@ -302,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — g jumps to the first row and G to the last.
     fn move_to_top_and_bottom_jump() {
         let mut s = table(5);
         s.move_to_bottom();
@@ -311,6 +315,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — table navigation is a safe no-op on an empty table.
     fn empty_table_navigation_selects_none_without_panic() {
         let mut s = table(0);
         s.move_down();
@@ -324,6 +329,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — navigation on a single-row table stays put.
     fn single_row_navigation_stays_put() {
         let mut s = table(1);
         s.move_down();
@@ -333,6 +339,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — column/horizontal movement clamps at the left edge.
     fn horizontal_scroll_does_not_underflow_at_left_edge() {
         let mut s = table(3);
         s.move_left();
@@ -343,6 +350,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — vim keys dispatch table row/column navigation.
     fn handle_events_dispatches_vim_keys() {
         let mut s = table(4);
         s.handle_events(KeyModifiers::NONE, KeyCode::Char('j'));
@@ -356,6 +364,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — replacing the rows selects the first row when nothing was selected.
     fn set_values_selects_first_row_when_previously_unselected() {
         let mut s = table(0);
         s.move_down(); // empty -> selection becomes None
@@ -365,6 +374,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — the selection clamps into range when the row list shrinks.
     fn set_values_clamps_selection_when_list_shrinks() {
         let mut s = table(5);
         s.move_to_bottom();
@@ -378,6 +388,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — emptying the rows clears the selection.
     fn set_values_clears_selection_when_emptied() {
         let mut s = table(3);
         s.set_values(Vec::new());
@@ -385,6 +396,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — replacing the rows keeps an existing in-range selection.
     fn set_values_keeps_existing_in_range_selection() {
         let mut s = table(5);
         s.move_down();
@@ -401,6 +413,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — a row can be selected directly by index.
     fn select_index_sets_selection_directly() {
         let mut s = table(4);
         s.select_index(3);
@@ -408,6 +421,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-047 — an unhandled table key returns Unhandled so it propagates to the enclosing layer.
     fn handle_events_returns_unhandled_for_unknown_key() {
         let mut s = table(2);
         let r = s.handle_events(KeyModifiers::NONE, KeyCode::Char('z'));

--- a/ferrowl-ui/src/state/vim.rs
+++ b/ferrowl-ui/src/state/vim.rs
@@ -194,11 +194,13 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-030 — the OSC 52 clipboard side-effect is best-effort and never panics.
     fn emit_osc52_does_not_panic() {
         emit_osc52("hello");
     }
 
     #[test]
+    /// UI-R-028 — the `w` motion treats a punctuation run as its own word.
     fn word_forward_skips_punct_run_as_own_word() {
         let lines = vec!["foo.bar baz".to_string()];
         assert_eq!(word_forward(&lines, 0, 0), (0, 3));
@@ -207,12 +209,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — the `w` motion crosses line boundaries like vim.
     fn word_forward_crosses_lines() {
         let lines = vec!["foo".to_string(), "bar".to_string()];
         assert_eq!(word_forward(&lines, 0, 0), (1, 0));
     }
 
     #[test]
+    /// UI-R-028 — the `b` motion moves to the start of the previous word.
     fn word_backward_basic() {
         let lines = vec!["foo bar baz".to_string()];
         assert_eq!(word_backward(&lines, 0, 8), (0, 4));
@@ -220,6 +224,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — the `e` motion moves to the end of the current/next word.
     fn word_end_forward_basic() {
         let lines = vec!["foo bar".to_string()];
         assert_eq!(word_end_forward(&lines, 0, 0), (0, 2));

--- a/ferrowl-ui/src/widgets/code_input_field.rs
+++ b/ferrowl-ui/src/widgets/code_input_field.rs
@@ -298,6 +298,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a focused vim editor shows its current mode tag in the title.
     fn focused_vim_field_appends_mode_tag_to_title() {
         let w = CodeInputFieldBuilder::default()
             .border(full_border())
@@ -311,6 +312,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — an unfocused editor shows no mode tag.
     fn unfocused_field_has_no_mode_tag() {
         let w = CodeInputFieldBuilder::default()
             .border(full_border())
@@ -329,6 +331,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — the mode tag tracks Insert and Visual mode transitions.
     fn mode_tag_tracks_insert_and_visual_after_events() {
         // No configured title -> bare "[LABEL]" title.
         let w = CodeInputFieldBuilder::default()
@@ -350,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a charwise visual selection is highlighted across two lines, with the cursor cell winning.
     fn selection_highlights_charwise_span_two_lines() {
         let w = CodeInputFieldBuilder::default().build().unwrap();
         let mut st = CodeInputFieldStateBuilder::default().build().unwrap();
@@ -383,6 +387,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-028 — a visual selection highlight is clipped to the horizontal-scroll window.
     fn selection_clips_to_h_scroll_window() {
         let w = CodeInputFieldBuilder::default().build().unwrap();
         let mut st = CodeInputFieldStateBuilder::default().build().unwrap();

--- a/ferrowl-ui/src/widgets/input_field.rs
+++ b/ferrowl-ui/src/widgets/input_field.rs
@@ -314,6 +314,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-048 — the u32 field filter accepts digits and rejects other characters.
     fn u32_allowed_char_accepts_digits_rejects_others() {
         assert!(u32::allowed_char('0'));
         assert!(u32::allowed_char('9'));
@@ -322,6 +323,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the i32 field filter accepts a leading minus.
     fn i32_allowed_char_accepts_minus() {
         assert!(i32::allowed_char('-'));
         assert!(i32::allowed_char('5'));
@@ -329,6 +331,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the f64 field filter accepts float characters.
     fn f64_allowed_char_accepts_float_chars() {
         assert!(f64::allowed_char('.'));
         assert!(f64::allowed_char('e'));
@@ -337,6 +340,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the String field filter accepts any character.
     fn string_allowed_char_accepts_anything() {
         assert!(String::allowed_char('a'));
         assert!(String::allowed_char('!'));

--- a/ferrowl-ui/tests/render.rs
+++ b/ferrowl-ui/tests/render.rs
@@ -211,6 +211,7 @@ fn code_input_field_render_variants() {
 }
 
 #[test]
+/// UI-R-039 — rendered Lua highlighting maps keyword/comment kinds to their theme colors.
 fn code_input_field_lua_syntax_highlighting() {
     let theme = SyntaxTheme::default();
     let content = "local x = 1 -- hi";
@@ -247,6 +248,7 @@ fn code_input_field_lua_syntax_highlighting() {
 }
 
 #[test]
+/// UI-R-039 — rendered JSON highlighting maps key/string kinds to their theme colors.
 fn code_input_field_json_key_and_string_styles() {
     let theme = SyntaxTheme::default();
     let content = r#"{"key": "value"}"#;
@@ -288,6 +290,7 @@ fn code_input_field_json_key_and_string_styles() {
 }
 
 #[test]
+/// UI-R-046 — horizontal scroll clips a highlighted span to the visible content window.
 fn code_input_field_h_scroll_clips_mid_span() {
     let theme = SyntaxTheme::default();
     let content = r#"local s = "abcdefghijklmnopqrstuvwxyz""#;
@@ -332,6 +335,7 @@ fn code_input_field_h_scroll_clips_mid_span() {
 // ---- ScrollingTabs ----
 
 #[test]
+/// UI-R-046 — the tab bar scrolls horizontally to keep the selected tab visible.
 fn scrolling_tabs_render_variants() {
     let w = ScrollingTabsBuilder::<String>::default().build().unwrap();
 
@@ -432,6 +436,7 @@ fn opened_suggest_state(input: &str) -> ferrowl_ui::state::SuggestInputState<Fix
 }
 
 #[test]
+/// UI-R-026 — the completion popup renders below its anchor when there is room.
 fn suggest_input_popup_renders_below_anchor() {
     let w = SuggestInputBuilder::<String, FixedProvider>::default()
         .build()
@@ -452,6 +457,7 @@ fn suggest_input_popup_renders_below_anchor() {
 }
 
 #[test]
+/// UI-R-026 — the completion popup flips above its anchor when there is no room below.
 fn suggest_input_popup_flips_above_when_no_room_below() {
     let w = SuggestInputBuilder::<String, FixedProvider>::default()
         .build()
@@ -471,6 +477,7 @@ fn suggest_input_popup_flips_above_when_no_room_below() {
 }
 
 #[test]
+/// UI-R-026 — rendering the popup on a tiny buffer, or when closed, is a no-op not a panic.
 fn suggest_input_popup_no_panic_on_tiny_buffer() {
     let w = SuggestInputBuilder::<String, FixedProvider>::default()
         .build()
@@ -560,6 +567,7 @@ impl Header<2> for Cols {
 }
 
 #[test]
+/// UI-R-046 — a table wider than its area renders with horizontal scroll.
 fn table_render_variants() {
     let rows = vec![
         Row(

--- a/ferrowl-util/src/convert.rs
+++ b/ferrowl-util/src/convert.rs
@@ -202,6 +202,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-002 — the encoding is selected from the file-path extension.
     fn ut_filetype_from_path() {
         assert_eq!(FileType::from_path("cfg.toml"), Some(FileType::Toml));
         assert_eq!(FileType::from_path("cfg.json"), Some(FileType::Json));
@@ -213,6 +214,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — a value saves and loads through TOML to an equal value.
     fn ut_toml_save_load_round_trip() {
         let path = tmp_path("toml");
         let value = Sample {
@@ -226,6 +228,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-005 — a numeric value serializes as a plain TOML number, not a wrapper table.
     fn ut_toml_embedded_json_value_number_is_plain() {
         // A struct embedding a `serde_json::Value` with numbers must serialize to plain TOML
         // integers — not the `$serde_json::private::Number` wrapper that `arbitrary_precision`
@@ -248,6 +251,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — a value saves and loads through JSON to an equal value.
     fn ut_json_save_load_round_trip() {
         let path = tmp_path("json");
         let value = Sample {
@@ -261,6 +265,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — converting TOML to JSON preserves the data model.
     fn ut_convert_toml_to_json_preserves_data() {
         let src = tmp_path("toml");
         let dst = tmp_path("json");
@@ -277,6 +282,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — converting JSON to TOML preserves the data model.
     fn ut_convert_json_to_toml_preserves_data() {
         // Exercises the JSON-source read path and the TOML-destination write path.
         let src = tmp_path("json");
@@ -306,6 +312,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-050 — a malformed source fails to convert with a deserialize error.
     fn ut_convert_json_source_malformed_error() {
         let src = tmp_path("json");
         std::fs::write(&src, "{ not valid json ").unwrap();
@@ -381,18 +388,21 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-006 — a top-level JSON null is not representable in TOML and fails serialization.
     fn ut_json_to_toml_null_top_level_errors() {
         let r = json_to_toml(&serde_json::Value::Null);
         assert!(matches!(r, Err(Error::Serialize(_))));
     }
 
     #[test]
+    /// CS-R-006 — a JSON null inside an array is not representable in TOML and fails.
     fn ut_json_to_toml_null_in_array_errors() {
         let r = json_to_toml(&serde_json::json!([1, null, 3]));
         assert!(matches!(r, Err(Error::Serialize(_))));
     }
 
     #[test]
+    /// CS-R-006 — a JSON null at an object key is dropped (field omitted) in TOML.
     fn ut_json_to_toml_null_in_object_is_dropped() {
         let v = json_to_toml(&serde_json::json!({ "a": 1, "b": null })).unwrap();
         let table = v.as_table().unwrap();
@@ -401,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-005 — a u64 exceeding the signed-64 range serializes as a TOML float.
     fn ut_json_to_toml_u64_overflow_falls_back_to_float() {
         let big = u64::MAX;
         let v = json_to_toml(&serde_json::json!(big)).unwrap();
@@ -408,12 +419,14 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-005 — a u64 within range stays a TOML integer.
     fn ut_json_to_toml_u64_in_range_stays_integer() {
         let v = json_to_toml(&serde_json::json!(42u64)).unwrap();
         assert_eq!(v.as_integer(), Some(42));
     }
 
     #[test]
+    /// CS-R-050 — malformed file content fails to load with a deserialize error.
     fn ut_load_malformed_content_errors() {
         let path = tmp_path("json");
         std::fs::write(&path, "{ not valid json ").unwrap();

--- a/ferrowl/src/app/commands.rs
+++ b/ferrowl/src/app/commands.rs
@@ -174,6 +174,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-017 — `:script copy <tab-index>` validates its index (usage error, out-of-range, self-copy).
     fn ut_validate_copy_index() {
         assert_eq!(
             validate_copy_index(None, 3, 0),

--- a/ferrowl/src/app/keys.rs
+++ b/ferrowl/src/app/keys.rs
@@ -241,31 +241,37 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-011 — a single digit jumps immediately when no two-digit index could start with it.
     fn single_digit_jumps_immediately_when_at_most_ten_tabs() {
         assert_eq!(digit_outcome(None, 3, 5), DigitOutcome::Jump(3));
     }
 
     #[test]
+    /// UI-R-011 — a first digit waits for a second when a valid two-digit index could start with it.
     fn first_digit_waits_when_it_could_start_a_two_digit_index() {
         assert_eq!(digit_outcome(None, 1, 25), DigitOutcome::Wait(1));
     }
 
     #[test]
+    /// UI-R-011 — a valid two-digit combination jumps to that index.
     fn valid_two_digit_combo_jumps() {
         assert_eq!(digit_outcome(Some(1), 2, 25), DigitOutcome::Jump(12));
     }
 
     #[test]
+    /// UI-R-011 — an out-of-range two-digit combination falls back to the first-digit jump.
     fn invalid_combo_falls_back_to_first_digit() {
         assert_eq!(digit_outcome(Some(1), 9, 15), DigitOutcome::Jump(1));
     }
 
     #[test]
+    /// UI-R-011 — an out-of-range single digit is ignored.
     fn out_of_range_single_digit_is_ignored() {
         assert_eq!(digit_outcome(None, 7, 5), DigitOutcome::Ignore);
     }
 
     #[test]
+    /// UI-R-011 — a leading zero jumps immediately regardless of tab count.
     fn leading_zero_jumps_immediately_even_with_many_tabs() {
         assert_eq!(digit_outcome(None, 0, 25), DigitOutcome::Jump(0));
     }

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -586,9 +586,9 @@ mod tests {
     use super::*;
     use std::io::Read;
 
+    #[test]
     /// UI-R-057 — exit only when zero tabs and no modal layer remain; any tab, or any open
     /// layer with zero tabs (e.g. the startup selector before cancel), keeps the app running.
-    #[test]
     fn ut_is_empty_shell() {
         assert!(is_empty_shell(0, false));
         assert!(!is_empty_shell(0, true)); // startup selector still open
@@ -597,8 +597,8 @@ mod tests {
         assert!(!is_empty_shell(2, true));
     }
 
-    /// UI-R-045 — a configured file sink buffers lines and flushes them to disk on flush/teardown, timestamped.
     #[test]
+    /// UI-R-045 — a configured file sink buffers lines and flushes them to disk on flush/teardown, timestamped.
     fn log_ring_persists_lines_to_file_sink() {
         let dir = std::env::temp_dir();
         let base = dir.join(format!("ferrowl_logring_test_{}.log", std::process::id()));

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -597,6 +597,7 @@ mod tests {
         assert!(!is_empty_shell(2, true));
     }
 
+    /// UI-R-045 — a configured file sink buffers lines and flushes them to disk on flush/teardown, timestamped.
     #[test]
     fn log_ring_persists_lines_to_file_sink() {
         let dir = std::env::temp_dir();

--- a/ferrowl/src/cli/headless.rs
+++ b/ferrowl/src/cli/headless.rs
@@ -350,6 +350,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-043 — log draining is exact-by-count, emitting every occurrence of a repeated line.
     async fn ut_drain_log_counts_exact_even_with_duplicate_lines() {
         let log = new_log();
         {
@@ -384,6 +385,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-043 — a ring overflow between ticks is reported with a synthetic dropped-lines line.
     async fn ut_drain_log_reports_dropped_lines_on_ring_overflow() {
         let log = new_log();
         let overflow_by = 5;
@@ -402,6 +404,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-031 — a `[sim]` line flags exit-code 2 only when --exit-on-error is set.
     async fn ut_drain_log_flags_sim_error_prefix_only_when_requested() {
         let log = new_log();
         log.write().await.write(Level::Error, "[sim] boom");
@@ -415,6 +418,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-040 — session-sim lines are drained under the source name `session`.
     async fn ut_drain_log_session_source_uses_session_prefix() {
         let log = new_log();
         log.write().await.write(Level::Info, "hello");
@@ -430,6 +434,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-031 — a `[sim]` session-sim line flags exit-code 2 under --exit-on-error.
     async fn ut_drain_log_session_sim_error_flags_exit_on_error() {
         let log = new_log();
         log.write().await.write(Level::Error, "[sim] boom");
@@ -455,6 +460,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-023 — no session files means no session sim is created.
     fn ut_load_session_scripts_none_without_session_files() {
         // Mirrors the single-module `--module key=val` headless path (point 5 of the task):
         // no `--session` file means no `Session`, so no session sim is even considered.
@@ -463,6 +469,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-027 — session scripts concatenate across files in order; the last file's interval wins.
     fn ut_load_session_scripts_aggregates_across_files_last_interval_wins() {
         use crate::config::Session as SessionConfig;
         use ferrowl_util::convert::{Converter, FileType};
@@ -602,6 +609,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-023 — the runner wires the session sim and drains its log under `session`.
     async fn ut_run_wires_session_sim_and_drains_its_log() {
         let args = session_run_args("enabled", true);
         let log_file = args.log_file.clone().unwrap();
@@ -617,6 +625,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// CL-R-023 — with no enabled session script, no session sim is spawned.
     async fn ut_run_with_zero_enabled_scripts_spawns_no_session_sim() {
         let args = session_run_args("disabled", false);
         let log_file = args.log_file.clone().unwrap();

--- a/ferrowl/src/cli/mod.rs
+++ b/ferrowl/src/cli/mod.rs
@@ -304,6 +304,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// CL-R-002 — a --module TCP descriptor parses into a module instance.
     fn ut_parse_tcp_module() {
         let spec = parse_module_spec(
             "name=evse-1,device=configs/evse.toml,transport=tcp,ip=10.0.0.5,port=502,role=server",
@@ -322,6 +323,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-002 — a --module TCP descriptor applies its documented defaults.
     fn ut_parse_tcp_defaults() {
         // ip and role default; type is an alias for device.
         let spec = parse_module_spec("name=m,type=d.toml,port=1502").unwrap();
@@ -336,6 +338,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-002 — a --module RTU descriptor parses into a module instance.
     fn ut_parse_rtu_module() {
         let spec = parse_module_spec(
             "name=m,device=d.toml,transport=rtu,path=/dev/ttyUSB0,baud=9600,role=client",
@@ -355,6 +358,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-004 — a --device occurrence auto-builds a TCP client with the fixed endpoint and default name.
     fn ut_device_spec_defaults() {
         let spec = create_module_spec_by_device("Device 0".to_string(), "d.toml".to_string());
         assert_eq!(spec.name, "Device 0");
@@ -370,16 +374,19 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-002 — a --module descriptor missing its name is a parse error.
     fn ut_missing_name_errors() {
         assert!(parse_module_spec("device=d.toml,port=502").is_err());
     }
 
     #[test]
+    /// CL-R-002 — a --module descriptor missing its port is a parse error.
     fn ut_missing_port_errors() {
         assert!(parse_module_spec("name=m,device=d.toml,transport=tcp").is_err());
     }
 
     #[test]
+    /// CL-R-007 — the instance set concatenates session, --module, then --device sources in order.
     fn ut_module_specs_combines_all_sources() {
         use ferrowl_util::convert::{Converter, FileType};
         let session = config::Session {
@@ -407,6 +414,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-003 — a --session file's instances resolve, split into modbus and ocpp.
     fn ut_session_splits_modbus_and_ocpp() {
         use ferrowl_util::convert::{Converter, FileType};
         let mut modbus =
@@ -456,6 +464,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-003 — a --session file that fails to load surfaces an error during resolution.
     fn ut_module_specs_session_load_error() {
         let args = CliArgs {
             command: None,
@@ -468,6 +477,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-002 — the descriptor mini-language rejects empty parts and malformed values.
     fn ut_parse_empty_parts_and_error_paths() {
         // Empty comma segment is skipped.
         assert_eq!(
@@ -488,6 +498,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-002 — a --module RTU descriptor parses its full option set.
     fn ut_parse_rtu_full_options() {
         let spec = parse_module_spec(
             "name=m,device=d,transport=rtu,path=/dev/x,baud_rate=4800,parity=even,data_bits=7,stop_bits=2",
@@ -506,6 +517,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-013 — a run --ocpp descriptor applies its documented defaults.
     fn ut_parse_ocpp_spec_defaults() {
         let spec = parse_ocpp_spec("name=cs-1,device=cs.toml,port=9000").unwrap();
         assert_eq!(spec.name, "cs-1");
@@ -517,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-013 — a run --ocpp descriptor parses its full option set.
     fn ut_parse_ocpp_spec_full() {
         let spec = parse_ocpp_spec(
             "name=cs-1,device=cs.toml,protocol=wss,ip=10.0.0.5,port=9001,path=/ocpp/cp001",
@@ -528,6 +541,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-013 — a malformed run --ocpp descriptor is a parse error.
     fn ut_parse_ocpp_spec_errors() {
         assert!(parse_ocpp_spec("device=d,port=1").is_err()); // missing name
         assert!(parse_ocpp_spec("name=m,port=1").is_err()); // missing device
@@ -537,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-013 — the run subcommand parses its own flag set.
     fn ut_run_subcommand_parses() {
         let args = CliArgs::parse_from([
             "ferrowl",
@@ -570,6 +585,7 @@ mod tests {
     }
 
     #[test]
+    /// CL-R-013 — run resolves modbus from --session/--module and ocpp from --session/--ocpp.
     fn ut_run_args_resolve_module_and_ocpp_specs() {
         let run = RunArgs {
             sessions: vec![],

--- a/ferrowl/src/config/mod.rs
+++ b/ferrowl/src/config/mod.rs
@@ -92,6 +92,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-033 — a saved device/session file reloads to an equal value (envelope round-trips).
     fn ut_load_device_and_session_roundtrip() {
         let dpath = tmp("ferrowl_cfgmod_device.toml");
         Converter::save(&DeviceConfig::default(), &dpath, FileType::Toml).unwrap();
@@ -103,6 +104,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-054 — loading a device config self-heals a legacy per-register `update` snippet on every load.
     fn ut_load_device_migrates_update_scripts() {
         let path = tmp("ferrowl_cfgmod_legacy_update.toml");
         std::fs::write(
@@ -119,6 +121,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-003 — a path with an unknown extension fails to load with an unknown-format error.
     fn ut_load_unknown_format_errors() {
         let e = load_session("/tmp/ferrowl_cfg.bin");
         assert!(matches!(e, Err(ConfigError::UnknownFormat(_))));

--- a/ferrowl/src/dialog/close_confirm.rs
+++ b/ferrowl/src/dialog/close_confirm.rs
@@ -191,6 +191,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// UI-R-023 — Enter on the close-confirm popup closes the underlying dialog.
     fn ut_enter_closes() {
         let mut d = CloseConfirmDialog::new();
         assert_eq!(
@@ -200,6 +201,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Space on the close-confirm popup closes the underlying dialog.
     fn ut_space_closes() {
         let mut d = CloseConfirmDialog::new();
         assert_eq!(
@@ -209,6 +211,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc dismisses the close-confirm popup and returns to editing.
     fn ut_esc_dismisses() {
         let mut d = CloseConfirmDialog::new();
         assert_eq!(
@@ -218,6 +221,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — a modified key is consumed and keeps the confirm popup open.
     fn ut_modified_keys_consumed() {
         let mut d = CloseConfirmDialog::new();
         for code in [KeyCode::Enter, KeyCode::Char(' '), KeyCode::Esc] {
@@ -232,6 +236,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — an unrelated key is consumed and keeps the confirm popup open.
     fn ut_other_keys_consumed() {
         let mut d = CloseConfirmDialog::new();
         assert_eq!(
@@ -267,6 +272,7 @@ mod tests {
     // --- route_close_confirm -------------------------------------------------
 
     #[test]
+    /// UI-R-023 — routing reports NotActive when no confirm popup is open.
     fn ut_route_not_active_when_none() {
         let mut confirm: Option<CloseConfirmDialog> = None;
         assert_eq!(
@@ -277,6 +283,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — confirming through the router closes and clears the popup.
     fn ut_route_close_clears_popup() {
         let mut confirm = Some(CloseConfirmDialog::new());
         assert_eq!(
@@ -287,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — dismissing through the router clears the popup and consumes the key.
     fn ut_route_dismiss_clears_popup_and_reports_consumed() {
         let mut confirm = Some(CloseConfirmDialog::new());
         assert_eq!(
@@ -297,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — an unrelated key routed to the popup keeps it open and is consumed.
     fn ut_route_other_key_stays_open_and_consumed() {
         let mut confirm = Some(CloseConfirmDialog::new());
         assert_eq!(

--- a/ferrowl/src/dialog/help.rs
+++ b/ferrowl/src/dialog/help.rs
@@ -192,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — Esc/q/? close the script dialog's help overlay.
     fn ut_handle_key_close_keys() {
         let mut o = overlay();
         assert!(o.handle_key(KeyModifiers::NONE, KeyCode::Esc));
@@ -200,6 +201,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — j/k scroll the help overlay.
     fn ut_handle_key_scroll() {
         let mut o = overlay();
         o.max_scroll = 100;
@@ -217,6 +219,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — g/G jump to the top/bottom of the help overlay.
     fn ut_handle_key_top_bottom() {
         let mut o = overlay();
         o.max_scroll = 20;
@@ -228,6 +231,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — scrolling past the bottom of the help overlay does not overflow.
     fn ut_handle_key_g_then_j_stays_at_max_no_overflow() {
         // Regression: `G` used to jump to `u16::MAX`, and `j` at the bottom used to keep
         // incrementing unboundedly. Both must clamp to `max_scroll`.
@@ -242,6 +246,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — the help overlay clamps its scroll to the rendered viewport height.
     fn ut_render_sets_max_scroll_and_handle_key_respects_it_after() {
         // A render with a tall content and small viewport should compute a finite max_scroll;
         // subsequent `G`/`j` must not exceed it.
@@ -258,6 +263,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — help overlay lines fit the popup width.
     fn ut_build_lines_fit_popup_width() {
         // popup_w = 75, inner_width = 73, desc_budget = 73 - 34 = 39.
         let lines = build_lines(lua_help::sections(ScriptContext::OcppClient), 39);
@@ -268,6 +274,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — a long help entry description wraps within the overlay.
     fn ut_build_lines_wraps_long_action_desc() {
         let secs = lua_help::sections(ScriptContext::OcppClient);
         let ocpp = secs.iter().find(|s| s.title == "C_OCPP").unwrap();
@@ -292,6 +299,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — the help overlay consumes all other keys while open.
     fn ut_handle_key_other_keys_eaten() {
         let mut o = overlay();
         assert!(!o.handle_key(KeyModifiers::NONE, KeyCode::Char('x')));
@@ -302,6 +310,7 @@ mod tests {
     // --- route_help -----------------------------------------------------
 
     #[test]
+    /// UI-R-056 — routing reports NotActive when the help overlay is closed.
     fn ut_route_not_active_when_none() {
         let mut help: Option<HelpOverlay> = None;
         assert_eq!(
@@ -312,6 +321,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — a close key routed to the help overlay clears it.
     fn ut_route_close_key_clears_overlay() {
         let mut help = Some(overlay());
         assert_eq!(
@@ -322,6 +332,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — an unrelated key keeps the help overlay open and is consumed.
     fn ut_route_other_key_stays_open_and_consumed() {
         let mut help = Some(overlay());
         assert_eq!(

--- a/ferrowl/src/dialog/mod.rs
+++ b/ferrowl/src/dialog/mod.rs
@@ -87,11 +87,13 @@ mod tests {
     // ---- NonEmpty ----
 
     #[test]
+    /// UI-R-048 — the non-empty field validator rejects empty input.
     fn non_empty_rejects_empty() {
         assert!(matches!(NonEmpty::validate(""), ValidateResult::Error(_)));
     }
 
     #[test]
+    /// UI-R-048 — the non-empty field validator accepts text.
     fn non_empty_accepts_text() {
         assert!(matches!(NonEmpty::validate("hello"), ValidateResult::None));
         assert!(matches!(NonEmpty::validate(" "), ValidateResult::None));
@@ -100,6 +102,7 @@ mod tests {
     // ---- Address ----
 
     #[test]
+    /// UI-R-048 — the address field validator accepts the `virtual` keyword.
     fn address_virtual_keyword() {
         assert!(matches!(
             Address::validate("virtual"),
@@ -108,6 +111,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the address field validator accepts an in-range value.
     fn address_valid_i16() {
         assert!(matches!(Address::validate("0"), ValidateResult::None));
         assert!(matches!(Address::validate("32767"), ValidateResult::None));
@@ -116,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the address field validator rejects an out-of-range value.
     fn address_overflow_i16() {
         assert!(matches!(
             Address::validate("32768"),
@@ -132,12 +137,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the address field validator rejects non-numeric input.
     fn address_non_numeric() {
         assert!(matches!(Address::validate("abc"), ValidateResult::Error(_)));
         assert!(matches!(Address::validate(""), ValidateResult::Error(_)));
     }
 
     #[test]
+    /// UI-R-048 — the address field's per-character filter admits only valid characters.
     fn address_allowed_char() {
         for c in "virtual1-".chars() {
             assert!(Address::allowed_char(c), "expected {c:?} to be allowed");
@@ -149,11 +156,13 @@ mod tests {
     // ---- Bitmask ----
 
     #[test]
+    /// UI-R-048 — an empty bitmask field validates as none.
     fn bitmask_empty_is_none() {
         assert!(matches!(Bitmask::validate(""), ValidateResult::None));
     }
 
     #[test]
+    /// UI-R-048 — the bitmask validator accepts a lowercase-prefixed hex value.
     fn bitmask_valid_hex_lowercase_prefix() {
         assert!(matches!(Bitmask::validate("0xFF"), ValidateResult::None));
         assert!(matches!(Bitmask::validate("0x0"), ValidateResult::None));
@@ -164,12 +173,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the bitmask validator accepts an uppercase-prefixed hex value.
     fn bitmask_valid_hex_uppercase_prefix() {
         assert!(matches!(Bitmask::validate("0XFF"), ValidateResult::None));
         assert!(matches!(Bitmask::validate("0X0"), ValidateResult::None));
     }
 
     #[test]
+    /// UI-R-048 — the bitmask validator rejects malformed hex.
     fn bitmask_invalid_hex() {
         assert!(matches!(
             Bitmask::validate("0xGG"),
@@ -179,6 +190,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the bitmask validator accepts a decimal value.
     fn bitmask_valid_decimal() {
         assert!(matches!(Bitmask::validate("0"), ValidateResult::None));
         assert!(matches!(Bitmask::validate("255"), ValidateResult::None));
@@ -189,12 +201,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the bitmask validator rejects malformed decimal.
     fn bitmask_invalid_decimal() {
         assert!(matches!(Bitmask::validate("abc"), ValidateResult::Error(_)));
         assert!(matches!(Bitmask::validate("-1"), ValidateResult::Error(_)));
     }
 
     #[test]
+    /// UI-R-048 — the bitmask field's per-character filter admits only valid characters.
     fn bitmask_allowed_char() {
         for c in ['F', 'x', 'X', '9', 'a'] {
             assert!(Bitmask::allowed_char(c), "expected {c:?} to be allowed");

--- a/ferrowl/src/dialog/path_suggest.rs
+++ b/ferrowl/src/dialog/path_suggest.rs
@@ -177,6 +177,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — path completion filters candidates by the typed prefix.
     fn ut_prefix_filtering() {
         let root = setup("ferrowl_pathsuggest_prefix");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -191,6 +192,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — directory completions carry a trailing slash (partial suggestions).
     fn ut_trailing_slash_on_dirs() {
         let root = setup("ferrowl_pathsuggest_slash");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -203,6 +205,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — hidden entries are excluded from completions by default.
     fn ut_hidden_excluded_by_default() {
         let root = setup("ferrowl_pathsuggest_hidden_excl");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -214,6 +217,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — hidden entries appear once a dot prefix is typed.
     fn ut_hidden_included_when_typed() {
         let root = setup("ferrowl_pathsuggest_hidden_incl");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -226,6 +230,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — an extension filter keeps directories reachable for descent.
     fn ut_extension_filter_keeps_dirs() {
         let root = setup("ferrowl_pathsuggest_ext");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -243,12 +248,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — a missing directory yields no completions.
     fn ut_missing_dir_returns_empty() {
         let results = complete_path("/no/such/ferrowl/dir/foo", None, MAX_SUGGESTIONS);
         assert!(results.is_empty());
     }
 
     #[test]
+    /// UI-R-026 — a leading tilde expands to the home directory in completions.
     fn ut_tilde_expansion_with_fake_home() {
         let root = setup("ferrowl_pathsuggest_tilde");
         let expanded = expand_tilde("~/conf", Some(&root));
@@ -260,6 +267,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — the completion list is capped in length.
     fn ut_result_cap() {
         let root = tmp("ferrowl_pathsuggest_cap");
         cleanup(&root);
@@ -278,6 +286,7 @@ mod tests {
     static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
+    /// UI-R-026 — empty input lists the current directory.
     fn ut_empty_input_lists_current_dir_without_prefix() {
         let _guard = CWD_LOCK.lock().unwrap();
         let original_cwd = std::env::current_dir().unwrap();
@@ -301,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — a directory suggestion is marked partial with a trailing-slash label.
     fn ut_provider_dir_partial_and_trailing_slash_label() {
         let root = setup("ferrowl_pathsuggest_provider_dir");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -317,6 +327,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — a file suggestion's label is its last path component.
     fn ut_provider_file_label_is_last_component() {
         let root = setup("ferrowl_pathsuggest_provider_file");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -333,6 +344,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — the provider honors the configured extension filter.
     fn ut_provider_extension_filter_honored() {
         let root = setup("ferrowl_pathsuggest_provider_ext");
         let dir_prefix = format!("{}/", root.to_string_lossy());
@@ -346,6 +358,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-026 — the provider returns no suggestions for a missing directory.
     fn ut_provider_missing_dir_returns_empty() {
         let provider = FsPathProvider::default();
         let results = provider.suggest("/no/such/ferrowl/dir/foo");

--- a/ferrowl/src/dialog/rename.rs
+++ b/ferrowl/src/dialog/rename.rs
@@ -200,6 +200,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-055 — typing edits the rename prompt's field.
     fn ut_typing_edits_the_field() {
         let mut prompt = RenamePrompt::new("a");
         assert_eq!(
@@ -233,6 +234,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-055 — routing reports NotActive when no rename prompt is open.
     fn ut_route_not_active_when_none() {
         let mut rename: Option<RenamePrompt> = None;
         assert_eq!(

--- a/ferrowl/src/dialog/rename.rs
+++ b/ferrowl/src/dialog/rename.rs
@@ -178,15 +178,15 @@ pub fn route_rename(
 mod tests {
     use super::*;
 
-    /// UI-R-055 — the prompt opens pre-filled with the current name.
     #[test]
+    /// UI-R-055 — the prompt opens pre-filled with the current name.
     fn ut_prompt_is_prefilled() {
         let prompt = RenamePrompt::new("boot");
         assert_eq!(prompt.input.state.input(), "boot");
     }
 
-    /// UI-R-055 — `Enter` commits the trimmed field content, `Esc` cancels.
     #[test]
+    /// UI-R-055 — `Enter` commits the trimmed field content, `Esc` cancels.
     fn ut_enter_commits_trimmed_and_esc_cancels() {
         let mut prompt = RenamePrompt::new("boot");
         assert_eq!(
@@ -213,8 +213,8 @@ mod tests {
         );
     }
 
-    /// UI-R-055 — `Esc` clears the prompt; a commit leaves it in place for the host to judge.
     #[test]
+    /// UI-R-055 — `Esc` clears the prompt; a commit leaves it in place for the host to judge.
     fn ut_route_cancel_clears_commit_keeps() {
         let mut rename = Some(RenamePrompt::new("a"));
         assert_eq!(

--- a/ferrowl/src/dialog/script_keys.rs
+++ b/ferrowl/src/dialog/script_keys.rs
@@ -53,6 +53,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — the overlay carries the script table's own bindings section.
     fn ut_overlay_carries_the_section() {
         let _ = script_keys_overlay();
     }

--- a/ferrowl/src/dialog/script_keys.rs
+++ b/ferrowl/src/dialog/script_keys.rs
@@ -34,8 +34,8 @@ pub fn script_keys_overlay() -> HelpOverlay {
 mod tests {
     use super::*;
 
-    /// UI-R-056 — the overlay documents every binding the script table has.
     #[test]
+    /// UI-R-056 — the overlay documents every binding the script table has.
     fn ut_lists_every_script_table_binding() {
         for key in ["Enter", "e", "t", "d", "c"] {
             assert!(

--- a/ferrowl/src/dialog/script_manager.rs
+++ b/ferrowl/src/dialog/script_manager.rs
@@ -372,8 +372,6 @@ mod tests {
         assert!(mgr.scripts.is_empty());
     }
 
-    /// UI-R-056 — the table title advertises the help overlay only; the binding list it used to
-    /// carry overflowed the panel and now lives in that overlay.
     #[test]
     /// UI-R-056 — the script table's title advertises only the help overlay, not individual bindings.
     fn ut_script_table_title_advertises_help_only() {
@@ -385,8 +383,8 @@ mod tests {
         }
     }
 
-    /// UI-R-054 — the suffix search skips every taken name, not just the base.
     #[test]
+    /// UI-R-054 — the suffix search skips every taken name, not just the base.
     fn ut_unique_name_suffixes_past_taken_names() {
         let scripts = vec![
             ScriptDef {
@@ -404,8 +402,6 @@ mod tests {
         assert_eq!(unique_name(&scripts, "sine"), "sine");
     }
 
-    /// UI-R-055 — renaming to the script's own name is accepted (a no-op), not refused as a
-    /// duplicate of itself.
     #[test]
     /// UI-R-055 — renaming a script to its own current name is accepted.
     fn ut_rename_to_own_name_is_accepted() {

--- a/ferrowl/src/dialog/script_manager.rs
+++ b/ferrowl/src/dialog/script_manager.rs
@@ -310,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-055 — a new script name that is empty or duplicates another is refused.
     fn ut_create_script_rejects_empty_and_duplicate_names() {
         let mut scripts = vec![ScriptDef {
             name: "boot".into(),
@@ -373,6 +374,7 @@ mod tests {
     /// UI-R-056 — the table title advertises the help overlay only; the binding list it used to
     /// carry overflowed the panel and now lives in that overlay.
     #[test]
+    /// UI-R-056 — the script table's title advertises only the help overlay, not individual bindings.
     fn ut_script_table_title_advertises_help_only() {
         let table = script_table(rows(&[]));
         let title = format!("{:?}", table.widget);
@@ -404,6 +406,7 @@ mod tests {
     /// UI-R-055 — renaming to the script's own name is accepted (a no-op), not refused as a
     /// duplicate of itself.
     #[test]
+    /// UI-R-055 — renaming a script to its own current name is accepted.
     fn ut_rename_to_own_name_is_accepted() {
         let mut scripts = vec![ScriptDef {
             name: "boot".into(),

--- a/ferrowl/src/dialog/script_manager.rs
+++ b/ferrowl/src/dialog/script_manager.rs
@@ -344,6 +344,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-058 — `t` toggles and `d` deletes the selected script in the working list.
     fn ut_toggle_and_delete_selected() {
         let mut scripts = vec![ScriptDef {
             name: "a".into(),
@@ -432,6 +433,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-058 — `c` toggles the script table between compact and normal rows.
     fn ut_toggle_compact_flips_row_margin() {
         let mut scripts: Vec<ScriptDef> = Vec::new();
         let mut table = script_table(rows(&scripts));

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -685,6 +685,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-058 — the script table adds, toggles-enabled, and deletes scripts in its working list.
     fn ut_create_toggle_delete_script() {
         let mut d = ScriptDialog::new(&[], Duration::from_secs(1), ScriptContext::Modbus);
         // Tab to the name input, type a name, Enter creates an enabled script.

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -701,8 +701,6 @@ mod tests {
         assert!(scripts[0].enabled);
     }
 
-    /// UI-R-051 — `e` on the focused table queues the selected script for a one-shot run, carrying
-    /// the editor's current content (edits not yet flushed to the script) and ignoring `enabled`.
     #[test]
     /// UI-R-051 — `e` on the script table requests a one-shot run of the selected script.
     fn ut_e_requests_run_of_selected_script() {
@@ -742,8 +740,8 @@ mod tests {
         assert!(d.take_run_request().is_none(), "request is taken once");
     }
 
-    /// UI-R-051 — `e` with no script selected is a no-op.
     #[test]
+    /// UI-R-051 — `e` with no script selected is a no-op.
     fn ut_e_without_selection_is_noop() {
         let mut d = ScriptDialog::new(&[], Duration::from_secs(1), ScriptContext::Modbus);
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table (empty)
@@ -751,8 +749,8 @@ mod tests {
         assert!(d.take_run_request().is_none());
     }
 
-    /// UI-R-051 — `e` is a table binding: in the name input it is literal text, not a run.
     #[test]
+    /// UI-R-051 — `e` is a table binding: in the name input it is literal text, not a run.
     fn ut_e_in_name_input_types_char() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -968,8 +966,6 @@ mod tests {
         }
     }
 
-    /// UI-R-052 — the Templates button sits in the focus cycle after the name input, and
-    /// `Enter`/`Space` on it opens the template browser.
     #[test]
     /// UI-R-052 — the Templates button sits in the focus cycle and opens the template browser.
     fn ut_templates_button_in_focus_cycle_and_opens_browser() {
@@ -986,8 +982,6 @@ mod tests {
         }
     }
 
-    /// UI-R-053 — while the browser is open it takes every key: `Esc` closes it instead of opening
-    /// the dialog's close-confirm.
     #[test]
     /// UI-R-053 — the open template browser takes precedence over all other dialog keys.
     fn ut_open_browser_takes_precedence_over_dialog_keys() {
@@ -1000,8 +994,6 @@ mod tests {
         assert!(d.close_confirm.is_none(), "and not the dialog");
     }
 
-    /// UI-R-054 — confirming a template appends it as a new enabled script, selects it, and leaves
-    /// the dialog open with the browser closed.
     #[test]
     /// UI-R-054 — confirming a template appends it as a new enabled script.
     fn ut_insert_template_appends_enabled_script() {
@@ -1020,8 +1012,8 @@ mod tests {
         assert!(scripts[1].enabled);
     }
 
-    /// UI-R-054 — inserting the same template twice suffixes the second rather than refusing it.
     #[test]
+    /// UI-R-054 — inserting the same template twice suffixes the second rather than refusing it.
     fn ut_insert_duplicate_template_auto_suffixes() {
         let mut d = dialog();
         for _ in 0..2 {
@@ -1038,8 +1030,6 @@ mod tests {
 
     // --- rename ---------------------------------------------------------
 
-    /// UI-R-055 — `Enter` on the script table opens a rename prompt pre-filled with the current
-    /// name; committing renames the script, preserving its code and enabled flag.
     #[test]
     /// UI-R-055 — Enter on a selected script opens the rename prompt and renames it.
     fn ut_enter_on_table_renames_selected_script() {
@@ -1068,8 +1058,8 @@ mod tests {
         assert!(!scripts[0].enabled);
     }
 
-    /// UI-R-055 — an empty or duplicate name is refused and the prompt stays open.
     #[test]
+    /// UI-R-055 — an empty or duplicate name is refused and the prompt stays open.
     fn ut_rename_refuses_empty_and_duplicate() {
         let mut d = ScriptDialog::new(
             &[
@@ -1107,8 +1097,6 @@ mod tests {
         assert_eq!(d.scripts[0].name, "boot", "the name is unchanged");
     }
 
-    /// UI-R-055 — `Esc` dismisses the prompt, leaving the name unchanged; with no script selected
-    /// `Enter` on the table is a no-op.
     #[test]
     /// UI-R-055 — Esc cancels the rename; Enter on an empty table is a no-op.
     fn ut_rename_esc_cancels_and_empty_table_is_noop() {
@@ -1129,8 +1117,8 @@ mod tests {
 
     // --- script-table keybind help --------------------------------------
 
-    /// UI-R-056 — `?` on the script table opens the keybind help, with or without a selection.
     #[test]
+    /// UI-R-056 — `?` on the script table opens the keybind help, with or without a selection.
     fn ut_question_mark_on_table_opens_script_keys_help() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -1143,8 +1131,8 @@ mod tests {
         assert!(empty.help.is_some());
     }
 
-    /// UI-R-056 — `Esc`, `q` and `?` each close the overlay.
     #[test]
+    /// UI-R-056 — `Esc`, `q` and `?` each close the overlay.
     fn ut_script_keys_help_closes_on_esc_q_question() {
         for close_key in [KeyCode::Esc, KeyCode::Char('q'), KeyCode::Char('?')] {
             let mut d = dialog();
@@ -1156,8 +1144,6 @@ mod tests {
         }
     }
 
-    /// UI-R-056 — while the overlay is open it takes every key: the table's own bindings and the
-    /// dialog's `Esc` are not reachable through it.
     #[test]
     /// UI-R-056 — the script-keys help overlay takes precedence over other dialog keys.
     fn ut_script_keys_help_takes_precedence() {

--- a/ferrowl/src/dialog/scripts.rs
+++ b/ferrowl/src/dialog/scripts.rs
@@ -558,12 +558,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the interval field validator accepts a positive finite value.
     fn ut_interval_validate_accepts_positive_finite() {
         assert!(matches!(Interval::validate("2.5"), ValidateResult::None));
         assert!(matches!(Interval::validate("1"), ValidateResult::None));
     }
 
     #[test]
+    /// UI-R-048 — the interval field validator rejects non-finite/non-positive values.
     fn ut_interval_validate_rejects_bad_values() {
         assert!(matches!(Interval::validate("0"), ValidateResult::Error(_)));
         assert!(matches!(Interval::validate("-1"), ValidateResult::Error(_)));
@@ -582,6 +584,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — the interval field's per-character filter admits only valid characters.
     fn ut_interval_allowed_char() {
         assert!(Interval::allowed_char('5'));
         assert!(Interval::allowed_char('.'));
@@ -613,6 +616,7 @@ mod tests {
     // The dialog-wide Tab rotation: Interval → table → name input → code editor → log →
     // Interval. The fixture has one script, so the code editor is reachable.
     #[test]
+    /// UI-R-022 — Tab rotates focus through every enabled dialog field.
     fn ut_tab_rotates_through_all_fields() {
         let mut d = dialog();
         assert_eq!(d.focus, ScriptDialogFocus::Interval);
@@ -631,6 +635,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Shift+Tab rotates dialog focus in reverse.
     fn ut_backtab_rotates_in_reverse() {
         let mut d = dialog();
         let expected = [
@@ -649,6 +654,7 @@ mod tests {
 
     // Without a selected script the code editor is disabled and both rotations skip it.
     #[test]
+    /// UI-R-022 — the focus cycle skips a disabled field (the code editor).
     fn ut_rotation_skips_disabled_code_editor() {
         let mut d = ScriptDialog::new(&[], Duration::from_secs(1), ScriptContext::Modbus);
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -661,6 +667,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc on the dialog opens the close-confirm rather than closing immediately.
     fn ut_esc_does_not_close() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -670,6 +677,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-048 — typing into the interval field updates its input.
     fn ut_typing_in_interval_updates_input() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Char('9'));
@@ -695,6 +703,7 @@ mod tests {
     /// UI-R-051 — `e` on the focused table queues the selected script for a one-shot run, carrying
     /// the editor's current content (edits not yet flushed to the script) and ignoring `enabled`.
     #[test]
+    /// UI-R-051 — `e` on the script table requests a one-shot run of the selected script.
     fn ut_e_requests_run_of_selected_script() {
         let mut d = ScriptDialog::new(
             &[ScriptDef {
@@ -799,6 +808,7 @@ mod tests {
     // --- close-confirm / lua-help integration -------------------------------
 
     #[test]
+    /// UI-R-023 — Esc then Enter confirms the close and dismisses the dialog.
     fn ut_esc_then_enter_closes() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -808,6 +818,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm returns to the dialog.
     fn ut_esc_in_confirm_keeps_dialog() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -818,6 +829,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Space in the close-confirm confirms the close.
     fn ut_space_in_confirm_closes() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Esc);
@@ -826,6 +838,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc from the code editor's Normal mode opens the close-confirm.
     fn ut_esc_from_code_normal_opens_confirm() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -839,6 +852,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc from Insert mode returns to Normal without opening the close-confirm.
     fn ut_insert_esc_goes_normal_no_confirm() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -854,6 +868,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into the name input rather than entering command mode.
     fn ut_colon_in_name_input_types() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -864,6 +879,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` inserts into the code editor in Insert mode.
     fn ut_colon_in_code_insert_inserts() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -878,6 +894,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` in the code editor's Normal mode opens no command line.
     fn ut_colon_in_code_normal_no_overlay() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -892,6 +909,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm still cancels the close.
     fn ut_confirm_esc_still_cancels() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -902,6 +920,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — `?` opens the keybind help only from the code editor's Normal mode (guarded).
     fn ut_question_opens_bindings_only_code_normal() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -924,6 +943,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-056 — Esc/q/? close the bindings help overlay.
     fn ut_bindings_close_keys() {
         for close_key in [KeyCode::Esc, KeyCode::Char('q'), KeyCode::Char('?')] {
             let mut d = dialog();
@@ -950,6 +970,7 @@ mod tests {
     /// UI-R-052 — the Templates button sits in the focus cycle after the name input, and
     /// `Enter`/`Space` on it opens the template browser.
     #[test]
+    /// UI-R-052 — the Templates button sits in the focus cycle and opens the template browser.
     fn ut_templates_button_in_focus_cycle_and_opens_browser() {
         for open_key in [KeyCode::Enter, KeyCode::Char(' ')] {
             let mut d = dialog();
@@ -967,6 +988,7 @@ mod tests {
     /// UI-R-053 — while the browser is open it takes every key: `Esc` closes it instead of opening
     /// the dialog's close-confirm.
     #[test]
+    /// UI-R-053 — the open template browser takes precedence over all other dialog keys.
     fn ut_open_browser_takes_precedence_over_dialog_keys() {
         let mut d = dialog();
         focus_templates_button(&mut d);
@@ -980,6 +1002,7 @@ mod tests {
     /// UI-R-054 — confirming a template appends it as a new enabled script, selects it, and leaves
     /// the dialog open with the browser closed.
     #[test]
+    /// UI-R-054 — confirming a template appends it as a new enabled script.
     fn ut_insert_template_appends_enabled_script() {
         let mut d = dialog();
         focus_templates_button(&mut d);
@@ -1017,6 +1040,7 @@ mod tests {
     /// UI-R-055 — `Enter` on the script table opens a rename prompt pre-filled with the current
     /// name; committing renames the script, preserving its code and enabled flag.
     #[test]
+    /// UI-R-055 — Enter on a selected script opens the rename prompt and renames it.
     fn ut_enter_on_table_renames_selected_script() {
         let mut d = ScriptDialog::new(
             &[ScriptDef {
@@ -1085,6 +1109,7 @@ mod tests {
     /// UI-R-055 — `Esc` dismisses the prompt, leaving the name unchanged; with no script selected
     /// `Enter` on the table is a no-op.
     #[test]
+    /// UI-R-055 — Esc cancels the rename; Enter on an empty table is a no-op.
     fn ut_rename_esc_cancels_and_empty_table_is_noop() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table
@@ -1133,6 +1158,7 @@ mod tests {
     /// UI-R-056 — while the overlay is open it takes every key: the table's own bindings and the
     /// dialog's `Esc` are not reachable through it.
     #[test]
+    /// UI-R-056 — the script-keys help overlay takes precedence over other dialog keys.
     fn ut_script_keys_help_takes_precedence() {
         let mut d = dialog();
         d.handle_events(KeyModifiers::NONE, KeyCode::Tab); // -> table

--- a/ferrowl/src/dialog/template_browser.rs
+++ b/ferrowl/src/dialog/template_browser.rs
@@ -337,6 +337,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-053 — Tab cycles focus between the template list and its preview.
     fn ut_tab_cycles_list_and_preview() {
         let mut browser = TemplateBrowser::new(ScriptContext::Modbus);
         assert_eq!(browser.focus, BrowserFocus::List);
@@ -347,6 +348,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-053 — routing reports NotActive when the browser is closed.
     fn ut_route_not_active_when_none() {
         let mut browser: Option<TemplateBrowser> = None;
         assert_eq!(
@@ -356,6 +358,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-054 — confirming a template through the router closes the browser overlay.
     fn ut_route_insert_clears_overlay() {
         let mut browser = Some(TemplateBrowser::new(ScriptContext::Session));
         let outcome = route_template_browser(&mut browser, KeyModifiers::NONE, KeyCode::Enter);
@@ -364,6 +367,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-053 — a close key clears the browser overlay.
     fn ut_route_close_clears_overlay() {
         let mut browser = Some(TemplateBrowser::new(ScriptContext::Session));
         assert_eq!(
@@ -382,6 +386,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-053 — the read-only template preview cannot be edited.
     fn ut_preview_stays_in_normal_mode() {
         // Sanity: a disabled vim editor never leaves Normal mode, so `i` cannot start typing.
         let mut browser = TemplateBrowser::new(ScriptContext::Modbus);

--- a/ferrowl/src/dialog/template_browser.rs
+++ b/ferrowl/src/dialog/template_browser.rs
@@ -274,8 +274,8 @@ mod tests {
     use super::*;
     use ferrowl_ui::state::VimMode;
 
-    /// UI-R-053 — the browser lists only the templates of its own script context.
     #[test]
+    /// UI-R-053 — the browser lists only the templates of its own script context.
     fn ut_lists_only_context_templates() {
         let browser = TemplateBrowser::new(ScriptContext::Modbus);
         assert!(!browser.templates.is_empty());
@@ -288,8 +288,8 @@ mod tests {
         }
     }
 
-    /// UI-R-053 — the preview shows the selected template's code and cannot be edited.
     #[test]
+    /// UI-R-053 — the preview shows the selected template's code and cannot be edited.
     fn ut_preview_is_read_only_and_follows_selection() {
         let mut browser = TemplateBrowser::new(ScriptContext::Modbus);
         let first = browser.selected().unwrap();
@@ -311,8 +311,8 @@ mod tests {
         assert_eq!(browser.preview.state.content().trim(), second.code.trim());
     }
 
-    /// UI-R-053 — `Esc` and `q` close the overlay without picking anything.
     #[test]
+    /// UI-R-053 — `Esc` and `q` close the overlay without picking anything.
     fn ut_esc_and_q_close() {
         let mut browser = TemplateBrowser::new(ScriptContext::Session);
         assert_eq!(
@@ -325,8 +325,8 @@ mod tests {
         );
     }
 
-    /// UI-R-054 — `Enter` yields the selected template for insertion.
     #[test]
+    /// UI-R-054 — `Enter` yields the selected template for insertion.
     fn ut_enter_yields_selected_template() {
         let mut browser = TemplateBrowser::new(ScriptContext::Session);
         let selected = browser.selected().unwrap();

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -366,8 +366,8 @@ mod tests {
         Arc::new(RwLock::new(HashMap::new()))
     }
 
-    /// SC-R-027 — a virtual register round-trips its natural Lua type through the C_Register bridge.
     #[test]
+    /// SC-R-027 — a virtual register round-trips its natural Lua type through the C_Register bridge.
     fn ut_bridge_virtual_register_roundtrip() {
         let virtual_store = vstore();
         let mut registers = evse_registers();
@@ -406,8 +406,8 @@ mod tests {
         );
     }
 
-    /// SC-R-028 — a Lua register write is applied to the module's in-memory state and reads back.
     #[test]
+    /// SC-R-028 — a Lua register write is applied to the module's in-memory state and reads back.
     fn ut_bridge_write_then_read() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         bridge
@@ -427,8 +427,8 @@ mod tests {
     }
 
     // Mirrors `run_sim`'s body once: a `power` update copying `setpoint` reflects after a cycle.
-    /// SC-R-028 — a script's register write lands in the module's in-memory state after a cycle.
     #[test]
+    /// SC-R-028 — a script's register write lands in the module's in-memory state after a cycle.
     fn ut_sim_script_mirrors_register() {
         let memory = evse_memory();
         let bridge = RegisterBridge::new(memory.clone(), vstore(), Arc::new(evse_registers()));
@@ -467,8 +467,8 @@ mod tests {
 
     // A failing `C_Test` assertion surfaces through the same `call_all` error path the sim loop
     // logs (and headless `--exit-on-error` keys off), mirroring the wiring in `run_sim`.
-    /// SC-R-032 — a failed C_Test assertion surfaces through the sim's collected-error path.
     #[test]
+    /// SC-R-032 — a failed C_Test assertion surfaces through the sim's collected-error path.
     fn ut_sim_script_test_assertion_failure_surfaces() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         let mut context = ContextBuilder::<String>::default()
@@ -523,8 +523,8 @@ mod tests {
             .collect()
     }
 
-    /// SC-R-035 — a one-shot run executes the script against the module's registers without a sim.
     #[test]
+    /// SC-R-035 — a one-shot run executes the script against the module's registers without a sim.
     fn ut_run_script_once_writes_register() {
         let memory = evse_memory();
         let log = script_log();
@@ -555,9 +555,9 @@ mod tests {
         }));
     }
 
+    #[test]
     /// SC-R-035 — a failing one-shot logs under `[run]`, never `[sim]`: headless `--exit-on-error`
     /// keys its exit code off `[sim]` (CL-R-031) and must not see an interactive test run.
-    #[test]
     fn ut_run_script_once_error_logged_with_run_prefix() {
         let log = script_log();
         run_script_once(
@@ -578,8 +578,8 @@ mod tests {
 
     // --- Typed write path (no string round-trip) ---
 
-    /// SC-R-027 — int/float/bool register writes round-trip as their natural host type.
     #[test]
+    /// SC-R-027 — int/float/bool register writes round-trip as their natural host type.
     fn ut_bridge_typed_int_float_bool_roundtrip() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
 
@@ -613,8 +613,8 @@ mod tests {
         }
     }
 
-    /// SC-R-027 — a fractional float onto an integer format is a range mismatch that errors, not truncates.
     #[test]
+    /// SC-R-027 — a fractional float onto an integer format is a range mismatch that errors, not truncates.
     fn ut_bridge_typed_float_fractional_onto_int_format_errors() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         assert!(
@@ -624,8 +624,8 @@ mod tests {
         );
     }
 
-    /// SC-R-027 — a string register write is applied via the encode path and reads back as its value.
     #[test]
+    /// SC-R-027 — a string register write is applied via the encode path and reads back as its value.
     fn ut_bridge_typed_string_roundtrip() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         bridge
@@ -637,8 +637,8 @@ mod tests {
         }
     }
 
-    /// SC-R-027 — a nil register write is rejected rather than silently coerced.
     #[test]
+    /// SC-R-027 — a nil register write is rejected rather than silently coerced.
     fn ut_bridge_typed_nil_errors_cleanly() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         let err = bridge
@@ -689,8 +689,8 @@ mod tests {
         }
     }
 
-    /// SC-R-027 — a nil write to a virtual register is rejected rather than coerced.
     #[test]
+    /// SC-R-027 — a nil write to a virtual register is rejected rather than coerced.
     fn ut_bridge_virtual_typed_nil_errors_cleanly() {
         let virtual_store = vstore();
         let mut registers = evse_registers();

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -366,6 +366,7 @@ mod tests {
         Arc::new(RwLock::new(HashMap::new()))
     }
 
+    /// SC-R-027 — a virtual register round-trips its natural Lua type through the C_Register bridge.
     #[test]
     fn ut_bridge_virtual_register_roundtrip() {
         let virtual_store = vstore();
@@ -405,6 +406,7 @@ mod tests {
         );
     }
 
+    /// SC-R-028 — a Lua register write is applied to the module's in-memory state and reads back.
     #[test]
     fn ut_bridge_write_then_read() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -425,6 +427,7 @@ mod tests {
     }
 
     // Mirrors `run_sim`'s body once: a `power` update copying `setpoint` reflects after a cycle.
+    /// SC-R-028 — a script's register write lands in the module's in-memory state after a cycle.
     #[test]
     fn ut_sim_script_mirrors_register() {
         let memory = evse_memory();
@@ -464,6 +467,7 @@ mod tests {
 
     // A failing `C_Test` assertion surfaces through the same `call_all` error path the sim loop
     // logs (and headless `--exit-on-error` keys off), mirroring the wiring in `run_sim`.
+    /// SC-R-032 — a failed C_Test assertion surfaces through the sim's collected-error path.
     #[test]
     fn ut_sim_script_test_assertion_failure_surfaces() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -574,6 +578,7 @@ mod tests {
 
     // --- Typed write path (no string round-trip) ---
 
+    /// SC-R-027 — int/float/bool register writes round-trip as their natural host type.
     #[test]
     fn ut_bridge_typed_int_float_bool_roundtrip() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -597,7 +602,7 @@ mod tests {
 
     #[test]
     fn ut_bridge_typed_float_whole_number_onto_int_format() {
-        // Mirrors the string path: a whole-number float parses onto an integer format.
+        // SC-R-027 — a whole-number float writes onto an integer format (no coercion loss).
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         bridge
             .write("setpoint".to_string(), ValueType::Float(42.0))
@@ -608,6 +613,7 @@ mod tests {
         }
     }
 
+    /// SC-R-027 — a fractional float onto an integer format is a range mismatch that errors, not truncates.
     #[test]
     fn ut_bridge_typed_float_fractional_onto_int_format_errors() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -618,6 +624,7 @@ mod tests {
         );
     }
 
+    /// SC-R-027 — a string register write is applied via the encode path and reads back as its value.
     #[test]
     fn ut_bridge_typed_string_roundtrip() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -630,6 +637,7 @@ mod tests {
         }
     }
 
+    /// SC-R-027 — a nil register write is rejected rather than silently coerced.
     #[test]
     fn ut_bridge_typed_nil_errors_cleanly() {
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
@@ -641,7 +649,7 @@ mod tests {
 
     #[test]
     fn ut_bridge_typed_int_overflow_errors_cleanly() {
-        // "setpoint" is U16 (max 65535); a too-large Int must error, not silently truncate.
+        // SC-R-027 — "setpoint" is U16 (max 65535); a too-large Int must error, not silently truncate.
         let bridge = RegisterBridge::new(evse_memory(), vstore(), Arc::new(evse_registers()));
         assert!(
             bridge
@@ -681,6 +689,7 @@ mod tests {
         }
     }
 
+    /// SC-R-027 — a nil write to a virtual register is rejected rather than coerced.
     #[test]
     fn ut_bridge_virtual_typed_nil_errors_cleanly() {
         let virtual_store = vstore();

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -407,6 +407,7 @@ mod tests {
     // The demo session script must at least parse and run cleanly against an empty module
     // registry (no modules -> the loop body never executes, so C_Log is never touched).
     #[test]
+    /// SC-R-020 — the demo session-level script runs against the module registry.
     fn ut_demo_session_script_runs_on_empty_registry() {
         let script = demo_session_script();
         assert!(script.enabled);

--- a/ferrowl/src/migrate.rs
+++ b/ferrowl/src/migrate.rs
@@ -549,6 +549,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-041 — migration swaps the legacy holding/input read codes.
     fn ut_migrate_read_code_swap() {
         assert_eq!(migrate_read_code(1).unwrap(), Kind::Coil);
         assert_eq!(migrate_read_code(2).unwrap(), Kind::DiscreteInput);
@@ -557,12 +558,14 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-044 — an unknown read code skips that register with a warning.
     fn ut_migrate_read_code_invalid() {
         assert!(migrate_read_code(0).is_err());
         assert!(migrate_read_code(5).is_err());
     }
 
     #[test]
+    /// CS-R-041 — a trailing `le` type suffix splits into an explicit little-endian byte order.
     fn ut_parse_le_type() {
         let (vt, endian) = parse_type("F32le").unwrap();
         assert_eq!(vt, ValueType::F32);
@@ -574,6 +577,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-041 — legacy ascii type subtypes are parsed by the migration transform.
     fn ut_parse_ascii_types() {
         for t in &["PackedAscii", "LooseAscii", "PackedUtf8", "LooseUtf8"] {
             let (vt, _) = parse_type(t).unwrap();
@@ -582,6 +586,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-041 — a hex address is parsed during migration.
     fn ut_address_hex_parse() {
         assert_eq!(
             LegacyAddress::Str("0x1000".into()).resolve().unwrap(),
@@ -592,6 +597,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-041 — a bare legacy value is named during the migration transform.
     fn ut_bare_value_gets_integer_name() {
         let mut warnings = Vec::new();
         let values = convert_values(
@@ -612,6 +618,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-044 — a per-register conversion error warns and does not panic, letting the rest proceed.
     fn ut_convert_def_invalid_read_code_warns_no_panic() {
         let def = LegacyRegisterDef {
             slave_id: 1,
@@ -643,6 +650,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-041 — a full legacy sample migrates through the transformation contract.
     fn ut_convert_full_sample() {
         let (device, warnings) = convert(legacy_sample());
 

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -360,8 +360,8 @@ mod tests {
         )
     }
 
-    /// MB-R-021 — parsed input carries the register's display resolution (non-numeric input falls through to ASCII).
     #[test]
+    /// MB-R-021 — parsed input carries the register's display resolution (non-numeric input falls through to ASCII).
     fn ut_str_to_value_uses_register_resolution() {
         use super::str_to_value;
         use ferrowl_codec::Value;
@@ -397,10 +397,10 @@ mod tests {
         }
     }
 
+    #[test]
     /// MB-R-081 — poll operations are derived from the registers, excluding write-only ones and grouping
     /// by (slave, read function code); different function codes never merge, and batches split at the
     /// per-request limit (MB-R-085) snapped to a register boundary (MB-R-086).
-    #[test]
     fn ut_build_read_operations_batches() {
         use super::build_read_operations;
         use crate::config::device::ReadRanges;
@@ -453,9 +453,9 @@ mod tests {
         assert_eq!((ops[1].range.start(), ops[1].range.end()), (120, 128));
     }
 
+    #[test]
     /// MB-R-083 — with explicit `read_ranges`, registers inside one range are read by a single request
     /// trimmed to their extent (bridging gaps), and registers outside every range are read on their own.
-    #[test]
     fn ut_explicit_read_ranges() {
         use super::build_read_operations;
         use crate::config::device::ReadRanges;
@@ -521,8 +521,8 @@ mod tests {
     }
 
     // Replicates the server `:set`/edit write path + the table decode read path.
-    /// MB-R-090 — writing a value to a fixed-address register on a server read-modify-writes it into the store, observable on read-back.
     #[test]
+    /// MB-R-090 — writing a value to a fixed-address register on a server read-modify-writes it into the store, observable on read-back.
     fn ut_server_value_write_roundtrip() {
         let mut memory: Memory<Key<SlaveKey>> = Memory::default();
         let key = Key {

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -360,6 +360,7 @@ mod tests {
         )
     }
 
+    /// MB-R-021 — parsed input carries the register's display resolution (non-numeric input falls through to ASCII).
     #[test]
     fn ut_str_to_value_uses_register_resolution() {
         use super::str_to_value;
@@ -396,6 +397,9 @@ mod tests {
         }
     }
 
+    /// MB-R-081 — poll operations are derived from the registers, excluding write-only ones and grouping
+    /// by (slave, read function code); different function codes never merge, and batches split at the
+    /// per-request limit (MB-R-085) snapped to a register boundary (MB-R-086).
     #[test]
     fn ut_build_read_operations_batches() {
         use super::build_read_operations;
@@ -449,6 +453,8 @@ mod tests {
         assert_eq!((ops[1].range.start(), ops[1].range.end()), (120, 128));
     }
 
+    /// MB-R-083 — with explicit `read_ranges`, registers inside one range are read by a single request
+    /// trimmed to their extent (bridging gaps), and registers outside every range are read on their own.
     #[test]
     fn ut_explicit_read_ranges() {
         use super::build_read_operations;
@@ -515,6 +521,7 @@ mod tests {
     }
 
     // Replicates the server `:set`/edit write path + the table decode read path.
+    /// MB-R-090 — writing a value to a fixed-address register on a server read-modify-writes it into the store, observable on read-back.
     #[test]
     fn ut_server_value_write_roundtrip() {
         let mut memory: Memory<Key<SlaveKey>> = Memory::default();

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -478,6 +478,7 @@ mod tests {
         );
     }
 
+    /// MB-R-077 — a register definition maps to its kind, memory cell type, and format width for store construction.
     #[test]
     fn ut_register_mapping() {
         let def = &sample().definitions["setpoint"];
@@ -486,6 +487,7 @@ mod tests {
         assert_eq!(def.format().width(), 1);
     }
 
+    /// MB-R-083 — read-range config parses inclusive bounds into address ranges, skipping malformed/reversed entries.
     #[test]
     fn ut_parse_ranges() {
         // Inclusive bounds; bare address = single-cell range; whitespace tolerated.
@@ -500,6 +502,7 @@ mod tests {
         assert_eq!(parse_ranges("9-3,4"), vec![Range::new(4, 1)]);
     }
 
+    /// MB-R-014 — a configured bit-field mask derives its shift from the trailing-zero count; absent/garbage yields the full mask.
     #[test]
     fn ut_parse_bitmask() {
         assert_eq!(parse_bitmask(Some("0xFF00")).mask, 0xFF00);
@@ -511,6 +514,7 @@ mod tests {
         assert!(parse_bitmask(Some("nonsense")).is_full());
     }
 
+    /// MB-R-017 — a bit-field mask threads into an integer format but float formats ignore it (full no-op mask).
     #[test]
     fn ut_bitmask_threaded_into_format() {
         let mut def = sample().definitions["setpoint"].clone();
@@ -546,6 +550,7 @@ mod tests {
         }
     }
 
+    /// MB-R-083 — explicit read ranges are configured per function code and resolved to that code's ranges.
     #[test]
     fn ut_read_ranges_is_empty_and_ranges_for() {
         let mut rr = ReadRanges::default();
@@ -616,6 +621,7 @@ mod tests {
         ));
     }
 
+    /// MB-R-078 — a register definition's kind fixes its memory cell type (coil vs register) across every value type.
     #[test]
     fn ut_register_def_kind_mem_type_and_all_formats() {
         for kind in [
@@ -657,6 +663,7 @@ mod tests {
         }
     }
 
+    /// MB-R-080 — a virtual register (or the `virtual` flag over a fixed address) occupies no store range; a fixed one does.
     #[test]
     fn ut_register_def_address_range_and_register() {
         let fixed = def_with(ValueType::U16, Kind::HoldingRegister, Some(10), false);

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -386,6 +386,7 @@ mod tests {
         }
     }
 
+    /// SC-R-025 — legacy per-register `update` snippets migrate into named, enabled script entries.
     #[test]
     fn ut_migrate_update_scripts() {
         let mut cfg = sample();
@@ -440,6 +441,7 @@ mod tests {
 
     // An old-format device config file (predating `script_interval`) must still load, with
     // `script_interval` defaulting to 1.0.
+    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     #[test]
     fn ut_device_config_loads_without_script_interval_field() {
         let path = std::env::temp_dir().join("ferrowl_device_no_script_interval.toml");
@@ -451,6 +453,7 @@ mod tests {
 
     // A hand-edited `script_interval` that is NaN, negative, or zero must fall back to the
     // 1.0s default instead of panicking or busy-waiting; a valid value converts as-is.
+    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     #[test]
     fn ut_device_config_script_interval_duration_sanitized() {
         let mut cfg = sample();
@@ -468,6 +471,7 @@ mod tests {
         }
     }
 
+    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     #[test]
     fn ut_device_config_script_interval_duration_floored() {
         let mut cfg = sample();

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -219,7 +219,7 @@ impl ToLabel for NamedValue {
 }
 
 fn default_kind() -> Kind {
-    Kind::InputRegister
+    Kind::HoldingRegister
 }
 
 fn default_resolution() -> f64 {
@@ -683,6 +683,7 @@ mod tests {
         );
     }
 
+    /// MB-R-097 — a register definition with no `kind` defaults to holding register (resolution 1.0, length 1).
     #[test]
     fn ut_register_def_serde_defaults() {
         // A minimal definition omitting kind/resolution/length triggers the default fns.
@@ -690,7 +691,7 @@ mod tests {
         let path = path.to_str().unwrap();
         std::fs::write(path, "type = \"U16\"\n").unwrap();
         let def: RegisterDef = Converter::load(path, FileType::Toml).unwrap();
-        assert_eq!(def.kind, Kind::InputRegister);
+        assert_eq!(def.kind, Kind::HoldingRegister);
         assert_eq!(def.resolution, 1.0);
         assert_eq!(def.length, 1);
     }

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -386,8 +386,8 @@ mod tests {
         }
     }
 
-    /// SC-R-025 — legacy per-register `update` snippets migrate into named, enabled script entries.
     #[test]
+    /// SC-R-025 — legacy per-register `update` snippets migrate into named, enabled script entries.
     fn ut_migrate_update_scripts() {
         let mut cfg = sample();
         cfg.scripts.clear();
@@ -444,8 +444,8 @@ mod tests {
 
     // An old-format device config file (predating `script_interval`) must still load, with
     // `script_interval` defaulting to 1.0.
-    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     #[test]
+    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     fn ut_device_config_loads_without_script_interval_field() {
         let path = std::env::temp_dir().join("ferrowl_device_no_script_interval.toml");
         let path = path.to_str().unwrap();
@@ -456,8 +456,8 @@ mod tests {
 
     // A hand-edited `script_interval` that is NaN, negative, or zero must fall back to the
     // 1.0s default instead of panicking or busy-waiting; a valid value converts as-is.
-    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     #[test]
+    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     fn ut_device_config_script_interval_duration_sanitized() {
         let mut cfg = sample();
         cfg.script_interval = 0.25;
@@ -474,8 +474,8 @@ mod tests {
         }
     }
 
-    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     #[test]
+    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     fn ut_device_config_script_interval_duration_floored() {
         let mut cfg = sample();
         cfg.script_interval = 0.0001;
@@ -485,8 +485,8 @@ mod tests {
         );
     }
 
-    /// MB-R-077 — a register definition maps to its kind, memory cell type, and format width for store construction.
     #[test]
+    /// MB-R-077 — a register definition maps to its kind, memory cell type, and format width for store construction.
     fn ut_register_mapping() {
         let def = &sample().definitions["setpoint"];
         assert!(matches!(def.kind(), Kind::HoldingRegister));
@@ -494,8 +494,8 @@ mod tests {
         assert_eq!(def.format().width(), 1);
     }
 
-    /// MB-R-083 — read-range config parses inclusive bounds into address ranges, skipping malformed/reversed entries.
     #[test]
+    /// MB-R-083 — read-range config parses inclusive bounds into address ranges, skipping malformed/reversed entries.
     fn ut_parse_ranges() {
         // Inclusive bounds; bare address = single-cell range; whitespace tolerated.
         assert_eq!(
@@ -509,8 +509,8 @@ mod tests {
         assert_eq!(parse_ranges("9-3,4"), vec![Range::new(4, 1)]);
     }
 
-    /// MB-R-014 — a configured bit-field mask derives its shift from the trailing-zero count; absent/garbage yields the full mask.
     #[test]
+    /// MB-R-014 — a configured bit-field mask derives its shift from the trailing-zero count; absent/garbage yields the full mask.
     fn ut_parse_bitmask() {
         assert_eq!(parse_bitmask(Some("0xFF00")).mask, 0xFF00);
         assert_eq!(parse_bitmask(Some("0xFF00")).shift(), 8);
@@ -521,8 +521,8 @@ mod tests {
         assert!(parse_bitmask(Some("nonsense")).is_full());
     }
 
-    /// MB-R-017 — a bit-field mask threads into an integer format but float formats ignore it (full no-op mask).
     #[test]
+    /// MB-R-017 — a bit-field mask threads into an integer format but float formats ignore it (full no-op mask).
     fn ut_bitmask_threaded_into_format() {
         let mut def = sample().definitions["setpoint"].clone();
         def.bitmask = Some("0x0FF0".to_string());
@@ -557,8 +557,8 @@ mod tests {
         }
     }
 
-    /// MB-R-083 — explicit read ranges are configured per function code and resolved to that code's ranges.
     #[test]
+    /// MB-R-083 — explicit read ranges are configured per function code and resolved to that code's ranges.
     fn ut_read_ranges_is_empty_and_ranges_for() {
         let mut rr = ReadRanges::default();
         assert!(rr.is_empty());
@@ -628,8 +628,8 @@ mod tests {
         ));
     }
 
-    /// MB-R-078 — a register definition's kind fixes its memory cell type (coil vs register) across every value type.
     #[test]
+    /// MB-R-078 — a register definition's kind fixes its memory cell type (coil vs register) across every value type.
     fn ut_register_def_kind_mem_type_and_all_formats() {
         for kind in [
             Kind::Coil,
@@ -670,8 +670,8 @@ mod tests {
         }
     }
 
-    /// MB-R-080 — a virtual register (or the `virtual` flag over a fixed address) occupies no store range; a fixed one does.
     #[test]
+    /// MB-R-080 — a virtual register (or the `virtual` flag over a fixed address) occupies no store range; a fixed one does.
     fn ut_register_def_address_range_and_register() {
         let fixed = def_with(ValueType::U16, Kind::HoldingRegister, Some(10), false);
         assert_eq!(fixed.address(), Address::Fixed(10));
@@ -690,8 +690,8 @@ mod tests {
         );
     }
 
-    /// MB-R-097 — a register definition with no `kind` defaults to holding register (resolution 1.0, length 1).
     #[test]
+    /// MB-R-097 — a register definition with no `kind` defaults to holding register (resolution 1.0, length 1).
     fn ut_register_def_serde_defaults() {
         // A minimal definition omitting kind/resolution/length triggers the default fns.
         let path = std::env::temp_dir().join("ferrowl_codecdef_min.toml");

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -418,11 +418,13 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — a device config round-trips through TOML with no field loss.
     fn ut_device_roundtrip_toml() {
         roundtrip(FileType::Toml, "toml");
     }
 
     #[test]
+    /// CS-R-004 — a device config round-trips through JSON with no field loss.
     fn ut_device_roundtrip_json() {
         roundtrip(FileType::Json, "json");
     }
@@ -431,6 +433,7 @@ mod tests {
     /// load, falling back to `None` (which `ModbusModule::resolve_timing` then maps to
     /// `DEFAULT_RECONNECT`).
     #[test]
+    /// CS-R-023 — a device config predating the reconnect field loads with its default.
     fn ut_device_config_loads_without_reconnect_field() {
         let path = std::env::temp_dir().join("ferrowl_device_no_reconnect.toml");
         let path = path.to_str().unwrap();

--- a/ferrowl/src/module/modbus/config/session.rs
+++ b/ferrowl/src/module/modbus/config/session.rs
@@ -206,6 +206,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-033 — a session file round-trips its module instances, scripts, and interval.
     fn ut_session_roundtrip() {
         let original = sample();
         for (ty, ext) in [(FileType::Toml, "toml"), (FileType::Json, "json")] {
@@ -220,6 +221,7 @@ mod tests {
     // An old-format session file (predating `scripts`/`interval`) must still load, with
     // `scripts` defaulting to empty and `interval` to 1.0.
     #[test]
+    /// CS-R-012 — a module entry with no `type` tag loads as modbus.
     fn ut_session_old_format_compat() {
         let json = r#"{"modules":[]}"#;
         let session: Session = serde_json::from_str(json).unwrap();
@@ -230,6 +232,7 @@ mod tests {
     // A hand-edited `interval` that is NaN, negative, or zero must fall back to the 1.0s
     // default instead of panicking or busy-waiting; a valid value converts as-is.
     #[test]
+    /// CS-R-017 — a non-finite/non-positive session interval falls back to 1.0s (no floor).
     fn ut_session_interval_duration_sanitized() {
         let mut session = Session::default();
         assert_eq!(session.interval_duration(), Duration::from_secs(1));

--- a/ferrowl/src/module/modbus/log.rs
+++ b/ferrowl/src/module/modbus/log.rs
@@ -89,6 +89,7 @@ pub(crate) fn append(sink: &FileSink, line: &str) {
 #[cfg(test)]
 mod tests {
     #[test]
+    /// UI-R-045 — the module file-sink path is derived from the base path and module name.
     fn ut_module_log_path() {
         use super::module_log_path;
         assert_eq!(
@@ -106,6 +107,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-045 — opening a file sink in a nonexistent directory errors.
     fn ut_open_sink_error_on_nonexistent_dir() {
         use super::{FileSink, open_sink};
 
@@ -118,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-045 — a file sink opens against a valid directory.
     fn ut_open_sink_success_with_valid_dir() {
         use super::{FileSink, open_sink};
 
@@ -138,6 +141,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-045 — a None base path clears the file sink.
     fn ut_open_sink_clears_on_none_base() {
         use super::{FileSink, open_sink};
 

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -413,6 +413,7 @@ impl ModbusModule {
 mod tests {
     use ferrowl_codec::Kind;
 
+    /// MB-R-087 — effective timing uses the device config's values when set, otherwise the built-in defaults.
     #[test]
     fn ut_resolve_timing_fallback() {
         use super::ModbusModule;
@@ -501,6 +502,7 @@ mod tests {
         }
     }
 
+    /// MB-R-076 — a module instance is a TCP server owning one store, register set, and log; register-cache edits rebuild it (MB-R-088).
     #[test]
     fn ut_module_new_tcp_server_and_sync_accessors() {
         use super::ModbusModule;
@@ -543,6 +545,7 @@ mod tests {
         );
     }
 
+    /// MB-R-076 — a module instance can be an RTU client, building its register set from the device config.
     #[test]
     fn ut_module_new_rtu_client() {
         use super::ModbusModule;

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -413,8 +413,8 @@ impl ModbusModule {
 mod tests {
     use ferrowl_codec::Kind;
 
-    /// MB-R-087 — effective timing uses the device config's values when set, otherwise the built-in defaults.
     #[test]
+    /// MB-R-087 — effective timing uses the device config's values when set, otherwise the built-in defaults.
     fn ut_resolve_timing_fallback() {
         use super::ModbusModule;
         use crate::config::DeviceConfig;
@@ -502,8 +502,8 @@ mod tests {
         }
     }
 
-    /// MB-R-076 — a module instance is a TCP server owning one store, register set, and log; register-cache edits rebuild it (MB-R-088).
     #[test]
+    /// MB-R-076 — a module instance is a TCP server owning one store, register set, and log; register-cache edits rebuild it (MB-R-088).
     fn ut_module_new_tcp_server_and_sync_accessors() {
         use super::ModbusModule;
         use crate::config::{Endpoint, ModuleSpec, Role};
@@ -545,8 +545,8 @@ mod tests {
         );
     }
 
-    /// MB-R-076 — a module instance can be an RTU client, building its register set from the device config.
     #[test]
+    /// MB-R-076 — a module instance can be an RTU client, building its register set from the device config.
     fn ut_module_new_rtu_client() {
         use super::ModbusModule;
         use crate::config::{Endpoint, ModuleSpec, Role};
@@ -682,8 +682,8 @@ mod tests {
         false
     }
 
-    /// SC-R-026 — a Modbus sim runs from construction on an enabled script, with no network start.
     #[test]
+    /// SC-R-026 — a Modbus sim runs from construction on an enabled script, with no network start.
     fn ut_sim_starts_at_construction_without_network_start() {
         use super::ModbusModule;
 
@@ -695,8 +695,8 @@ mod tests {
         assert!(wait_for_marker(&module, 7));
     }
 
-    /// SC-R-011 — with no enabled script (empty or disabled), no sim thread is spawned.
     #[test]
+    /// SC-R-011 — with no enabled script (empty or disabled), no sim thread is spawned.
     fn ut_sim_not_started_when_no_enabled_scripts() {
         use super::ModbusModule;
 
@@ -709,8 +709,8 @@ mod tests {
         assert!(!module.lua_running());
     }
 
-    /// SC-R-024 — reloading with no enabled script stops the running sim and leaves it stopped.
     #[test]
+    /// SC-R-024 — reloading with no enabled script stops the running sim and leaves it stopped.
     fn ut_reload_scripts_all_disabled_stops_sim() {
         use super::ModbusModule;
 
@@ -722,8 +722,8 @@ mod tests {
         assert!(!module.lua_running());
     }
 
-    /// SC-R-024 — toggling a script on via reload starts a fresh sim thread.
     #[test]
+    /// SC-R-024 — toggling a script on via reload starts a fresh sim thread.
     fn ut_reload_scripts_toggle_on_starts_sim() {
         use super::ModbusModule;
 
@@ -739,8 +739,8 @@ mod tests {
         assert!(wait_for_marker(&module, 7));
     }
 
-    /// SC-R-024 — editing a script restarts the sim on a fresh Lua context so the new code takes over.
     #[test]
+    /// SC-R-024 — editing a script restarts the sim on a fresh Lua context so the new code takes over.
     fn ut_reload_scripts_changed_code_takes_effect() {
         use super::ModbusModule;
 
@@ -757,8 +757,8 @@ mod tests {
         assert!(wait_for_marker(&module, 2));
     }
 
-    /// SC-R-026 — starting or stopping the network instance leaves the sim thread running.
     #[tokio::test]
+    /// SC-R-026 — starting or stopping the network instance leaves the sim thread running.
     async fn ut_network_stop_leaves_sim_running() {
         use super::ModbusModule;
 
@@ -774,8 +774,8 @@ mod tests {
 
     // Confirms the log-ring split (stage 5): Lua `print()`/`C_Log` output lands only in
     // `script_log`, never in the module's general `log` (connection/status/traffic lines).
-    /// SC-R-031 — Modbus sim print/C_Log output goes to the module's script log, not its connection log.
     #[test]
+    /// SC-R-031 — Modbus sim print/C_Log output goes to the module's script log, not its connection log.
     fn ut_lua_output_lands_in_script_log_not_general_log() {
         use super::ModbusModule;
 

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -682,6 +682,7 @@ mod tests {
         false
     }
 
+    /// SC-R-026 — a Modbus sim runs from construction on an enabled script, with no network start.
     #[test]
     fn ut_sim_starts_at_construction_without_network_start() {
         use super::ModbusModule;
@@ -694,6 +695,7 @@ mod tests {
         assert!(wait_for_marker(&module, 7));
     }
 
+    /// SC-R-011 — with no enabled script (empty or disabled), no sim thread is spawned.
     #[test]
     fn ut_sim_not_started_when_no_enabled_scripts() {
         use super::ModbusModule;
@@ -707,6 +709,7 @@ mod tests {
         assert!(!module.lua_running());
     }
 
+    /// SC-R-024 — reloading with no enabled script stops the running sim and leaves it stopped.
     #[test]
     fn ut_reload_scripts_all_disabled_stops_sim() {
         use super::ModbusModule;
@@ -719,6 +722,7 @@ mod tests {
         assert!(!module.lua_running());
     }
 
+    /// SC-R-024 — toggling a script on via reload starts a fresh sim thread.
     #[test]
     fn ut_reload_scripts_toggle_on_starts_sim() {
         use super::ModbusModule;
@@ -735,6 +739,7 @@ mod tests {
         assert!(wait_for_marker(&module, 7));
     }
 
+    /// SC-R-024 — editing a script restarts the sim on a fresh Lua context so the new code takes over.
     #[test]
     fn ut_reload_scripts_changed_code_takes_effect() {
         use super::ModbusModule;
@@ -752,6 +757,7 @@ mod tests {
         assert!(wait_for_marker(&module, 2));
     }
 
+    /// SC-R-026 — starting or stopping the network instance leaves the sim thread running.
     #[tokio::test]
     async fn ut_network_stop_leaves_sim_running() {
         use super::ModbusModule;
@@ -768,6 +774,7 @@ mod tests {
 
     // Confirms the log-ring split (stage 5): Lua `print()`/`C_Log` output lands only in
     // `script_log`, never in the module's general `log` (connection/status/traffic lines).
+    /// SC-R-031 — Modbus sim print/C_Log output goes to the module's script log, not its connection log.
     #[test]
     fn ut_lua_output_lands_in_script_log_not_general_log() {
         use super::ModbusModule;

--- a/ferrowl/src/module/modbus/setup.rs
+++ b/ferrowl/src/module/modbus/setup.rs
@@ -99,6 +99,7 @@ mod tests {
     // to delegate to the dialog's close-confirm popup, or the creation overlay's Esc/Enter would
     // silently do nothing for a Modbus module setup.
     #[test]
+    /// UI-R-023 — the module setup delegates close-requested to the dialog's close-request flag.
     fn ut_close_requested_delegates_to_dialog_take_close_request() {
         let mut sv = ModbusSetupView::new_create();
         assert!(!sv.close_requested());

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -847,6 +847,7 @@ mod tests {
     /// Typing into the config-path field opens the filesystem suggestion popup, and the
     /// popup is drawn on top of the dialog by the trailing `render_overlay` calls in `render`.
     #[test]
+    /// UI-R-026 — the config-path field shows a completion popup.
     fn ut_render_config_path_field_shows_suggestion_popup() {
         let mut dialog = SetupDialog::create(Timing {
             timeout_ms: 0,
@@ -869,6 +870,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — the setup dialog resolves a reconnect-off selection into the config value.
     fn ut_resolve_reconnect_off_maps_to_some_false() {
         let mut dialog = SetupDialog::create(Timing {
             timeout_ms: 0,
@@ -884,6 +886,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server-role setup resolves to no reconnect setting.
     fn ut_resolve_server_role_reports_no_reconnect() {
         // Reconnect is hidden for servers; resolving must not report a value for a setting the
         // user never saw, so applying it can't clobber the device config's existing setting.
@@ -900,6 +903,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — Edit mode pre-fills the dialog from the existing config.
     fn ut_edit_prefills_reconnect_off() {
         let timing = Timing {
             timeout_ms: 100,
@@ -925,6 +929,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — the focus cycle skips the reconnect field when it is disabled for a server role.
     fn ut_focus_next_skips_reconnect_for_server_role() {
         let mut dialog = SetupDialog::create(Timing {
             timeout_ms: 0,
@@ -950,6 +955,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter sets the close request, which clears after being taken.
     fn ut_take_close_request_set_via_esc_enter_and_cleared_after_take() {
         let mut dialog = SetupDialog::create(default_timing());
         assert!(!dialog.take_close_request());
@@ -961,6 +967,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into a setup text field rather than entering command mode.
     fn ut_colon_in_text_input_types() {
         let mut dialog = SetupDialog::create(default_timing());
         // Default focus is Name, a free-text field; `:` is typed as ordinary text.
@@ -969,6 +976,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm keeps the setup dialog open.
     fn ut_esc_in_confirm_keeps_setup_open() {
         let mut dialog = SetupDialog::create(default_timing());
         dialog.handle_events(KeyModifiers::NONE, KeyCode::Esc);
@@ -979,6 +987,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Space in the close-confirm closes the setup dialog.
     fn ut_space_in_confirm_closes() {
         let mut dialog = SetupDialog::create(default_timing());
         dialog.handle_events(KeyModifiers::NONE, KeyCode::Esc);

--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -308,12 +308,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — an unchanged register row carries no change-highlight cell style.
     fn ut_no_change_has_no_cell_styles() {
         let d = definition();
         assert!(d.cell_styles().iter().all(Option::is_none));
     }
 
     #[test]
+    /// UI-R-046 — a recently-changed register value highlights its row for a brief window.
     fn ut_recent_change_highlights_full_row() {
         let mut d = definition();
         d.changed_at = Some(Instant::now());
@@ -321,6 +323,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — the change highlight expires after its window.
     fn ut_highlight_expires_after_window() {
         let mut d = definition();
         d.changed_at = Instant::now().checked_sub(CHANGE_HIGHLIGHT + Duration::from_secs(1));

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -1015,6 +1015,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — a fixed register's live value decodes from its memory word for display.
     fn ut_decode_definition_fixed_reads_memory_word() {
         let def = fixed_def();
         let mut memory = Memory::<Key<SlaveKey>>::default();
@@ -1037,6 +1038,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — a fixed register with no memory decodes to a zero display value.
     fn ut_decode_definition_fixed_missing_memory_defaults_to_zero() {
         let def = fixed_def();
         let memory = Memory::<Key<SlaveKey>>::default();
@@ -1046,6 +1048,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — a virtual register's live value comes from the virtual store.
     fn ut_decode_definition_virtual_uses_store_value() {
         let def = virtual_def();
         let memory = Memory::<Key<SlaveKey>>::default();
@@ -1057,6 +1060,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — a virtual register with no value renders blank.
     fn ut_decode_definition_virtual_missing_value_is_blank() {
         let def = virtual_def();
         let memory = Memory::<Key<SlaveKey>>::default();
@@ -1067,6 +1071,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — the first value fill is not counted as a change (no highlight).
     fn ut_decode_definition_first_fill_is_not_a_change() {
         let def = fixed_def();
         let memory = Memory::<Key<SlaveKey>>::default();
@@ -1079,6 +1084,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-046 — a changed value stamps its change time to drive the highlight window.
     fn ut_decode_definition_value_change_stamps_changed_at() {
         let mut memory = Memory::<Key<SlaveKey>>::default();
         let key = Key {
@@ -1104,12 +1110,14 @@ mod tests {
     // --- view construction & key handling -----------------------------------
 
     #[test]
+    /// UI-R-021 — a new view starts with no overlay open.
     fn ut_new_view_starts_with_no_overlay() {
         let view = new_view();
         assert!(!view.is_overlay_active());
     }
 
     #[test]
+    /// UI-R-021 — Enter on an empty table opens no overlay.
     fn ut_enter_on_empty_table_does_not_open_overlay() {
         // No registers selected -> open_edit returns early without an overlay.
         let mut view = new_view();
@@ -1119,6 +1127,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-018 — the `:scripts` command is handled by the view, opening the script overlay.
     fn ut_scripts_command_opens_overlay_and_close_applies() {
         let mut view = new_view();
         drop(view.handle_command("script"));
@@ -1141,6 +1150,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-018 — the `:edit` command is handled by the view, opening the setup overlay.
     fn ut_edit_command_opens_setup_overlay() {
         let mut view = new_view();
         drop(view.handle_command("edit"));
@@ -1148,6 +1158,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Tab cycles focus through the setup overlay fields.
     fn ut_setup_overlay_tab_cycles_focus_via_derive() {
         // Regression for the `#[derive(Overlay)]` port: `Setup` is tagged `focus_cycle`, so Tab
         // must still advance the dialog's own focus once the dialog itself leaves the key
@@ -1169,6 +1180,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Shift+Tab cycles the setup overlay focus in reverse.
     fn ut_setup_overlay_backtab_cycles_focus_reverse() {
         use ferrowl_ui::traits::IsFocus;
         let mut view = new_view();
@@ -1184,6 +1196,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-021 — an open register overlay consumes table-navigation keys.
     fn ut_register_overlay_swallows_table_navigation_key() {
         // Regression: while the register overlay is open, `Down` must be consumed by the
         // overlay's own dispatch (untagged -> bespoke `handle_overlay_key`), not fall through to
@@ -1202,6 +1215,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Enter confirms the edit dialog after field routing.
     fn ut_enter_still_confirms_edit_dialog_after_offer_first_routing() {
         // Regression for the offer-first key-routing refactor: the setup dialog is now offered
         // every key before the default Esc/Enter/Tab/BackTab handling runs, but Enter must still
@@ -1216,6 +1230,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc opens the close-confirm rather than closing the setup overlay.
     fn ut_esc_does_not_close_setup_overlay() {
         let mut view = new_view();
         drop(view.handle_command("edit"));
@@ -1229,6 +1244,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter closes the setup overlay.
     fn ut_esc_then_enter_closes_setup_overlay() {
         let mut view = new_view();
         drop(view.handle_command("edit"));
@@ -1240,6 +1256,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-018 — the `:add` command is handled by the view, opening the register-add overlay.
     fn ut_add_command_opens_add_overlay() {
         let mut view = new_view();
         drop(view.handle_command("add"));
@@ -1253,6 +1270,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-018 — the `:compact` command toggles the table's compact flag.
     fn ut_compact_command_toggles_table_compact_flag() {
         let mut view = new_view();
         assert!(!view.table.compact);
@@ -1320,6 +1338,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc opens the close-confirm rather than closing the register overlay.
     fn ut_esc_does_not_close_register_overlay() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1339,6 +1358,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter closes the register overlay.
     fn ut_esc_then_enter_closes_register_overlay() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1351,6 +1371,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into the value input rather than entering command mode.
     fn ut_colon_in_value_input_types() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1363,6 +1384,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the delete-confirm still cancels.
     fn ut_confirm_delete_esc_still_cancels() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1379,6 +1401,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the named-value sub-dialog still cancels.
     fn ut_named_value_subdialog_esc_still_cancels() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1392,6 +1415,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-021 — Enter on a named-value register opens the selection overlay.
     fn ut_enter_on_named_value_register_opens_selection_overlay() {
         let mut view = view_for(device_with_defs());
         view.table.select_first();
@@ -1449,6 +1473,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-016 — `:set` argument parsing splits on the first whitespace.
     fn ut_parse_set_args_unquoted_splits_on_first_whitespace() {
         assert_eq!(parse_set_args("reg 123"), ("reg".into(), "123".into()));
         // Extra leading whitespace before the value is trimmed.
@@ -1458,6 +1483,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-016 — a quoted `:set` name keeps its inner spaces.
     fn ut_parse_set_args_quoted_name_keeps_inner_spaces() {
         assert_eq!(
             parse_set_args("\"my reg\" 456"),
@@ -1475,6 +1501,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// UI-R-024 — applying a server-role setup preserves the existing reconnect setting.
     async fn ut_apply_setup_server_role_preserves_existing_reconnect() {
         // Reconnect is hidden/unset (None) for Server-role dialog saves; applying it must not
         // clobber whatever the device config already had for a setting the user never saw.

--- a/ferrowl/src/module/ocpp/action_dialog.rs
+++ b/ferrowl/src/module/ocpp/action_dialog.rs
@@ -851,6 +851,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-021 — Enter on an argument row opens the value editor sub-overlay.
     fn enter_on_row_opens_value_editor() {
         let mut d = dialog();
         assert!(d.editor.is_none());
@@ -954,6 +955,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc on the action dialog returns no close (opens the confirm).
     fn esc_returns_none() {
         let mut d = dialog();
         assert!(d.input(KeyModifiers::NONE, KeyCode::Esc).is_none());
@@ -963,6 +965,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter on the action dialog returns close.
     fn esc_then_enter_returns_close() {
         let mut d = dialog();
         assert!(d.input(KeyModifiers::NONE, KeyCode::Esc).is_none());
@@ -974,6 +977,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Space on the focused Send button sends and keeps the dialog open.
     fn space_on_send_returns_send_keep() {
         let mut d = dialog();
         while d.focus != ActionDialogFocus::Send {
@@ -986,6 +990,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Space off the Send button does not send.
     fn space_elsewhere_does_not_send() {
         let mut d = dialog();
         assert!(d.focus == ActionDialogFocus::Table);
@@ -993,6 +998,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc cancels only the value editor, not the whole dialog.
     fn value_editor_esc_still_cancels_editor_only() {
         let mut d = dialog();
         d.input(KeyModifiers::NONE, KeyCode::Enter); // open value editor for selected row
@@ -1002,6 +1008,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` inserts into the JSON editor in Insert mode.
     fn json_insert_colon_inserts() {
         let mut d = dialog();
         d.toggle_mode();
@@ -1020,6 +1027,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc from JSON Insert mode returns to Normal without opening the confirm.
     fn json_insert_esc_goes_normal_no_confirm() {
         let mut d = dialog();
         d.toggle_mode();
@@ -1041,6 +1049,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` in JSON Normal mode is consumed by the editor, opening no command line.
     fn json_normal_colon_consumed_by_editor() {
         let mut d = dialog();
         d.toggle_mode();
@@ -1054,6 +1063,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm keeps the action dialog open.
     fn esc_in_confirm_keeps_dialog() {
         let mut d = dialog();
         d.input(KeyModifiers::NONE, KeyCode::Esc);
@@ -1065,6 +1075,7 @@ mod tests {
     // --- #[derive(Focus)] cycle characterization --------------------------
 
     #[test]
+    /// UI-R-022 — Tab cycles table → toggle → Send in table mode.
     fn tab_cycles_table_toggle_send_in_table_mode() {
         let mut d = dialog();
         assert_eq!(d.focus, ActionDialogFocus::Table);
@@ -1080,6 +1091,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — Tab cycles JSON → Send, skipping the disabled toggle in JSON-only mode.
     fn tab_cycles_json_send_skipping_toggle_in_json_only_mode() {
         let mut d = ActionDialog::json_only("Custom".into(), "{}");
         assert_eq!(d.focus, ActionDialogFocus::Json);
@@ -1093,6 +1105,7 @@ mod tests {
     // Sanctioned behavior change: pressing Toggle no longer jumps focus back to the fields;
     // it stays on the Toggle button, and the next Tab now routes through Json instead of Table.
     #[test]
+    /// UI-R-022 — toggling keeps focus, then Tab routes through the JSON editor.
     fn toggle_keeps_focus_then_tab_routes_through_json() {
         let mut d = dialog();
         d.input(KeyModifiers::NONE, KeyCode::Tab); // Table -> Toggle

--- a/ferrowl/src/module/ocpp/action_dialog.rs
+++ b/ferrowl/src/module/ocpp/action_dialog.rs
@@ -729,6 +729,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-089 — a typed dialog assembles a flat property table with each property's kind and prefill source.
     fn assemble_coerces_kinds_and_prefills_state() {
         let mut d = dialog();
         // connectorId prefilled from state (number), idTag from constant, optional note omitted.
@@ -754,6 +755,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-093 — a nested action (SetChargingProfile) is driven by a typed dialog whose custom assembler folds flat fields into the nested request.
     fn set_charging_profile_charging_rate_unit_in_table() {
         let s = crate::module::ocpp::spec::v1_6::action_spec("SetChargingProfile").unwrap();
         let mut d = ActionDialog::new("SetChargingProfile".into(), &s, |_| None, || "t".into());
@@ -764,6 +766,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-089 — a typed property is coerced to its declared kind (integer vs float) when assembled.
     fn number_coercion_int_vs_float() {
         assert_eq!(ActionDialog::coerce(PropKind::Number, "3"), Some(json!(3)));
         assert_eq!(
@@ -778,6 +781,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-089 — a property with a "now" prefill source is populated from current state.
     fn now_prefill_is_nonempty() {
         const TS: &[PropSpec] = &[PropSpec {
             name: "expiryDate",
@@ -799,6 +803,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-092 — a typed dialog's raw-JSON mode is prefilled from the current property rows.
     fn json_toggle_matches_assembled_rows() {
         let mut d = dialog();
         let assembled = d.payload().unwrap();
@@ -808,6 +813,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-094 — a payload that fails to decode against the version's request type is reported and not sent.
     fn malformed_json_aborts_send_and_sets_error() {
         let mut d = ActionDialog::json_only("Custom".into(), "{}");
         d.json.state.set_content("{ \"a\": 1, }"); // trailing comma: invalid JSON
@@ -826,6 +832,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-094 — a payload that decodes against the version's request type clears the error and is sent.
     fn valid_json_send_clears_error_and_sends() {
         let mut d = ActionDialog::json_only("Custom".into(), "{}");
         d.json_error = Some("stale error from a previous attempt".into());
@@ -852,6 +859,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-094 — the assembled payload is validated by decoding against the version's request type before it is sent.
     fn send_button_emits_decodable_payload() {
         // Drive a real spec end-to-end: assemble must decode into the typed action.
         let s = crate::module::ocpp::spec::v1_6::action_spec("ChangeAvailability").unwrap();
@@ -868,6 +876,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-093 — a typed dialog's custom assembler folds flat fields into a nested SetChargingProfile request that decodes.
     fn nested_set_charging_profile_decodes() {
         let s = crate::module::ocpp::spec::v1_6::action_spec("SetChargingProfile").unwrap();
         let mut d = ActionDialog::new(
@@ -886,6 +895,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-093 — a typed dialog's custom assembler builds a nested SendLocalList request that decodes.
     fn nested_send_local_list_single_entry_decodes() {
         let s = crate::module::ocpp::spec::v1_6::action_spec("SendLocalList").unwrap();
         let mut d = ActionDialog::new(
@@ -900,6 +910,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-092 — a nested typed dialog's raw-JSON mode round-trips with its assembled rows.
     fn nested_json_toggle_round_trips() {
         let s = crate::module::ocpp::spec::v1_6::action_spec("SetChargingProfile").unwrap();
         let mut d = ActionDialog::new("SetChargingProfile".into(), &s, |_| None, || "t".into());
@@ -910,6 +921,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-093 — a typed dialog's custom assembler builds a nested NotifyEvent request that decodes.
     fn nested_notify_event_single_entry_decodes() {
         use ferrowl_ocpp::V2_0_1;
         let s = crate::module::ocpp::spec::v2_0_1::action_spec("NotifyEvent").unwrap();

--- a/ferrowl/src/module/ocpp/client/backend.rs
+++ b/ferrowl/src/module/ocpp/client/backend.rs
@@ -416,6 +416,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    /// OC-R-060 — the CS heartbeat cadence uses the interval the CSMS returned in its BootNotification response.
     fn boot_interval_prefers_csms_value() {
         let resp =
             json!({ "currentTime": "2026-01-01T00:00:00Z", "interval": 120, "status": "Accepted" });
@@ -423,6 +424,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-060 — the heartbeat cadence falls back to 30 s when the CSMS interval is absent or zero.
     fn boot_interval_falls_back_on_zero_or_absent() {
         // Zero is treated as "unset" so the caller uses DEFAULT_HEARTBEAT_SECS.
         assert_eq!(boot_interval(&json!({ "interval": 0 })), None);
@@ -431,6 +433,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-087 — the in-memory message log is bounded to the most recent 200 messages, evicting oldest-first.
     fn push_capped_evicts_oldest_beyond_limit() {
         let mut buf = Vec::new();
         for _ in 0..(MAX_MESSAGES + 50) {
@@ -447,6 +450,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-078 — each recorded message renders its direction, status, and payload for display and logging.
     fn log_line_renders_direction_status_and_payload() {
         let m = OcppMessage::new(
             Dir::In,

--- a/ferrowl/src/module/ocpp/client/config.rs
+++ b/ferrowl/src/module/ocpp/client/config.rs
@@ -232,6 +232,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter sets the close request, which clears after being taken.
     fn ut_take_close_request_set_via_esc_enter_and_cleared_after_take() {
         let mut dialog = dialog();
         assert!(!dialog.take_close_request());
@@ -243,6 +244,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm keeps the config dialog open.
     fn ut_esc_in_confirm_keeps_open() {
         let mut dialog = dialog();
         dialog.handle_events(KeyModifiers::NONE, KeyCode::Esc);
@@ -253,6 +255,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into a config text field rather than entering command mode.
     fn ut_colon_in_text_input_types() {
         let mut dialog = dialog();
         // Default focus is Key, a free-text field; `:` must be typed as ordinary text.

--- a/ferrowl/src/module/ocpp/client/v1_6/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/handler.rs
@@ -473,6 +473,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    /// OC-R-063 — an inbound Call naming a connector this CS does not have is rejected with PropertyConstraintViolation.
     fn ut_unknown_connector_rejected() {
         let mut s = CsState::default();
         s.connectors.clear();
@@ -536,6 +537,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a reservation is recorded at the connector level the request targets.
     fn ut_reserve_now_targets_connector_not_cs() {
         let h = handler_with(two_connectors());
         drive(
@@ -556,6 +558,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — connector id 0 records the reservation at the charge-point level (OC-R-063: id 0 is the charge point).
     fn ut_reserve_now_connector_zero_is_cs_level() {
         let h = handler_with(CsState::default());
         drive(
@@ -571,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a cancellation carrying the same reservation id clears the reservation at whichever level holds it.
     fn ut_cancel_reservation_clears_matching_connector() {
         let h = handler_with(two_connectors());
         drive(
@@ -586,6 +590,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-063 — connector id 0 means the charge point itself, so ChangeAvailability at 0 targets every connector.
     fn ut_change_availability_status_and_zero_targets_all() {
         let h = handler_with(two_connectors());
         drive(
@@ -604,6 +609,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-070 — a remote start mints a transaction id and sets the connector charging; a remote stop clears it and returns to available.
     fn ut_remote_start_then_stop_transaction() {
         let h = handler_with(two_connectors());
         drive(
@@ -624,6 +630,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-068 — clearing charging profiles with no purpose erases every per-purpose limit on the connector.
     fn ut_clear_profile_and_unlock_connector() {
         let mut s = two_connectors();
         s.connector_mut(1).unwrap().limit = Some(16.0);
@@ -636,6 +643,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-068 — clearing charging profiles by purpose erases only the per-purpose limit matching that criterion.
     fn ut_clear_profile_erases_only_named_purpose() {
         let mut s = two_connectors();
         {
@@ -684,6 +692,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-067 — a charging-profile installation whose stack level exceeds the configured maximum is rejected.
     fn ut_set_charging_profile_rejects_above_max_stack() {
         // Default config seeds ChargeProfileMaxStackLevel = 10.
         let h = handler_with(two_connectors());
@@ -700,6 +709,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-067 — an accepted charging profile applies its limit to the targeted connector under the field matching its purpose.
     fn ut_set_charging_profile_routes_by_purpose() {
         let h = handler_with(two_connectors());
         drive(&h, "SetChargingProfile", set_profile("TxProfile", 0, 16.0));
@@ -721,6 +731,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-072 — ending a transaction clears only the transaction-scoped limit; the default and maximum limits persist.
     fn ut_stop_clears_only_tx_limit() {
         let mut s = two_connectors();
         {

--- a/ferrowl/src/module/ocpp/client/v1_6/state.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/state.rs
@@ -477,6 +477,7 @@ mod tests {
     use ferrowl_lua::module::ValueType as Vt;
 
     #[test]
+    /// OC-R-061 — the CS builds a MeterValues request from a connector's live transaction state that decodes as valid.
     fn ut_meter_values_payload_decodes() {
         use ferrowl_ocpp::{V1_6, Version};
         // The full measurand/unit set (incl. Frequency/Temperature/SoC) must decode as a typed
@@ -490,6 +491,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-058 — each connector carries its own metering/status/transaction/limit/tag/reservation fields.
     fn ut_connector_get_set_field_roundtrip() {
         let mut c = ConnectorState::new(1);
         // Numeric set accepts int or float; string fields accept strings.
@@ -505,6 +507,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-057 — the CS maintains charge-point-wide state plus a list of connector states.
     fn ut_cs_level_field_roundtrip_and_connectors() {
         let mut s = CsState::default();
         assert!(s.cs_set_field("Model", Vt::String("M".into())));

--- a/ferrowl/src/module/ocpp/client/v2_0_1/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v2_0_1/handler.rs
@@ -489,6 +489,7 @@ mod tests {
     use parking_lot::RwLock;
 
     #[test]
+    /// OC-R-063 — an inbound Call naming an EVSE this CS does not have is rejected with PropertyConstraintViolation.
     fn ut_unknown_evse_rejected() {
         let mut s = CsState::default();
         s.connectors.clear();
@@ -503,6 +504,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-078 — an inbound Call is tagged with the connector/EVSE scope it belongs to for recording.
     fn ut_inbound_scope_keyed_by_evse_only() {
         // A nested connectorId is ignored: the scope is keyed by EVSE id with connector `None`.
         assert_eq!(
@@ -568,6 +570,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a reservation is recorded at the EVSE level the request targets.
     fn ut_reserve_now_targets_evse_not_cs() {
         let h = handler_with(two_evses());
         drive(
@@ -585,6 +588,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a reservation with no EVSE is recorded at the charge-point level.
     fn ut_reserve_now_without_evse_is_cs_level() {
         let h = handler_with(two_evses());
         drive(
@@ -600,6 +604,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a cancellation carrying the same reservation id clears the reservation at whichever level holds it.
     fn ut_cancel_reservation_clears_matching_evse() {
         let h = handler_with(two_evses());
         drive(
@@ -616,6 +621,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-063 — an absent EVSE id means the charge point itself, so ChangeAvailability targets every connector.
     fn ut_change_availability_status_and_absent_evse_targets_all() {
         let h = handler_with(two_evses());
         drive(
@@ -637,6 +643,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-070 — a remote start mints a transaction id and sets the EVSE charging; a remote stop clears it and returns to available.
     fn ut_request_start_then_stop_transaction() {
         let h = handler_with(two_evses());
         drive(
@@ -658,6 +665,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-068 — clearing charging profiles erases the per-purpose limit(s) on the targeted EVSE.
     fn ut_clear_profile_and_unlock_by_evse() {
         let mut s = two_evses();
         s.connector_mut_by_evse(1).unwrap().limit = Some(16.0);

--- a/ferrowl/src/module/ocpp/client/v2_0_1/state.rs
+++ b/ferrowl/src/module/ocpp/client/v2_0_1/state.rs
@@ -507,6 +507,7 @@ mod tests {
     use ferrowl_lua::module::ValueType as Vt;
 
     #[test]
+    /// OC-R-061 — the 2.0.1 CS builds a MeterValues request from a connector's live transaction state that decodes as valid.
     fn ut_meter_values_payload_decodes() {
         use ferrowl_ocpp::{V2_0_1, Version};
         let c = ConnectorState::new(1, 1);
@@ -518,6 +519,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-058 — each 2.0.1 connector carries its own EVSE-keyed metering/status/transaction/limit/tag/reservation fields.
     fn ut_connector_get_set_field_evse_id() {
         let mut c = ConnectorState::new(1, 1);
         assert!(c.set_field("EvseId", Vt::Int(2)));
@@ -528,6 +530,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-057 — the 2.0.1 CS maintains charge-point-wide state plus a list of connector states.
     fn ut_cs_level_and_connectors() {
         let mut s = CsState::default();
         assert!(s.cs_set_field("Model", Vt::String("M".into())));

--- a/ferrowl/src/module/ocpp/client/v2_1/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v2_1/handler.rs
@@ -543,6 +543,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a reservation is recorded at the EVSE level the request targets.
     fn ut_reserve_now_targets_evse_not_cs() {
         let h = handler_with(two_evses());
         drive(
@@ -560,6 +561,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a reservation with no EVSE is recorded at the charge-point level.
     fn ut_reserve_now_without_evse_is_cs_level() {
         let h = handler_with(two_evses());
         drive(
@@ -575,6 +577,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-069 — a cancellation carrying the same reservation id clears the reservation at whichever level holds it.
     fn ut_cancel_reservation_clears_matching_evse() {
         let h = handler_with(two_evses());
         drive(
@@ -591,6 +594,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-063 — an absent EVSE id means the charge point itself, so ChangeAvailability targets every connector.
     fn ut_change_availability_status_and_absent_evse_targets_all() {
         let h = handler_with(two_evses());
         drive(
@@ -612,6 +616,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-070 — a remote start mints a transaction id and sets the EVSE charging; a remote stop clears it and returns to available.
     fn ut_request_start_then_stop_transaction() {
         let h = handler_with(two_evses());
         drive(
@@ -633,6 +638,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-068 — clearing charging profiles erases the per-purpose limit(s) on the targeted EVSE.
     fn ut_clear_profile_and_unlock_by_evse() {
         let mut s = two_evses();
         s.connector_mut_by_evse(1).unwrap().limit = Some(16.0);

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -768,11 +768,13 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-049 — the 1.6 client view's focus cycle includes the payload pane.
     fn focus_cycle_includes_payload_pane_v1_6() {
         assert_focus_cycle::<V1_6>(OcppVersion::V1_6);
     }
 
     #[test]
+    /// UI-R-049 — the 2.0.1 client view's focus cycle includes the payload pane.
     fn focus_cycle_includes_payload_pane_v2_0_1() {
         assert_focus_cycle::<V2_0_1>(OcppVersion::V2_0_1);
     }
@@ -855,6 +857,7 @@ mod tests {
     // --- Esc-confirm migration: Setup / Config overlays --------------------------------------
 
     #[test]
+    /// UI-R-023 — Esc opens the close-confirm on the setup overlay; Enter closes it.
     fn setup_overlay_esc_opens_confirm_enter_closes() {
         let mut v = client_view::<V1_6>(OcppVersion::V1_6);
         v.overlay = ClientOverlay::Setup(Box::new(OcppSetupDialog::new()));
@@ -871,6 +874,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc opens the close-confirm on the config overlay; Enter closes it.
     fn config_overlay_esc_opens_confirm_enter_closes() {
         let mut v = client_view::<V1_6>(OcppVersion::V1_6);
         v.overlay = ClientOverlay::Config(Box::new(ConfigEditDialog::new(

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -258,6 +258,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — an OCPP device config round-trips through TOML and JSON.
     fn ut_device_config_roundtrip() {
         let cfg = OcppDeviceConfig {
             version: Some("0.1.0".into()),
@@ -323,6 +324,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-023 — an OCPP device config predating the security section loads with its default.
     fn ut_device_config_without_security_section_still_parses() {
         // Pre-existing config files (written before Security Profiles were added) have no
         // `security` table/key at all; `#[serde(default)]` must fill it in as the all-`None`
@@ -392,6 +394,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-004 — new security fields round-trip through TOML and JSON.
     fn ut_security_config_new_fields_round_trip() {
         let cfg = OcppSecurityConfig {
             self_signed: true,

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -249,8 +249,8 @@ mod tests {
     use super::*;
     use ferrowl_util::convert::{Converter, FileType};
 
-    /// SC-R-022 — a script entry with no `enabled` flag defaults to enabled.
     #[test]
+    /// SC-R-022 — a script entry with no `enabled` flag defaults to enabled.
     fn ut_script_enabled_defaults_true() {
         // A file entry without an `enabled` flag deserializes as active.
         let s: ScriptDef = serde_json::from_str(r#"{"name":"a","code":"x = 1"}"#).unwrap();
@@ -345,8 +345,8 @@ mod tests {
 
     // An old-format device config file (predating `script_interval`) must still load, with
     // `script_interval` defaulting to 1.0.
-    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     #[test]
+    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     fn ut_device_config_loads_without_script_interval_field() {
         let json = serde_json::json!({
             "ocpp_version": "1.6",
@@ -358,8 +358,8 @@ mod tests {
 
     // A hand-edited `script_interval` that is NaN, negative, or zero must fall back to the
     // 1.0s default instead of panicking or busy-waiting; a valid value converts as-is.
-    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     #[test]
+    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     fn ut_device_config_script_interval_duration_sanitized() {
         let mut cfg = OcppDeviceConfig::default();
         assert_eq!(
@@ -380,8 +380,8 @@ mod tests {
         }
     }
 
-    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     #[test]
+    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     fn ut_device_config_script_interval_duration_floored() {
         let cfg = OcppDeviceConfig {
             script_interval: 0.0001,

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -249,6 +249,7 @@ mod tests {
     use super::*;
     use ferrowl_util::convert::{Converter, FileType};
 
+    /// SC-R-022 — a script entry with no `enabled` flag defaults to enabled.
     #[test]
     fn ut_script_enabled_defaults_true() {
         // A file entry without an `enabled` flag deserializes as active.
@@ -342,6 +343,7 @@ mod tests {
 
     // An old-format device config file (predating `script_interval`) must still load, with
     // `script_interval` defaulting to 1.0.
+    /// SC-R-016 — an absent script_interval resolves to the 1.0s default.
     #[test]
     fn ut_device_config_loads_without_script_interval_field() {
         let json = serde_json::json!({
@@ -354,6 +356,7 @@ mod tests {
 
     // A hand-edited `script_interval` that is NaN, negative, or zero must fall back to the
     // 1.0s default instead of panicking or busy-waiting; a valid value converts as-is.
+    /// SC-R-016 — a non-finite or non-positive script_interval falls back to the 1.0s default.
     #[test]
     fn ut_device_config_script_interval_duration_sanitized() {
         let mut cfg = OcppDeviceConfig::default();
@@ -375,6 +378,7 @@ mod tests {
         }
     }
 
+    /// SC-R-016 — a per-module script_interval is floored to 0.05s.
     #[test]
     fn ut_device_config_script_interval_duration_floored() {
         let cfg = OcppDeviceConfig {

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -404,6 +404,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-096 — a wss CSMS with no server cert/key files uses `self_signed` for its TLS material.
     fn ut_csms_tls_self_signed_without_cert_files() {
         let cfg = OcppSecurityConfig {
             self_signed: true,
@@ -414,6 +415,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-096 — explicit server cert + key files take precedence over `self_signed` for a wss CSMS.
     fn ut_csms_tls_explicit_files_win_over_self_signed() {
         let cfg = OcppSecurityConfig {
             self_signed: true,
@@ -426,6 +428,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-036 — a CS TLS configuration carries the `insecure_skip_verify` flag.
     fn ut_cs_tls_carries_insecure_skip_verify() {
         let cfg = OcppSecurityConfig {
             insecure_skip_verify: true,
@@ -438,6 +441,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-081 — the device config carries the module's Lua scripts (not the session entry).
     fn ut_from_spec_carries_scripts() {
         let spec = OcppSpec {
             name: "cs-1".into(),

--- a/ferrowl/src/module/ocpp/config/session.rs
+++ b/ferrowl/src/module/ocpp/config/session.rs
@@ -197,6 +197,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// OC-R-081 — the session entry carries the endpoint (scheme, ip, port, path), from which the connection URL is built.
     fn ut_protocol_display_and_url() {
         let spec = OcppSpec {
             name: "cs-1".into(),
@@ -272,6 +273,7 @@ mod tests {
     // A wss endpoint without TLS material must never yield `None` (would bind plain TCP):
     // it falls back to the ephemeral self-signed mode.
     #[test]
+    /// OC-R-095 — a wss CSMS with no TLS material configured falls back to an ephemeral self-signed certificate.
     fn ut_effective_csms_tls_wss_without_material_falls_back_to_self_signed() {
         let spec = spec_with(OcppProtocol::Wss, Default::default());
         assert!(spec.csms_self_signed_fallback());
@@ -281,6 +283,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-042 — a ws:// CSMS endpoint binds plain TCP; the endpoint scheme is authoritative for the transport.
     fn ut_effective_csms_tls_ws_stays_plain() {
         let spec = spec_with(OcppProtocol::Ws, Default::default());
         assert!(!spec.csms_self_signed_fallback());
@@ -290,6 +293,7 @@ mod tests {
     // The scheme wins: a ws endpoint binds plain TCP even with certificate files configured, so
     // the URL never advertises a transport the listener doesn't speak.
     #[test]
+    /// OC-R-042 — a ws:// CSMS endpoint leaves any configured TLS material inert.
     fn ut_effective_csms_tls_ws_ignores_configured_certificates() {
         let security = crate::config::ocpp::OcppSecurityConfig {
             cert_file: Some("certs/csms.pem".into()),
@@ -301,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-096 — explicit server cert + key files take precedence over the ephemeral self-signed fallback.
     fn ut_effective_csms_tls_explicit_files_win_over_fallback() {
         let security = crate::config::ocpp::OcppSecurityConfig {
             cert_file: Some("certs/csms.pem".into()),

--- a/ferrowl/src/module/ocpp/config/session.rs
+++ b/ferrowl/src/module/ocpp/config/session.rs
@@ -233,6 +233,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-011 — an OCPP module entry round-trips carrying its self-describing `type` tag.
     fn ut_spec_roundtrip_with_type_tag() {
         let spec = OcppSpec {
             name: "cs-1".into(),

--- a/ferrowl/src/module/ocpp/scope.rs
+++ b/ferrowl/src/module/ocpp/scope.rs
@@ -64,6 +64,7 @@ impl Scope {
 mod tests {
     use super::Scope;
 
+    /// OC-R-078 — a message scope labels the charge point, a 1.6 connector, or a 2.0.1 EVSE/connector for display and logging.
     #[test]
     fn ut_scope_label_and_is_connector() {
         assert_eq!(Scope::CS.label(), "");

--- a/ferrowl/src/module/ocpp/scope.rs
+++ b/ferrowl/src/module/ocpp/scope.rs
@@ -64,8 +64,8 @@ impl Scope {
 mod tests {
     use super::Scope;
 
-    /// OC-R-078 — a message scope labels the charge point, a 1.6 connector, or a 2.0.1 EVSE/connector for display and logging.
     #[test]
+    /// OC-R-078 — a message scope labels the charge point, a 1.6 connector, or a 2.0.1 EVSE/connector for display and logging.
     fn ut_scope_label_and_is_connector() {
         assert_eq!(Scope::CS.label(), "");
         assert!(!Scope::CS.is_connector());

--- a/ferrowl/src/module/ocpp/server/backend.rs
+++ b/ferrowl/src/module/ocpp/server/backend.rs
@@ -294,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-074 — the CSMS maintains charge-point-wide and per-connector RFID accept-lists, deduplicating entries.
     fn ut_add_remove_dedup() {
         let mut s = RfidStore::default();
         assert!(s.add(Scope::CS, "A".into()));
@@ -306,6 +307,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-075 — an empty effective accept-set (nothing listed anywhere) accepts every tag.
     fn ut_empty_everywhere_accepts_all() {
         let s = store(&[]);
         assert!(cs_authorized(&s, "ANY"));
@@ -313,6 +315,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-076 — a charge-point-wide authorization is checked against the cp-wide list unioned with every connector list.
     fn ut_cs_authorize_unions_all_connectors() {
         let s = store(&["CS"]);
         with_rfids_mut(&s, |s| s.add(Scope::connector(2), "CONN2".into()));
@@ -324,6 +327,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-074 — a connector's effective accept-set is its own list unioned with the charge-point-wide list.
     fn ut_scope_authorize_inherits_cs_only() {
         let s = store(&["CS"]);
         with_rfids_mut(&s, |s| s.add(Scope::connector(1), "CONN1".into()));

--- a/ferrowl/src/module/ocpp/server/detail.rs
+++ b/ferrowl/src/module/ocpp/server/detail.rs
@@ -662,6 +662,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// OC-R-066 — a config-update merges into existing keys and appends new ones in the CS detail view.
     fn merge_config_updates_existing_and_appends_new() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("A".into(), "1".into(), false);
@@ -677,6 +678,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — the connector detail overlay's focus cycle omits the config-key pane.
     fn connector_overlay_has_no_key_pane() {
         let mut d = DetailOverlay::new("CP".into(), Scope::connector(1), false);
         assert!(!d.is_cs);
@@ -688,6 +690,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — the CS detail overlay's focus cycle reaches the config-key pane.
     fn cs_overlay_reaches_key_pane() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         assert!(d.is_cs);
@@ -762,6 +765,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — the detail overlay's focus cycle includes the RFID panes.
     fn focus_cycle_includes_rfid_panes() {
         // CS flat (component_col=false): State -> Cfg -> KeyInput -> Rfid -> RfidInput -> wrap.
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
@@ -789,6 +793,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — the CS detail focus cycle includes the component column.
     fn focus_cycle_cs_component_col() {
         // CS with a Component column: State -> Cfg4 -> KeyInput -> Rfid -> RfidInput -> wrap.
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, true);
@@ -816,6 +821,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-066 — the CS config table shows a readonly column per key.
     fn config_table_shows_readonly_column() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("A".into(), "1".into(), true);
@@ -831,6 +837,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-066 — deleting removes the selected config key.
     fn delete_removes_selected_config_key() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("A".into(), "1".into(), false);
@@ -842,6 +849,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-066 — refetching the selected config key requests a fetch.
     fn refetch_selected_config_key_requests_fetch() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("HeartbeatInterval".into(), "30".into(), false);
@@ -851,6 +859,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-021 — Enter on a config key opens the value dialog, then emits a set request.
     fn enter_on_config_opens_value_dialog_then_set_request() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("HeartbeatInterval".into(), "30".into(), false);
@@ -883,6 +892,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc on the detail overlay returns no close (opens the confirm).
     fn esc_returns_none() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         assert!(d.input(KeyModifiers::NONE, KeyCode::Esc).is_none());
@@ -892,6 +902,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter on the detail overlay returns close.
     fn esc_then_enter_returns_close() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         assert!(d.input(KeyModifiers::NONE, KeyCode::Esc).is_none());
@@ -903,6 +914,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc cancels the set-value sub-dialog.
     fn set_value_dialog_esc_cancels() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.merge_config("HeartbeatInterval".into(), "30".into(), false);
@@ -914,6 +926,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into the RFID input rather than entering command mode.
     fn colon_in_rfid_input_types() {
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, false);
         d.focus = DetailOverlayFocus::RfidInput;

--- a/ferrowl/src/module/ocpp/server/lua.rs
+++ b/ferrowl/src/module/ocpp/server/lua.rs
@@ -312,6 +312,7 @@ mod tests {
     type Cs = <V1_6 as ServerVersion>::Cs;
     type Conn = <V1_6 as ServerVersion>::Conn;
 
+    /// SC-R-021 — a server module's C_OCPP bridge enumerates stations and routes Get/Set/action by identity.
     #[test]
     fn ut_server_host_resolves_and_routes_by_identity() {
         let states: SharedServerStates<V1_6> = Arc::new(RwLock::new(ServerStates::default()));

--- a/ferrowl/src/module/ocpp/server/lua.rs
+++ b/ferrowl/src/module/ocpp/server/lua.rs
@@ -312,8 +312,8 @@ mod tests {
     type Cs = <V1_6 as ServerVersion>::Cs;
     type Conn = <V1_6 as ServerVersion>::Conn;
 
-    /// SC-R-021 — a server module's C_OCPP bridge enumerates stations and routes Get/Set/action by identity.
     #[test]
+    /// SC-R-021 — a server module's C_OCPP bridge enumerates stations and routes Get/Set/action by identity.
     fn ut_server_host_resolves_and_routes_by_identity() {
         let states: SharedServerStates<V1_6> = Arc::new(RwLock::new(ServerStates::default()));
         with_state_mut(&states, |reg| {

--- a/ferrowl/src/module/ocpp/server/v1_6/handler.rs
+++ b/ferrowl/src/module/ocpp/server/v1_6/handler.rs
@@ -144,6 +144,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-073 — the CSMS answers BootNotification with a crafted response carrying the current time and a heartbeat interval.
     async fn ut_boot_response_and_inbound_event() {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let handler = CsmsHandler16::new(tx, empty_rfids());
@@ -160,6 +161,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-073 — the CSMS answers a transaction start with a freshly minted, unique transaction id plus an accept/reject status.
     async fn ut_start_transaction_mints_unique_txids() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handler = CsmsHandler16::new(tx, empty_rfids());
@@ -186,6 +188,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-076 — an authorization (naming no connector) is checked against the charge-point-wide list unioned with every connector list.
     async fn ut_authorize_gated_by_rfid_list() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let store = RfidStore {
@@ -208,6 +211,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-076 — a transaction start (naming a connector) is checked against that connector's effective set only.
     async fn ut_start_transaction_gated_per_connector() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         // CONN1 is allowed only on connector 1; the inherited CS tag is allowed anywhere.
@@ -251,6 +255,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-075 — an empty effective accept-set accepts every tag.
     async fn ut_empty_rfid_list_accepts_all() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handler = CsmsHandler16::new(tx, empty_rfids());

--- a/ferrowl/src/module/ocpp/server/v1_6/mod.rs
+++ b/ferrowl/src/module/ocpp/server/v1_6/mod.rs
@@ -107,6 +107,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    /// OC-R-078 — an inbound Call is tagged with the charge-point/connector scope it belongs to.
     fn ut_inbound_connector_scope() {
         assert_eq!(
             V1_6::inbound_connector("StatusNotification", &json!({ "connectorId": 2 })),
@@ -124,6 +125,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-078 — an outbound Call is tagged with the connector scope it targets, defaulting the connector id.
     fn ut_inject_scope_defaults_connector_id() {
         // A connector-scoped Lua payload gets the connector id when it lacks one.
         let mut p = json!({});
@@ -144,6 +146,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-065 — a GetConfiguration naming keys targets those keys; naming none targets every key.
     fn ut_config_request_all_vs_single() {
         assert_eq!(V1_6::config_request(""), json!({}));
         assert_eq!(
@@ -153,6 +156,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-065 — a GetConfiguration request's key list is parsed to select which configuration keys are read.
     fn ut_parse_get_configuration() {
         let resp = json!({
             "configurationKey": [

--- a/ferrowl/src/module/ocpp/server/v1_6/state.rs
+++ b/ferrowl/src/module/ocpp/server/v1_6/state.rs
@@ -471,6 +471,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// OC-R-077 — the CSMS observes a station's connectors from inbound MeterValues traffic and tracks their state.
     fn ut_connector_meter_values_update_state() {
         let mut s = ConnectorState::default();
         let req = serde_json::json!({
@@ -491,6 +492,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-077 — the CSMS derives a connector's observed state, tracked per connection rather than pre-configured.
     fn ut_connector_derive_payload() {
         let mut s = ConnectorState::default();
         s.apply_inbound(
@@ -518,6 +520,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-067 — an accepted charging profile is mirrored into the targeted connector under the field matching its purpose.
     fn ut_apply_outbound_mirrors_accepted_profile_by_purpose() {
         let mut s = ConnectorState::default();
         let profile = |purpose: &str, limit: f64| {
@@ -556,6 +559,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-072 — ending a transaction clears only the transaction-scoped limit; the default and maximum limits persist.
     fn ut_limit_fields_are_readonly_and_stop_clears_only_tx() {
         let mut s = ConnectorState::default();
         // The mirror fields reject writes via the Lua/edit path.
@@ -577,6 +581,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-077 — the CSMS observes and derives charge-point-level state from inbound traffic.
     fn ut_cs_level_boot_and_derive() {
         let mut s = CsLevelState::default();
         s.apply_inbound(

--- a/ferrowl/src/module/ocpp/server/v2_0_1/handler.rs
+++ b/ferrowl/src/module/ocpp/server/v2_0_1/handler.rs
@@ -105,6 +105,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-076 — a 2.0.1 authorization is checked against the charge-point-wide list unioned with every EVSE list.
     async fn ut_authorize_gated_by_rfid_list() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let store = RfidStore {
@@ -125,6 +126,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-075 — an empty effective accept-set accepts every tag.
     async fn ut_empty_rfid_list_accepts_all() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let handler = CsmsHandler::new(tx, rfids(RfidStore::default()));
@@ -136,6 +138,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-076 — a transaction event (naming an EVSE) is checked against that EVSE's effective set only.
     async fn ut_transaction_event_gated_per_evse() {
         let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         // EVSE1 allows ETAG only on evse 1; the inherited CS tag is allowed anywhere.

--- a/ferrowl/src/module/ocpp/server/v2_0_1/mod.rs
+++ b/ferrowl/src/module/ocpp/server/v2_0_1/mod.rs
@@ -82,6 +82,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    /// OC-R-078 — an inbound 2.0.1 Call is tagged with the charge-point/EVSE scope it belongs to.
     fn ut_inbound_connector_scope() {
         // Connectors are bucketed by EVSE id only — a nested `connectorId` is ignored, so two
         // connectors on the same EVSE map to the same (connector-less) scope.
@@ -109,6 +110,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-078 — an outbound 2.0.1 Call is tagged with the EVSE scope it targets, defaulting the EVSE id.
     fn ut_inject_scope_defaults_evse_id() {
         // A connector-scoped Lua payload gets the EVSE id when it lacks one.
         let mut p = json!({});
@@ -138,6 +140,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-065 — a 2.0.1 GetVariables request splits into component/variable targets to select which keys are read.
     fn ut_config_request_splits_component_variable() {
         let req = V2_0_1::config_request("OCPPCommCtrlr/HeartbeatInterval");
         assert_eq!(
@@ -155,6 +158,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-065 — a 2.0.1 GetVariables request's key list is parsed to select which configuration keys are read.
     fn ut_parse_get_variables() {
         let resp = json!({
             "getVariableResult": [

--- a/ferrowl/src/module/ocpp/server/v2_0_1/state.rs
+++ b/ferrowl/src/module/ocpp/server/v2_0_1/state.rs
@@ -475,6 +475,7 @@ mod tests {
     use super::*;
 
     #[test]
+    /// OC-R-077 — the 2.0.1 CSMS observes a station's EVSEs from inbound MeterValues traffic and tracks their state.
     fn ut_connector_meter_values_update_state() {
         let mut s = ConnectorState::default();
         let req = serde_json::json!({
@@ -495,6 +496,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-077 — the 2.0.1 CSMS derives an EVSE's observed state, tracked per connection rather than pre-configured.
     fn ut_connector_derive_payload() {
         let mut s = ConnectorState::default();
         s.apply_inbound(
@@ -527,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-067 — an accepted charging profile is mirrored into the targeted EVSE under the field matching its purpose.
     fn ut_apply_outbound_mirrors_accepted_profile_by_purpose() {
         let mut s = ConnectorState::default();
         let profile = |purpose: &str, limit: f64| {
@@ -571,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-072 — ending a transaction clears only the transaction-scoped limit; the default and maximum limits persist.
     fn ut_limit_fields_are_readonly_and_stop_clears_only_tx() {
         let mut s = ConnectorState::default();
         // The mirror fields reject writes via the Lua/edit path.
@@ -592,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-077 — the 2.0.1 CSMS observes and derives charge-point-level state from inbound traffic.
     fn ut_cs_level_boot_and_derive() {
         let mut s = CsLevelState::default();
         s.apply_inbound(

--- a/ferrowl/src/module/ocpp/server/view/mod.rs
+++ b/ferrowl/src/module/ocpp/server/view/mod.rs
@@ -616,6 +616,7 @@ mod tests {
     // `start(&spec, ..)` — and stops the old listener so the next start rebinds with the edited
     // endpoint/security (e.g. wss + Basic Auth no longer leaves a plain unauthenticated listener).
     #[tokio::test]
+    /// UI-R-024 — applying an edit updates the module spec and stops its listener.
     async fn ut_edit_apply_updates_spec_and_stops_listener() {
         let mut v = server_view();
         let mut edited = v.spec.clone();
@@ -632,6 +633,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-049 — the server view's focus cycle includes the payload pane.
     fn focus_cycle_includes_payload_pane() {
         let mut v = server_view();
         // CsTable -> Scripts -> Actions -> Messages -> Payload -> CsTable.
@@ -672,6 +674,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-021 — opening detail builds an overlay for the selected entry.
     fn open_detail_builds_overlay_for_selected_entry() {
         let mut v = server_view();
         // Add a CS-level entry and select its row.
@@ -842,6 +845,7 @@ mod tests {
     // --- Esc-confirm migration: Setup overlay; Confirm keeps Esc ----------------------------
 
     #[test]
+    /// UI-R-023 — Esc opens the close-confirm on the setup overlay; Enter closes it.
     fn setup_overlay_esc_opens_confirm_enter_closes() {
         let mut v = server_view();
         v.overlay = ServerOverlay::Setup(Box::new(
@@ -860,6 +864,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — the confirm overlay still closes on Esc.
     fn confirm_overlay_still_closes_on_esc() {
         let mut v = server_view();
         v.overlay = ServerOverlay::Confirm(Box::new(ConfirmDeleteDialog::new("CP1")));
@@ -871,6 +876,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-013 — syncing actions preserves the table selection when nothing is selected.
     fn sync_actions_preserves_selection_when_no_entry_selected() {
         let mut v = server_view();
         // First sync builds the CS-level action list.

--- a/ferrowl/src/module/ocpp/setup.rs
+++ b/ferrowl/src/module/ocpp/setup.rs
@@ -100,6 +100,7 @@ mod tests {
     // to delegate to the dialog's close-confirm popup, or the creation overlay's Esc→confirm
     // flow would silently do nothing for an OCPP module setup.
     #[test]
+    /// UI-R-023 — the OCPP setup delegates close-requested to the dialog's close-request flag.
     fn ut_close_requested_delegates_to_dialog_take_close_request() {
         let mut sv = OcppSetupView::new();
         assert!(!sv.close_requested());
@@ -127,6 +128,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a ws setup preserves the loaded security config on resolve.
     fn ut_ws_preserves_loaded_security() {
         let mut loaded = OcppDeviceConfig {
             security: OcppSecurityConfig {
@@ -142,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a wss setup resolves the dialog's security config over the loaded one.
     fn ut_wss_overwrites_loaded_security_with_dialog() {
         let mut loaded = OcppDeviceConfig {
             security: OcppSecurityConfig {

--- a/ferrowl/src/module/ocpp/setup_dialog.rs
+++ b/ferrowl/src/module/ocpp/setup_dialog.rs
@@ -975,6 +975,7 @@ mod tests {
     // over plain ws is valid, config-file-only) must hand that section back unchanged — the
     // security UI is hidden for ws, and a hidden section must never clobber the file.
     #[test]
+    /// UI-R-024 — a ws setup resolves preserving the prefilled security.
     fn ut_resolve_ws_preserves_prefilled_security() {
         let security = OcppSecurityConfig {
             username: Some("cp001".into()),
@@ -1008,6 +1009,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a wss server with no TLS material resolves (self-signed) without a validation error.
     fn ut_server_wss_none_resolves_self_signed_no_cert_error() {
         let d = wss_dialog(1); // Server, security level defaults to None
         let spec = d
@@ -1019,6 +1021,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a wss server with basic auth resolves without a validation error.
     fn ut_server_wss_basic_auth_resolves_self_signed_no_cert_error() {
         let mut d = wss_dialog(1); // Server
         d.security
@@ -1034,6 +1037,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server TLS setup missing its cert fails validation and keeps the dialog open.
     fn ut_server_tls_missing_cert_is_rejected() {
         let mut d = wss_dialog(1);
         d.security.state.set_selection(SecurityLevel::Tls.index());
@@ -1042,6 +1046,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server TLS setup with a nonexistent cert file fails validation.
     fn ut_server_tls_nonexistent_cert_is_rejected() {
         let mut d = wss_dialog(1);
         d.security.state.set_selection(SecurityLevel::Tls.index());
@@ -1052,6 +1057,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server TLS setup with valid files passes validation.
     fn ut_server_tls_valid_files_pass() {
         let cert = tmp_file("cert.crt");
         let key = tmp_file("key.key");
@@ -1063,6 +1069,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS server missing its client CA fails validation.
     fn ut_server_mutual_tls_missing_client_ca_is_rejected() {
         let cert = tmp_file("cert2.crt");
         let key = tmp_file("key2.key");
@@ -1077,6 +1084,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS client missing its cert/key fails validation.
     fn ut_client_mutual_tls_missing_cert_key_is_rejected() {
         let mut d = wss_dialog(0); // Client
         d.security
@@ -1087,6 +1095,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a client CA file, when set, must exist to pass validation.
     fn ut_client_ca_file_when_set_must_exist() {
         let mut d = wss_dialog(0);
         d.security.state.set_selection(SecurityLevel::Tls.index());
@@ -1096,12 +1105,14 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a wss client with no TLS material passes validation.
     fn ut_client_wss_none_is_allowed() {
         let d = wss_dialog(0); // Client, level defaults to None
         assert!(d.resolve().is_ok());
     }
 
     #[test]
+    /// UI-R-024 — a ws setup never requires security material.
     fn ut_ws_never_requires_security() {
         let mut d = OcppSetupDialog::new(); // Ws, Client by default
         set_text(&mut d.name, "cs-1");
@@ -1112,6 +1123,7 @@ mod tests {
     // --- edit -> resolve round trip ------------------------------------------------------------
 
     #[test]
+    /// UI-R-024 — Edit mode round-trips a mutual-TLS server config through the dialog.
     fn ut_edit_resolve_roundtrip_mutual_tls_server() {
         let cert = tmp_file("rt_cert.crt");
         let key = tmp_file("rt_key.key");
@@ -1139,6 +1151,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — Edit mode round-trips a skip-verify client config through the dialog.
     fn ut_edit_resolve_roundtrip_client_skip_verify() {
         let spec = OcppSpec {
             name: "cp-1".into(),
@@ -1163,6 +1176,7 @@ mod tests {
     // --- render height -----------------------------------------------------------------------
 
     #[test]
+    /// UI-R-024 — the TLS hint row renders only for the server role.
     fn ut_render_hint_row_only_for_server_below_tls() {
         let area = Rect::new(0, 0, 80, 60);
 
@@ -1202,6 +1216,7 @@ mod tests {
     // --- focus traversal ------------------------------------------------------------------------
 
     #[test]
+    /// UI-R-022 — a ws selection hides (skips) all security fields in the focus cycle.
     fn ut_focus_ws_hides_all_security_fields() {
         let mut d = OcppSetupDialog::new(); // Ws by default
         d.set_focused(true);
@@ -1226,6 +1241,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — a wss client focus cycle includes the security selection and skip-verify fields.
     fn ut_focus_wss_none_shows_security_selection_and_skip_verify_for_client() {
         let mut d = wss_dialog(0); // Client, wss, level None
         d.set_focused(true);
@@ -1241,6 +1257,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — a wss server focus cycle omits the skip-verify field.
     fn ut_focus_wss_none_server_has_no_skip_verify() {
         let mut d = wss_dialog(1); // Server, wss, level None
         d.set_focused(true);
@@ -1254,6 +1271,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-022 — a mutual-TLS server focus cycle reaches the client-CA field.
     fn ut_focus_wss_mutual_tls_server_reaches_client_ca_file() {
         let mut d = wss_dialog(1); // Server
         d.security
@@ -1274,6 +1292,7 @@ mod tests {
     /// Typing into the config-path field opens the filesystem suggestion popup, and the popup is
     /// drawn on top of the dialog by the trailing `render_overlay` calls in `render`.
     #[test]
+    /// UI-R-026 — the config-path field shows a completion popup.
     fn ut_render_config_path_field_shows_suggestion_popup() {
         let mut dialog = OcppSetupDialog::new();
         dialog.config_path.state.set_focused(true);
@@ -1293,6 +1312,7 @@ mod tests {
     // --- close-confirm --------------------------------------------------------------------------
 
     #[test]
+    /// UI-R-023 — Esc-then-Enter sets the close request, which clears after being taken.
     fn ut_take_close_request_set_via_esc_enter_and_cleared_after_take() {
         let mut dialog = OcppSetupDialog::new();
         assert!(!dialog.take_close_request());
@@ -1304,6 +1324,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-023 — Esc in the close-confirm keeps the setup dialog open.
     fn ut_esc_in_confirm_keeps_open() {
         let mut dialog = OcppSetupDialog::new();
         dialog.handle_events(KeyModifiers::NONE, KeyCode::Esc);
@@ -1314,6 +1335,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-014 — `:` types into a setup text field rather than entering command mode.
     fn ut_colon_in_text_input_types() {
         let mut dialog = OcppSetupDialog::new();
         // Default focus is Name, a free-text field; `:` must be typed as ordinary text.

--- a/ferrowl/src/module/ocpp/setup_dialog/security.rs
+++ b/ferrowl/src/module/ocpp/setup_dialog/security.rs
@@ -238,6 +238,7 @@ mod tests {
     // --- SecurityLevel::from_config -----------------------------------------------------------
 
     #[test]
+    /// UI-R-024 — the security fields load from a no-security config for both roles.
     fn ut_from_config_none_both_roles() {
         let cfg = OcppSecurityConfig::default();
         assert_eq!(
@@ -251,6 +252,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — the security fields load from a basic-auth config for both roles.
     fn ut_from_config_basic_auth_both_roles() {
         let cfg = OcppSecurityConfig {
             username: Some("u".into()),
@@ -268,6 +270,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a client TLS config loads into the CA-file field.
     fn ut_from_config_tls_client_is_ca_file() {
         let cfg = OcppSecurityConfig {
             ca_file: Some("ca.pem".into()),
@@ -280,6 +283,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server TLS config loads into the cert and key fields.
     fn ut_from_config_tls_server_is_cert_and_key() {
         let cfg = OcppSecurityConfig {
             cert_file: Some("s.crt".into()),
@@ -293,6 +297,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS client config loads into the client-cert fields.
     fn ut_from_config_mutual_tls_client_is_client_cert() {
         let cfg = OcppSecurityConfig {
             client_cert_file: Some("c.crt".into()),
@@ -305,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS server config loads into the require-flag/client-CA fields.
     fn ut_from_config_mutual_tls_server_is_require_flag_or_client_ca() {
         let by_flag = OcppSecurityConfig {
             require_client_cert: true,
@@ -327,6 +333,7 @@ mod tests {
     // --- SecurityLevel::build_config -----------------------------------------------------------
 
     #[test]
+    /// UI-R-024 — building the config drops fields not visible at the chosen security level.
     fn ut_build_config_drops_fields_not_visible_at_level() {
         let cfg = SecurityLevel::BasicAuth.build_config(
             OcppRole::Server,
@@ -350,6 +357,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a server TLS build keeps cert/key and drops client fields.
     fn ut_build_config_tls_server_keeps_cert_key_not_client_fields() {
         let cfg = SecurityLevel::Tls.build_config(
             OcppRole::Server,
@@ -371,6 +379,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS server build sets require-client-cert.
     fn ut_build_config_mutual_tls_server_sets_require_client_cert() {
         let cfg = SecurityLevel::MutualTls.build_config(
             OcppRole::Server,
@@ -391,6 +400,7 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-024 — a mutual-TLS client build keeps the client cert/key.
     fn ut_build_config_mutual_tls_client_keeps_client_cert_key() {
         let cfg = SecurityLevel::MutualTls.build_config(
             OcppRole::Client,

--- a/ferrowl/src/module/ocpp/spec/v1_6.rs
+++ b/ferrowl/src/module/ocpp/spec/v1_6.rs
@@ -439,6 +439,7 @@ mod tests {
     use ferrowl_ocpp::{V1_6, Version};
 
     /// Every JSON-only action ships a handcrafted template that decodes and validates.
+    /// OC-R-091 — every raw-JSON action ships a template that decodes and validates against its version's request type.
     #[test]
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
@@ -463,6 +464,7 @@ mod tests {
         "StopTransaction",
     ];
 
+    /// OC-R-089 — dialog-reachable actions are classified as typed (a property-table spec) or raw-JSON.
     #[test]
     fn ut_flat_and_nested_actions_have_specs() {
         assert!(action_spec("Reset").is_some());
@@ -474,6 +476,7 @@ mod tests {
 
     /// Every action a dialog can open is classified: a typed spec or an explicit JSON action,
     /// disjoint and complete (no silent JSON-by-absence).
+    /// OC-R-089 — every dialog-reachable action is exactly one of typed or raw-JSON (disjoint and complete, no silent omission).
     #[test]
     fn ut_every_dialog_action_is_classified() {
         let mut reachable: Vec<&str> = V1_6::csms_actions().iter().map(|(n, _)| *n).collect();

--- a/ferrowl/src/module/ocpp/spec/v1_6.rs
+++ b/ferrowl/src/module/ocpp/spec/v1_6.rs
@@ -439,8 +439,8 @@ mod tests {
     use ferrowl_ocpp::{V1_6, Version};
 
     /// Every JSON-only action ships a handcrafted template that decodes and validates.
-    /// OC-R-091 — every raw-JSON action ships a template that decodes and validates against its version's request type.
     #[test]
+    /// OC-R-091 — every raw-JSON action ships a template that decodes and validates against its version's request type.
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
             let template =
@@ -464,8 +464,8 @@ mod tests {
         "StopTransaction",
     ];
 
-    /// OC-R-089 — dialog-reachable actions are classified as typed (a property-table spec) or raw-JSON.
     #[test]
+    /// OC-R-089 — dialog-reachable actions are classified as typed (a property-table spec) or raw-JSON.
     fn ut_flat_and_nested_actions_have_specs() {
         assert!(action_spec("Reset").is_some());
         assert!(action_spec("ChangeAvailability").is_some());
@@ -476,8 +476,8 @@ mod tests {
 
     /// Every action a dialog can open is classified: a typed spec or an explicit JSON action,
     /// disjoint and complete (no silent JSON-by-absence).
-    /// OC-R-089 — every dialog-reachable action is exactly one of typed or raw-JSON (disjoint and complete, no silent omission).
     #[test]
+    /// OC-R-089 — every dialog-reachable action is exactly one of typed or raw-JSON (disjoint and complete, no silent omission).
     fn ut_every_dialog_action_is_classified() {
         let mut reachable: Vec<&str> = V1_6::csms_actions().iter().map(|(n, _)| *n).collect();
         reachable.extend(

--- a/ferrowl/src/module/ocpp/spec/v2_0_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_0_1.rs
@@ -1523,8 +1523,8 @@ mod tests {
     use ferrowl_ocpp::{V2_0_1, Version};
 
     /// Every JSON-only action ships a handcrafted template that decodes and validates.
-    /// OC-R-091 — every 2.0.1 raw-JSON action ships a template that decodes and validates against its request type.
     #[test]
+    /// OC-R-091 — every 2.0.1 raw-JSON action ships a template that decodes and validates against its request type.
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
             let template =
@@ -1546,8 +1546,8 @@ mod tests {
         "StatusNotification",
     ];
 
-    /// OC-R-090 — an action is raw-JSON exactly when its required fields include nested/repeated shapes a flat table cannot express.
     #[test]
+    /// OC-R-090 — an action is raw-JSON exactly when its required fields include nested/repeated shapes a flat table cannot express.
     fn ut_flat_and_nested_actions_have_specs() {
         assert!(action_spec("Reset").is_some());
         assert!(action_spec("UnlockConnector").is_some());
@@ -1563,8 +1563,8 @@ mod tests {
     }
 
     /// Every dialog-reachable action is exactly one of: a typed spec or an explicit JSON action.
-    /// OC-R-089 — every dialog-reachable 2.0.1 action is exactly one of typed or raw-JSON.
     #[test]
+    /// OC-R-089 — every dialog-reachable 2.0.1 action is exactly one of typed or raw-JSON.
     fn ut_every_dialog_action_is_classified() {
         let mut reachable: Vec<&str> = V2_0_1::csms_actions().iter().map(|(n, _)| *n).collect();
         reachable.extend(
@@ -1586,8 +1586,8 @@ mod tests {
     /// Every typed action's default-prefilled dialog assembles a payload that decodes into the
     /// real rust-ocpp request type (required fields present, enum values + types valid). This is
     /// the guardrail against a wrong wire name / enum / nesting in a spec or assembler.
-    /// OC-R-094 — every typed action's default-prefilled dialog assembles a payload that decodes against the version's request type.
     #[test]
+    /// OC-R-094 — every typed action's default-prefilled dialog assembles a payload that decodes against the version's request type.
     fn ut_default_payloads_decode_for_every_spec() {
         let mut reachable: Vec<&str> = V2_0_1::csms_actions().iter().map(|(n, _)| *n).collect();
         reachable.extend(

--- a/ferrowl/src/module/ocpp/spec/v2_0_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_0_1.rs
@@ -1523,6 +1523,7 @@ mod tests {
     use ferrowl_ocpp::{V2_0_1, Version};
 
     /// Every JSON-only action ships a handcrafted template that decodes and validates.
+    /// OC-R-091 — every 2.0.1 raw-JSON action ships a template that decodes and validates against its request type.
     #[test]
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
@@ -1545,6 +1546,7 @@ mod tests {
         "StatusNotification",
     ];
 
+    /// OC-R-090 — an action is raw-JSON exactly when its required fields include nested/repeated shapes a flat table cannot express.
     #[test]
     fn ut_flat_and_nested_actions_have_specs() {
         assert!(action_spec("Reset").is_some());
@@ -1561,6 +1563,7 @@ mod tests {
     }
 
     /// Every dialog-reachable action is exactly one of: a typed spec or an explicit JSON action.
+    /// OC-R-089 — every dialog-reachable 2.0.1 action is exactly one of typed or raw-JSON.
     #[test]
     fn ut_every_dialog_action_is_classified() {
         let mut reachable: Vec<&str> = V2_0_1::csms_actions().iter().map(|(n, _)| *n).collect();
@@ -1583,6 +1586,7 @@ mod tests {
     /// Every typed action's default-prefilled dialog assembles a payload that decodes into the
     /// real rust-ocpp request type (required fields present, enum values + types valid). This is
     /// the guardrail against a wrong wire name / enum / nesting in a spec or assembler.
+    /// OC-R-094 — every typed action's default-prefilled dialog assembles a payload that decodes against the version's request type.
     #[test]
     fn ut_default_payloads_decode_for_every_spec() {
         let mut reachable: Vec<&str> = V2_0_1::csms_actions().iter().map(|(n, _)| *n).collect();

--- a/ferrowl/src/module/ocpp/spec/v2_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_1.rs
@@ -554,6 +554,7 @@ mod tests {
 
     /// Every JSON-only action (2.1-only and inherited) ships a template that decodes and
     /// validates against the 2.1 types — this also proves the reused 2.0.1 templates still fit.
+    /// OC-R-091 — every 2.1 raw-JSON action (own and inherited) ships a template that decodes and validates against the 2.1 types.
     #[test]
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
@@ -587,6 +588,7 @@ mod tests {
         names
     }
 
+    /// OC-R-090 — the new 2.1 actions are classified typed vs raw-JSON by whether their required fields are nested/repeated.
     #[test]
     fn ut_new_2_1_actions_have_specs_or_are_json() {
         // Flat.
@@ -604,6 +606,7 @@ mod tests {
         assert!(json_actions().contains(&"SetDefaultTariff"));
     }
 
+    /// OC-R-089 — a 2.1 action shared with 2.0.1 resolves to the same typed/raw-JSON classification through the version seam.
     #[test]
     fn ut_shared_actions_delegate_to_v2_0_1() {
         // A shared action classified by 2.0.1 must resolve identically through 2.1's seam.
@@ -614,6 +617,7 @@ mod tests {
     }
 
     /// Every dialog-reachable 2.1 action is exactly one of: a typed spec or an explicit JSON action.
+    /// OC-R-089 — every dialog-reachable 2.1 action is exactly one of typed or raw-JSON.
     #[test]
     fn ut_every_dialog_action_is_classified() {
         for name in reachable() {
@@ -628,6 +632,7 @@ mod tests {
 
     /// Every typed action's default-prefilled dialog assembles a payload that decodes into the real
     /// rust-ocpp 2.1 request type.
+    /// OC-R-094 — every typed 2.1 action's default-prefilled dialog assembles a payload that decodes against the 2.1 request type.
     #[test]
     fn ut_default_payloads_decode_for_every_spec() {
         for name in reachable() {

--- a/ferrowl/src/module/ocpp/spec/v2_1.rs
+++ b/ferrowl/src/module/ocpp/spec/v2_1.rs
@@ -554,8 +554,8 @@ mod tests {
 
     /// Every JSON-only action (2.1-only and inherited) ships a template that decodes and
     /// validates against the 2.1 types — this also proves the reused 2.0.1 templates still fit.
-    /// OC-R-091 — every 2.1 raw-JSON action (own and inherited) ships a template that decodes and validates against the 2.1 types.
     #[test]
+    /// OC-R-091 — every 2.1 raw-JSON action (own and inherited) ships a template that decodes and validates against the 2.1 types.
     fn ut_json_templates_cover_all_json_actions_and_decode() {
         for name in json_actions() {
             let template =
@@ -588,8 +588,8 @@ mod tests {
         names
     }
 
-    /// OC-R-090 — the new 2.1 actions are classified typed vs raw-JSON by whether their required fields are nested/repeated.
     #[test]
+    /// OC-R-090 — the new 2.1 actions are classified typed vs raw-JSON by whether their required fields are nested/repeated.
     fn ut_new_2_1_actions_have_specs_or_are_json() {
         // Flat.
         assert!(action_spec("NotifyDERAlarm").is_some());
@@ -606,8 +606,8 @@ mod tests {
         assert!(json_actions().contains(&"SetDefaultTariff"));
     }
 
-    /// OC-R-089 — a 2.1 action shared with 2.0.1 resolves to the same typed/raw-JSON classification through the version seam.
     #[test]
+    /// OC-R-089 — a 2.1 action shared with 2.0.1 resolves to the same typed/raw-JSON classification through the version seam.
     fn ut_shared_actions_delegate_to_v2_0_1() {
         // A shared action classified by 2.0.1 must resolve identically through 2.1's seam.
         assert!(action_spec("Reset").is_some());
@@ -617,8 +617,8 @@ mod tests {
     }
 
     /// Every dialog-reachable 2.1 action is exactly one of: a typed spec or an explicit JSON action.
-    /// OC-R-089 — every dialog-reachable 2.1 action is exactly one of typed or raw-JSON.
     #[test]
+    /// OC-R-089 — every dialog-reachable 2.1 action is exactly one of typed or raw-JSON.
     fn ut_every_dialog_action_is_classified() {
         for name in reachable() {
             let has_spec = action_spec(name).is_some();
@@ -632,8 +632,8 @@ mod tests {
 
     /// Every typed action's default-prefilled dialog assembles a payload that decodes into the real
     /// rust-ocpp 2.1 request type.
-    /// OC-R-094 — every typed 2.1 action's default-prefilled dialog assembles a payload that decodes against the 2.1 request type.
     #[test]
+    /// OC-R-094 — every typed 2.1 action's default-prefilled dialog assembles a payload that decodes against the 2.1 request type.
     fn ut_default_payloads_decode_for_every_spec() {
         for name in reachable() {
             let Some(spec) = action_spec(name) else {

--- a/ferrowl/src/registry.rs
+++ b/ferrowl/src/registry.rs
@@ -198,6 +198,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — the module registry (C_Module) resolves and lists modules by name.
     fn ut_registry_resolve_and_list() {
         let registry = ModuleRegistry::new();
         assert!(registry.list().is_empty());
@@ -230,6 +231,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — replacing the registry drops stale module entries.
     fn ut_registry_replace_all_drops_stale_entries() {
         let registry = ModuleRegistry::new();
         let mut first: HashMap<String, Arc<dyn ModuleHost>> = HashMap::new();
@@ -250,6 +252,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-014 — the first occurrence of a duplicated instance name is left unchanged.
     fn ut_dedupe_names_first_occurrence_unchanged() {
         assert_eq!(
             dedupe_names(&["a".to_string(), "b".to_string()]),
@@ -258,6 +261,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-014 — later duplicate names are suffixed ` (2)`, ` (3)`, … in creation order.
     fn ut_dedupe_names_suffixes_repeats_in_order() {
         let names = vec!["a".to_string(), "a".to_string(), "a".to_string()];
         assert_eq!(
@@ -267,6 +271,7 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-014 — name de-duplication skips a suffix already taken by an earlier name.
     fn ut_dedupe_names_skips_candidate_colliding_with_earlier_name() {
         // "a (2)" is already taken by an earlier distinct name, so the second "a" must skip to
         // "a (3)".
@@ -484,6 +489,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — a handle resolved before a registry replace goes stale and errors.
     fn ut_resolve_stale_after_replace_all_errors() {
         let registry = ModuleRegistry::new();
         let mut modules: HashMap<String, Arc<dyn ModuleHost>> = HashMap::new();

--- a/ferrowl/src/registry.rs
+++ b/ferrowl/src/registry.rs
@@ -320,6 +320,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — a modbus module's register state is reachable from the session sim via the C_Module directory.
     fn ut_modbus_host_roundtrip_through_directory() {
         let mut registers = HashMap::new();
         registers.insert("setpoint".to_string(), holding(0));
@@ -368,6 +369,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — an ocpp client module's state and actions are reachable from the session sim via C_Module.
     fn ut_ocpp_client_entry_roundtrip_through_directory() {
         use crate::module::ocpp::client::lua_sim::ClientFields;
         use crate::module::ocpp::client::v1_6::state::CsState as Cs16;
@@ -418,6 +420,7 @@ mod tests {
     }
 
     #[test]
+    /// SC-R-020 — an ocpp server module's stations are reachable from the session sim via C_Module.
     fn ut_ocpp_server_entry_roundtrip_through_directory() {
         use crate::module::ocpp::client::lua_sim::OcppFields;
         use crate::module::ocpp::lock::with_state_mut;

--- a/ferrowl/src/script_template.rs
+++ b/ferrowl/src/script_template.rs
@@ -98,9 +98,9 @@ mod tests {
         ScriptContext::Session,
     ];
 
+    #[test]
     /// SC-R-037 — every bundled template's code body loads in the Lua runtime; a syntax error in a
     /// template is a test failure, never something a user meets after inserting it.
-    #[test]
     fn ut_every_template_compiles() {
         for template in TEMPLATES {
             let ctx = ferrowl_lua::ContextBuilder::<String>::default()
@@ -116,8 +116,8 @@ mod tests {
         }
     }
 
-    /// SC-R-036 — `templates(ctx)` returns exactly the templates declaring `ctx`.
     #[test]
+    /// SC-R-036 — `templates(ctx)` returns exactly the templates declaring `ctx`.
     fn ut_templates_filtered_by_context() {
         for ctx in CONTEXTS {
             for template in templates(ctx) {
@@ -136,8 +136,8 @@ mod tests {
         assert!(!modbus.contains(&"power-report"));
     }
 
-    /// SC-R-036 — every script context has at least one template, so the browser is never empty.
     #[test]
+    /// SC-R-036 — every script context has at least one template, so the browser is never empty.
     fn ut_every_context_has_a_template() {
         for ctx in CONTEXTS {
             assert!(!templates(ctx).is_empty(), "{ctx:?} has no template");

--- a/ferrowl/src/session/e2e_tests.rs
+++ b/ferrowl/src/session/e2e_tests.rs
@@ -176,6 +176,7 @@ fn server_entry_with_station(
 // --- 1. Two modbus modules, session mirror ----------------------------------
 
 #[test]
+/// SC-R-020 — the session sim mirrors state between two modbus modules via C_Module.
 fn it_two_modbus_modules_session_mirror() {
     let mem_a = evse_memory();
     let mem_b = evse_memory();
@@ -210,6 +211,7 @@ fn it_two_modbus_modules_session_mirror() {
 // --- 2. OCPP client -> modbus mirror -----------------------------------------
 
 #[test]
+/// SC-R-020 — the session sim mirrors OCPP client state into a modbus module via C_Module.
 fn it_ocpp_client_to_modbus_mirror() {
     let (state, _queue, entry) = client_entry();
     // seed connector 1 power before the sim starts.
@@ -240,6 +242,7 @@ fn it_ocpp_client_to_modbus_mirror() {
 // --- 3. OCPP action dispatch cross-module -------------------------------------
 
 #[test]
+/// SC-R-020 — the session sim dispatches an OCPP action on another module via C_Module.
 fn it_ocpp_action_dispatch_cross_module() {
     let (_state, queue, entry) = client_entry();
     let registry = registry_from(vec![("cs1", Arc::new(entry) as Arc<dyn ModuleHost>)]);
@@ -273,6 +276,7 @@ fn it_ocpp_action_dispatch_cross_module() {
 // --- 4. OCPP server enumeration -----------------------------------------------
 
 #[test]
+/// SC-R-020 — the session sim enumerates an OCPP server's stations via C_Module.
 fn it_ocpp_server_enumeration() {
     let (states, _queue, entry) = server_entry_with_station("CP1", 1);
     let registry = registry_from(vec![("csms", Arc::new(entry) as Arc<dyn ModuleHost>)]);
@@ -310,6 +314,7 @@ fn it_ocpp_server_enumeration() {
 // --- 5. Module removal mid-run -------------------------------------------------
 
 #[test]
+/// SC-R-020 — a module removed mid-run makes its C_Module handle error while the sim keeps looping.
 fn it_module_removal_mid_run_logs_error_and_keeps_looping() {
     let mem_b = evse_memory();
     let mem_keep = evse_memory();
@@ -364,6 +369,7 @@ fn it_module_removal_mid_run_logs_error_and_keeps_looping() {
 // --- 6. Rename -----------------------------------------------------------------
 
 #[test]
+/// SC-R-020 — after a rename, the old C_Module name errors and the new name resolves.
 fn it_module_rename_old_name_errors_new_name_resolves() {
     let mem_b = evse_memory();
     let registry = ModuleRegistry::new();
@@ -418,6 +424,7 @@ fn it_module_rename_old_name_errors_new_name_resolves() {
 // --- 7. Type/Role introspection -------------------------------------------------
 
 #[test]
+/// SC-R-020 — C_Module reports each module's type and role.
 fn it_type_role_introspection() {
     let mem = evse_memory();
     let (_state, _queue, entry) = client_entry();

--- a/ferrowl/src/session/sim.rs
+++ b/ferrowl/src/session/sim.rs
@@ -260,6 +260,7 @@ mod tests {
         cond()
     }
 
+    /// SC-R-011 — an enabled session script starts the session sim with no explicit start call.
     #[test]
     fn ut_enabled_script_runs_without_explicit_start() {
         let rw = MockReadWrite::default();
@@ -277,6 +278,7 @@ mod tests {
         }));
     }
 
+    /// SC-R-011 — with every session script disabled, no sim thread exists.
     #[test]
     fn ut_all_disabled_stops() {
         let rw = MockReadWrite::default();
@@ -291,6 +293,7 @@ mod tests {
         assert!(sim.handle.is_none());
     }
 
+    /// SC-R-024 — toggling a session script's enabled flag starts then stops the sim thread.
     #[test]
     fn ut_toggle_scripts_starts_and_stops() {
         let rw = MockReadWrite::default();
@@ -316,6 +319,7 @@ mod tests {
         assert!(sim.handle.is_none());
     }
 
+    /// SC-R-024 — editing a session script restarts the sim on a fresh context so new code takes over.
     #[test]
     fn ut_code_change_restarts_with_new_behavior() {
         let rw = MockReadWrite::default();
@@ -341,6 +345,7 @@ mod tests {
         }));
     }
 
+    /// SC-R-032 — a session script error is logged at Error level with a `[sim]` prefix; print still logs.
     #[test]
     fn ut_script_error_logged_with_sim_prefix_and_print_logged() {
         let rw = MockReadWrite::default();
@@ -364,6 +369,7 @@ mod tests {
         }));
     }
 
+    /// SC-R-032 — one session script's error does not prevent the others from running that cycle.
     #[test]
     fn ut_unknown_module_error_does_not_stop_loop() {
         let rw = MockReadWrite::default();
@@ -406,6 +412,7 @@ mod tests {
         assert!(sim.handle.is_none(), "run_once must not start a sim thread");
     }
 
+    /// SC-R-014 — the session sim runs its script about once per cycle interval.
     #[test]
     fn ut_interval_honored_roughly() {
         let rw = MockReadWrite::default();

--- a/ferrowl/src/session/sim.rs
+++ b/ferrowl/src/session/sim.rs
@@ -260,8 +260,8 @@ mod tests {
         cond()
     }
 
-    /// SC-R-011 — an enabled session script starts the session sim with no explicit start call.
     #[test]
+    /// SC-R-011 — an enabled session script starts the session sim with no explicit start call.
     fn ut_enabled_script_runs_without_explicit_start() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw.clone());
@@ -278,8 +278,8 @@ mod tests {
         }));
     }
 
-    /// SC-R-011 — with every session script disabled, no sim thread exists.
     #[test]
+    /// SC-R-011 — with every session script disabled, no sim thread exists.
     fn ut_all_disabled_stops() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw);
@@ -293,8 +293,8 @@ mod tests {
         assert!(sim.handle.is_none());
     }
 
-    /// SC-R-024 — toggling a session script's enabled flag starts then stops the sim thread.
     #[test]
+    /// SC-R-024 — toggling a session script's enabled flag starts then stops the sim thread.
     fn ut_toggle_scripts_starts_and_stops() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw.clone());
@@ -319,8 +319,8 @@ mod tests {
         assert!(sim.handle.is_none());
     }
 
-    /// SC-R-024 — editing a session script restarts the sim on a fresh context so new code takes over.
     #[test]
+    /// SC-R-024 — editing a session script restarts the sim on a fresh context so new code takes over.
     fn ut_code_change_restarts_with_new_behavior() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw.clone());
@@ -345,8 +345,8 @@ mod tests {
         }));
     }
 
-    /// SC-R-032 — a session script error is logged at Error level with a `[sim]` prefix; print still logs.
     #[test]
+    /// SC-R-032 — a session script error is logged at Error level with a `[sim]` prefix; print still logs.
     fn ut_script_error_logged_with_sim_prefix_and_print_logged() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw);
@@ -369,8 +369,8 @@ mod tests {
         }));
     }
 
-    /// SC-R-032 — one session script's error does not prevent the others from running that cycle.
     #[test]
+    /// SC-R-032 — one session script's error does not prevent the others from running that cycle.
     fn ut_unknown_module_error_does_not_stop_loop() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw.clone());
@@ -387,9 +387,9 @@ mod tests {
         }));
     }
 
+    #[test]
     /// SC-R-035 / SC-R-011 — `run_once` executes a **disabled** script on demand and starts no sim
     /// thread: the one-shot is independent of the sim lifecycle.
-    #[test]
     fn ut_run_once_executes_disabled_script_without_sim() {
         let rw = MockReadWrite::default();
         let directory = directory_with_mock(rw.clone());
@@ -412,8 +412,8 @@ mod tests {
         assert!(sim.handle.is_none(), "run_once must not start a sim thread");
     }
 
-    /// SC-R-014 — the session sim runs its script about once per cycle interval.
     #[test]
+    /// SC-R-014 — the session sim runs its script about once per cycle interval.
     fn ut_interval_honored_roughly() {
         let rw = MockReadWrite::default();
         rw.store

--- a/ferrowl/tests/headless.rs
+++ b/ferrowl/tests/headless.rs
@@ -9,6 +9,7 @@ fn bin() -> Command {
 }
 
 #[test]
+/// CL-R-032 — a headless run reaching its --duration deadline exits 0.
 fn it_runs_a_modbus_server_and_exits_clean() {
     let device = concat!(env!("CARGO_MANIFEST_DIR"), "/../configs/evse.toml");
     let module = format!(
@@ -34,6 +35,7 @@ fn it_runs_a_modbus_server_and_exits_clean() {
 }
 
 #[test]
+/// CL-R-030 — a module whose device config fails to load makes the headless run exit 1.
 fn it_fails_hard_on_a_missing_device_config() {
     let module = "name=it-headless-bad,device=/no/such/device.toml,transport=tcp,ip=127.0.0.1,port=15921,role=server";
     let output = bin()


### PR DESCRIPTION
## Why

`docs/specs/` is the authoritative spec, but only 35 of ~1180 tests cited the requirement they verify — the suite was not an auditable map onto the spec. AGENTS.md step 6 actively forbade fixing this ("Do not backfill IDs onto existing tests").

This branch makes every test that pins observable behavior cite its requirement, and — as a deliberate second outcome — inverts the map to surface (a) behavior tested with no requirement (→ add the requirement) and (b) requirements with no test (→ catalogue for follow-up).

## Requirements

Three new requirements were added (each gate-1 approved and shipped with a citing test), plus one spec-text fix:

- **MB-R-097** — a register definition's kind defaults to holding register when unspecified. (The code default was also changed input→holding to match.)
- **SC-R-038** — the `C_Test` module exposes `Assert(cond, msg)` / `Fail(msg)` with Lua-falsy semantics and the `assertion failed:` message the headless runner keys off. (Previously specified only in `scripting/api-contract.md §8`.)
- **UI-R-058** — the script-manager table's add / toggle-enabled / delete / compact bindings. (Previously only *listed* in UI-R-056's help overlay, never specified.)
- **Spec fix (MB-R-012 / `modbus/data-contract.md §2.1`)** — the U8/I8 byte-placement text was backwards (big-endian → low byte, little-endian → high byte); the code and tests were already correct.

The convention itself changed:

- **AGENTS.md step 6** — replaced "Do not backfill IDs onto existing tests" with: every test that pins observable behavior shall cite its requirement; a pure internal/helper test may stay untagged; tested-but-unspecified behavior goes through gate 1.
- **AGENTS.md gate 1b / gate 3** — issues and PRs must use `##` section headers.

## What changed

Tagging ran crate-by-crate in spec-area order; each crate is one green commit.

- **Modbus (MB-R):** ferrowl-codec, ferrowl-modbus, ferrowl-store, and the ferrowl-crate modbus module + views.
- **OCPP (OC-R):** ferrowl-ocpp and the ferrowl-crate ocpp module + views.
- **Scripting (SC-R):** ferrowl-lua, and the per-module + session sims, bridges, and `C_Module` registry.
- **TUI (UI-R):** ferrowl-syntax, ferrowl-ui, ferrowl-ui-derive, and the ferrowl-crate app shell, dialogs, and module views.
- **Config/session (CS-R):** ferrowl-util `convert`, the config loader/envelope, `migrate`, and name de-duplication.
- **CLI/headless (CL-R):** argument parsing and the headless run/exit-code contract.

Tests of pure internal/helper detail, generic utilities (ferrowl-ring, ferrowl-util macros), and render-smoke coverage were left untagged by design. NF-R requirements are meta/design-posture and carry no dedicated test; their testable content is cross-referenced to per-area requirements already covered.

**200 of 372 requirements are now cited by a test.** The 172 without a test are catalogued and routed to follow-up issues #98 (CLI + app-shell integration coverage), #99 (Modbus/OCPP review), and #100 (record the intentionally-untested set).

## Verification

Per-commit green checkpoint throughout; final full-workspace run:

| Command | Result |
|---|---|
| `cargo test --workspace` | 40 suites ok, 0 failed |
| `cargo clippy --workspace --tests -- -D warnings` | clean |
| `cargo fmt --check` | clean |

The three new requirements each have a doc-comment-cited test; the MB-R-097 default change was verified against the full suite (no regression). Spot-checked tagged tests against the cited requirement's "shall" text, and cross-checked the untested-requirement report by grepping each area's IDs against `/// <ID>` occurrences.
