### PR TITLE
Backfill citing tests for 66 untested Modbus and OCPP requirements

### DIFF
--- a/ferrowl-codec/src/codec.rs
+++ b/ferrowl-codec/src/codec.rs
@@ -829,6 +829,14 @@ mod tests {
         }
     }
 
+    #[test]
+    /// MB-R-024 — decoding an `Ascii` format whose bytes are not valid UTF-8 fails with a packed-ASCII error.
+    fn ut_decode_ascii_invalid_utf8() {
+        // 0xFF is never a valid UTF-8 lead byte.
+        let r = reg(Format::Ascii((Alignment::Left, Width(1))));
+        assert!(matches!(r.decode(&[0xFFFF]), Err(CodecError::PackedAscii)));
+    }
+
     // --- Resolution scaling ---
 
     #[test]

--- a/ferrowl-codec/src/lib.rs
+++ b/ferrowl-codec/src/lib.rs
@@ -100,3 +100,49 @@ impl Register {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::format::{Endian, Format, Resolution, Width};
+    use crate::{Access, Address, Alignment, BitField, Kind, RegisterBuilder};
+
+    fn u16_be() -> Format {
+        Format::U16((Endian::Big, Resolution(1.0), BitField::default()))
+    }
+
+    #[test]
+    /// MB-R-001 — a register is described by exactly five properties: slave id, access, kind, address, format.
+    fn ut_register_carries_five_properties() {
+        let r = RegisterBuilder::default()
+            .slave_id(7)
+            .access(Access::ReadOnly)
+            .kind(Kind::InputRegister)
+            .address(Address::Fixed(100))
+            .format(u16_be())
+            .build()
+            .unwrap();
+
+        assert_eq!(*r.slave_id(), 7);
+        assert_eq!(*r.access(), Access::ReadOnly);
+        assert_eq!(*r.kind(), Kind::InputRegister);
+        assert_eq!(*r.address(), Address::Fixed(100));
+        assert_eq!(r.format().width(), 1);
+    }
+
+    #[test]
+    /// MB-R-006 — a register's format determines its width in 16-bit registers, the count of consecutive addresses it occupies.
+    fn ut_format_width_is_consecutive_address_count() {
+        // U16 = 1 word, F32 = 2 words, U64 = 4 words, U128 = 8 words, Ascii = its width.
+        assert_eq!(u16_be().width(), 1);
+        assert_eq!(Format::F32((Endian::Big, Resolution(1.0))).width(), 2);
+        assert_eq!(
+            Format::U64((Endian::Big, Resolution(1.0), BitField::default())).width(),
+            4
+        );
+        assert_eq!(
+            Format::U128((Endian::Big, Resolution(1.0), BitField::default())).width(),
+            8
+        );
+        assert_eq!(Format::Ascii((Alignment::Left, Width(5))).width(), 5);
+    }
+}

--- a/ferrowl-modbus/src/client_core.rs
+++ b/ferrowl-modbus/src/client_core.rs
@@ -608,6 +608,60 @@ mod tests {
     }
 
     #[test]
+    /// MB-R-051 — the reconnect backoff starts at 1 s, doubles after each failed attempt, and is capped at 30 s.
+    fn ut_backoff_starts_doubles_and_caps() {
+        assert_eq!(INITIAL_BACKOFF, Duration::from_secs(1));
+        assert_eq!(MAX_BACKOFF, Duration::from_secs(30));
+        // Replays the exact production step `(backoff * 2).min(MAX_BACKOFF)` from
+        // `run_reconnect_loop`, starting at `INITIAL_BACKOFF`.
+        let mut backoff = INITIAL_BACKOFF;
+        let mut seq = vec![backoff];
+        for _ in 0..7 {
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+            seq.push(backoff);
+        }
+        let secs: Vec<u64> = seq.iter().map(|d| d.as_secs()).collect();
+        assert_eq!(secs, vec![1, 2, 4, 8, 16, 30, 30, 30]);
+    }
+
+    #[tokio::test]
+    /// MB-R-054 — a non-terminate command arriving while backing off is dropped (with a log line), not queued.
+    async fn ut_backoff_drops_non_terminate_command() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Command>(4);
+        let lines = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let sink = lines.clone();
+        let log = move |s: String| {
+            let sink = sink.clone();
+            async move {
+                sink.lock().push(s);
+            }
+        };
+        // A non-terminate command sent before the backoff elapses must be dropped, so the wait
+        // still runs to completion and returns `false` (not aborted).
+        tx.send(Command::WriteSingleRegister(1, 0, 42))
+            .await
+            .unwrap();
+        let aborted =
+            ClientCore::wait_reconnect_backoff(&mut rx, Duration::from_millis(50), &log).await;
+        assert!(!aborted);
+        assert!(lines.lock().iter().any(|l| l.contains("Command dropped")));
+    }
+
+    #[tokio::test]
+    /// MB-R-054 — Terminate (and the command channel closing) aborts the backoff wait immediately.
+    async fn ut_backoff_aborts_on_terminate_or_close() {
+        let sink = |_s: String| async move {};
+        // Terminate aborts (returns true).
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Command>(4);
+        tx.send(Command::Terminate).await.unwrap();
+        assert!(ClientCore::wait_reconnect_backoff(&mut rx, Duration::from_secs(30), &sink).await);
+        // The channel closing aborts too.
+        let (tx2, mut rx2) = tokio::sync::mpsc::channel::<Command>(4);
+        drop(tx2);
+        assert!(ClientCore::wait_reconnect_backoff(&mut rx2, Duration::from_secs(30), &sink).await);
+    }
+
+    #[test]
     /// MB-R-042 — a successful coil read is mapped through to one word per bit.
     fn ut_classify_maps_bits_through_to_words_on_success() {
         // Same classify() call the ReadCoils/ReadDiscreteInputs arms make, chained with

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -943,6 +943,85 @@ mod tests {
         assert_eq!(err, ExceptionCode::IllegalDataAddress);
     }
 
+    #[tokio::test]
+    /// MB-R-065 — the server answers any slave id for which regions are declared; it does not filter by a configured slave id.
+    async fn ut_server_serves_any_declared_slave() {
+        // Regions declared for two different slave ids; the server has no "configured" slave.
+        let mut mem = Memory::<Key<SlaveKey>>::default();
+        for &slave in &[3u8, 9u8] {
+            let key = Key {
+                id: SlaveKey {
+                    slave_id: slave,
+                    kind: RegKind::HoldingRegister,
+                },
+            };
+            mem.add_ranges(
+                key.clone(),
+                &MemKind::ReadWrite(CellType::Register),
+                &[Range::new(0, 2)],
+            );
+            mem.write(
+                key,
+                &CellType::Register,
+                &Range::new(0, 2),
+                &[slave as u16, 0],
+            )
+            .unwrap();
+        }
+        let mem = Arc::new(RwLock::new(mem));
+        let (log, _) = recording_log();
+
+        // Both slaves are answered from their own declared regions.
+        for &slave in &[3u8, 9u8] {
+            let resp = handle_request::<SlaveKey, _>(
+                slave,
+                Request::ReadHoldingRegisters(0, 2),
+                &mem,
+                &log,
+                false,
+            )
+            .await
+            .unwrap();
+            assert!(matches!(resp, Response::ReadHoldingRegisters(v) if v[0] == slave as u16));
+        }
+    }
+
+    #[tokio::test]
+    /// MB-R-066 — a "request received" line is logged for every inbound request, including a rejected function code.
+    async fn ut_logs_request_received_including_rejected() {
+        let mem = seeded(
+            RegKind::HoldingRegister,
+            CellType::Register,
+            4,
+            &[10, 20, 30, 40],
+        );
+
+        // A supported request logs "request received".
+        let (log, buf) = recording_log();
+        handle_request::<SlaveKey, _>(1, Request::ReadHoldingRegisters(0, 2), &mem, &log, false)
+            .await
+            .unwrap();
+        assert!(
+            buf.lock()
+                .unwrap()
+                .iter()
+                .any(|l| l.contains("request received"))
+        );
+
+        // A rejected function code still logs "request received" before the IllegalFunction reply.
+        let (log, buf) = recording_log();
+        let err = handle_request::<SlaveKey, _>(1, Request::ReportServerId, &mem, &log, false)
+            .await
+            .unwrap_err();
+        assert_eq!(err, ExceptionCode::IllegalFunction);
+        assert!(
+            buf.lock()
+                .unwrap()
+                .iter()
+                .any(|l| l.contains("request received"))
+        );
+    }
+
     // ---- Unsupported function codes ----
 
     #[tokio::test]

--- a/ferrowl-modbus/tests/rtu_serial.rs
+++ b/ferrowl-modbus/tests/rtu_serial.rs
@@ -1,0 +1,107 @@
+//! RTU (serial) transport tests. A real serial loopback needs hardware (or a named
+//! PTY the RTU builders can open by path), which isn't portable in CI, so these cover
+//! the serial-open failure paths — which is where the RTU-specific lifecycle behavior
+//! (open-once-at-start for the server, reconnect-on-open-failure for the client) is
+//! observable.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrowl_modbus::rtu;
+use ferrowl_modbus::{Command, Error, FunctionCode, Key, Operation, SerialError, SlaveKey};
+use ferrowl_store::{Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+fn empty_mem() -> Mem {
+    Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()))
+}
+
+/// A serial path that cannot be opened, so `SerialStream::open` fails.
+fn bad_config(reconnect: bool) -> rtu::Config {
+    rtu::Config {
+        path: "/nonexistent/ferrowl-no-such-serial-port".to_string(),
+        baud_rate: 115200,
+        slave: 1,
+        parity: None,
+        data_bits: None,
+        stop_bits: None,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-075 — failure to open the serial port fails an RTU server's start with a serial error.
+/// MB-R-074 — the RTU server opens the port once at start (there is no accept loop deferring it), so
+/// an unopenable port surfaces at `spawn` rather than being retried per connection.
+async fn rtu_server_open_failure_fails_start() {
+    let res = rtu::ServerBuilder::new(Arc::new(RwLock::new(bad_config(false))), empty_mem())
+        .spawn(sink())
+        .await;
+    assert!(matches!(res, Err(Error::Serial(SerialError::Error(_)))));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-075 — for an RTU client, a serial-open failure is a failed connection attempt; with
+/// reconnect disabled it ends the client task with the error.
+async fn rtu_client_open_failure_reconnect_false_dies() {
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (_tx, rx) = mpsc::channel::<Command>(16);
+    let client = rtu::ClientBuilder::new(
+        Arc::new(RwLock::new(bad_config(false))),
+        operations,
+        empty_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("spawn succeeds; the open error surfaces from the task");
+
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client task did not finish in time")
+        .expect("client task panicked");
+    assert!(joined.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-075 — for an RTU client, a serial-open failure with reconnect enabled is subject to the
+/// reconnect rules: the task keeps retrying rather than dying, and Terminate ends it cleanly.
+async fn rtu_client_open_failure_reconnect_true_retries() {
+    let operations = Arc::new(RwLock::new(vec![]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = rtu::ClientBuilder::new(
+        Arc::new(RwLock::new(bad_config(true))),
+        operations,
+        empty_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("spawn succeeds");
+
+    // The open keeps failing; with reconnect on, the task must still be alive (backing off), not
+    // finished. Terminate then ends it with success.
+    sleep(Duration::from_millis(200)).await;
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("Terminate did not end the retrying client in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+}

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -334,6 +334,87 @@ async fn tcp_client_handles_server_rejections() {
 }
 
 #[tokio::test]
+/// MB-R-069 — an `ip`/`port` pair that does not parse as a socket address fails with a TCP address
+/// error, for both the client and the server.
+async fn tcp_unparseable_address_is_error() {
+    use ferrowl_modbus::{Error, TcpError};
+
+    let mut bad = config(502);
+    bad.ip = "not.an.ip.address".to_string();
+
+    // Client side (`Client` isn't `Debug`, so match the result rather than `unwrap_err`).
+    assert!(matches!(
+        tcp::Client::connect(&bad).await,
+        Err(Error::Tcp(TcpError::Address(_)))
+    ));
+
+    // Server side.
+    let mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let server_err = tcp::ServerBuilder::new(Arc::new(RwLock::new(bad)), mem)
+        .spawn(sink())
+        .await
+        .unwrap_err();
+    assert!(matches!(server_err, Error::Tcp(TcpError::Address(_))));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-070 — a TCP server accepts connections in a loop, serving multiple concurrent clients
+/// against the same shared store.
+async fn tcp_server_serves_concurrent_clients() {
+    let port = free_port();
+    let srv_mem = server_mem();
+
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // Two independent clients connect at the same time and both read from the one server.
+    let ops = || {
+        Arc::new(RwLock::new(vec![Operation {
+            slave_id: 1,
+            fn_code: FunctionCode::ReadHoldingRegisters,
+            range: Range::new(0, 4),
+        }]))
+    };
+    let mem_a = client_mem();
+    let mem_b = client_mem();
+    let (tx_a, rx_a) = mpsc::channel::<Command>(16);
+    let (tx_b, rx_b) = mpsc::channel::<Command>(16);
+    let client_a =
+        tcp::ClientBuilder::new(Arc::new(RwLock::new(config(port))), ops(), mem_a.clone())
+            .spawn(rx_a, sink(), sink())
+            .await
+            .expect("client A failed to connect");
+    let client_b =
+        tcp::ClientBuilder::new(Arc::new(RwLock::new(config(port))), ops(), mem_b.clone())
+            .spawn(rx_b, sink(), sink())
+            .await
+            .expect("client B failed to connect");
+
+    sleep(Duration::from_millis(600)).await;
+
+    for m in [&mem_a, &mem_b] {
+        assert_eq!(
+            m.read()
+                .read(
+                    key(RegKind::HoldingRegister),
+                    &CellType::Register,
+                    &Range::new(0, 4)
+                )
+                .unwrap(),
+            vec![10, 20, 30, 40]
+        );
+    }
+
+    tx_a.send(Command::Terminate).await.unwrap();
+    tx_b.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client_a).await;
+    let _ = tokio::time::timeout(Duration::from_secs(5), client_b).await;
+    server.abort();
+}
+
+#[tokio::test]
 /// MB-R-068 — a TCP client connect attempt to a port with no listener fails.
 async fn tcp_client_connect_refused_is_error() {
     // Nothing is listening on this port, so the connect fails.

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -12,6 +12,7 @@ use ferrowl_codec::Kind as RegKind;
 use ferrowl_modbus::tcp;
 use ferrowl_modbus::{Command, FunctionCode, Key, Operation, SlaveKey};
 use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::Mutex;
 use parking_lot::RwLock as MemLock;
 use tokio::sync::{RwLock, mpsc};
 use tokio::time::sleep;
@@ -25,6 +26,20 @@ fn key(kind: RegKind) -> Key<SlaveKey> {
 /// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
 fn sink() -> impl ferrowl_modbus::LogFn + Clone {
     |_s: String| async move {}
+}
+
+/// A log sink that records every line, so a test can assert on what the client logged.
+/// `LogFn + Clone` is satisfied by a move-closure capturing an `Arc`.
+fn capturing() -> (impl ferrowl_modbus::LogFn + Clone, Arc<Mutex<Vec<String>>>) {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+    let sink = log.clone();
+    let f = move |s: String| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().push(s);
+        }
+    };
+    (f, log)
 }
 
 /// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
@@ -137,6 +152,9 @@ fn client_mem() -> Mem {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 /// MB-R-035 — the client polls every read operation and writes each result into the shared store
 /// (and accepts write commands, MB-R-046, and terminates gracefully, MB-R-049).
+/// MB-R-037 — polling advances round-robin, so all four operations are read in one pass.
+/// MB-R-039 — `interval_ms` of 0 (this config) is treated as a fast tick rather than rejected.
+/// MB-R-041 — the poll loop issues exactly the four read function codes (coils, discrete inputs, input registers, holding registers).
 async fn tcp_client_polls_server_and_executes_commands() {
     let port = free_port();
     let srv_mem = server_mem();
@@ -450,4 +468,319 @@ async fn tcp_client_terminate_during_backoff_exits_promptly() {
         .expect("Terminate did not interrupt the reconnect backoff promptly")
         .expect("client task panicked");
     assert!(joined.is_ok());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-036 — the operation list is shared and mutable at runtime; an operation added after the
+/// client is polling is picked up on a later poll cycle without any reconnect.
+async fn tcp_client_operation_list_mutated_at_runtime() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // Start with a single operation reading the holding registers.
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations.clone(),
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    sleep(Duration::from_millis(300)).await;
+    // The input-register table has not been read yet: still zeros in the client store.
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::InputRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![0, 0, 0, 0]
+    );
+
+    // Add an input-register operation at runtime — no reconnect.
+    operations.write().await.push(Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadInputRegisters,
+        range: Range::new(0, 4),
+    });
+    sleep(Duration::from_millis(400)).await;
+
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::InputRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![100, 200, 300, 400]
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-048 — each read addresses the slave id carried by the operation, independent of any slave
+/// id configured on the transport (the TCP transport configures none).
+async fn tcp_client_addresses_operation_slave_id() {
+    let port = free_port();
+
+    // Server memory declared only under slave id 7. A request for any other slave finds no region.
+    let k7 = || {
+        Key::new(SlaveKey {
+            slave_id: 7,
+            kind: RegKind::HoldingRegister,
+        })
+    };
+    let mut sm = Memory::<Key<SlaveKey>>::default();
+    sm.add_ranges(
+        k7(),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    sm.write(
+        k7(),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[11, 22, 33, 44],
+    )
+    .unwrap();
+    let srv_mem: Mem = Arc::new(MemLock::new(sm));
+
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // Client store keyed on slave 7 too; the operation targets slave 7.
+    let mut cm = Memory::<Key<SlaveKey>>::default();
+    cm.add_ranges(
+        k7(),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let cli_mem: Mem = Arc::new(MemLock::new(cm));
+
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 7,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    sleep(Duration::from_millis(400)).await;
+    // The read only succeeds if the request was addressed to slave 7 (set from the operation).
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(k7(), &CellType::Register, &Range::new(0, 4))
+            .unwrap(),
+        vec![11, 22, 33, 44]
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-038 — the client waits `delay_ms` before its first poll on a connection.
+async fn tcp_client_delays_before_first_poll() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // A long start delay: nothing should be read until it elapses.
+    let cfg = tcp::Config {
+        delay_ms: 600,
+        ..config(port)
+    };
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(Arc::new(RwLock::new(cfg)), operations, cli_mem.clone())
+        .spawn(rx, sink(), sink())
+        .await
+        .expect("client failed to connect");
+
+    // Well before the 600ms delay elapses: nothing polled yet.
+    sleep(Duration::from_millis(250)).await;
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![0, 0, 0, 0]
+    );
+
+    // After the delay plus a poll tick: the values are in.
+    sleep(Duration::from_millis(600)).await;
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![10, 20, 30, 40]
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-040 — every read is bounded by `timeout_ms`; a server that accepts the connection but never
+/// answers makes the read time out, which (with reconnect off) ends the client task with an error.
+async fn tcp_client_read_times_out_when_server_silent() {
+    // A raw TCP listener that accepts connections but never speaks Modbus.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let silent = tokio::spawn(async move {
+        let mut held = Vec::new();
+        loop {
+            if let Ok((stream, _)) = listener.accept().await {
+                held.push(stream); // keep it open; never reply
+            }
+        }
+    });
+
+    let cfg = tcp::Config {
+        timeout_ms: 300,
+        ..config_no_reconnect(port)
+    };
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (_tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(Arc::new(RwLock::new(cfg)), operations, client_mem())
+        .spawn(rx, sink(), sink())
+        .await
+        .expect("connect (TCP handshake) succeeds against the silent listener");
+
+    // timeout_ms is 300ms; the task must end with an error well before this bound.
+    let joined = tokio::time::timeout(Duration::from_secs(3), client)
+        .await
+        .expect("read did not time out within the bound")
+        .expect("client task panicked");
+    assert!(joined.is_err());
+    silent.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-044 — a successful read resets the retry counter, so an operation that was failing and then
+/// recovers keeps polling successfully instead of staying skipped.
+async fn tcp_client_success_resets_retry_counter() {
+    let port = free_port();
+    // Server starts with no region declared: every read for slave 1 is rejected (exceptions).
+    let cli_mem = client_mem();
+    let srv_mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem.clone())
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let (log, lines) = capturing();
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, log, sink())
+    .await
+    .expect("client failed to connect");
+
+    // Let several exception-retry cycles run against the region-less server.
+    sleep(Duration::from_millis(500)).await;
+
+    // Now declare and seed the region: reads start succeeding, which resets the retry counter.
+    {
+        let mut g = srv_mem.write();
+        g.add_ranges(
+            key(RegKind::HoldingRegister),
+            &MemKind::ReadWrite(CellType::Register),
+            &[Range::new(0, 4)],
+        );
+        g.write(
+            key(RegKind::HoldingRegister),
+            &CellType::Register,
+            &Range::new(0, 4),
+            &[10, 20, 30, 40],
+        )
+        .unwrap();
+    }
+    sleep(Duration::from_millis(500)).await;
+
+    // The recovered operation keeps polling and fills the client store.
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![10, 20, 30, 40]
+    );
+    // A "successful" read line was logged after recovery, proving the counter was reset and the
+    // operation resumed rather than staying permanently invalid.
+    assert!(
+        lines.lock().iter().any(|l| l.contains("successful")),
+        "expected a successful read after recovery"
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+    server.abort();
 }

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -539,6 +539,127 @@ async fn tcp_client_operation_list_mutated_at_runtime() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-056 — the connection settings (here the endpoint) are re-read from the shared config on
+/// every connection attempt, so an edit takes effect on the next reconnect.
+async fn tcp_client_rereads_config_on_reconnect() {
+    let good_port = free_port();
+    let bad_port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // A server listens on `good_port`; the client is initially pointed at `bad_port` (no listener).
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(good_port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    let shared_cfg = Arc::new(RwLock::new(config(bad_port)));
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = tcp::ClientBuilder::new(shared_cfg.clone(), operations, cli_mem.clone())
+        .spawn(rx, sink(), sink())
+        .await
+        .expect("spawn succeeds; first connect fails against the empty port");
+
+    // First connect attempt fails; while it backs off, repoint the config at the live server.
+    sleep(Duration::from_millis(200)).await;
+    shared_cfg.write().await.port = good_port;
+
+    // The 1 s initial backoff plus a poll tick must elapse before the re-read connect and read.
+    sleep(Duration::from_millis(2000)).await;
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![10, 20, 30, 40]
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-052 — the backoff resets to 1 s after a connection run that got at least one read through,
+/// so the reconnect logged after a successful run is "1s" even though the backoff had already grown.
+async fn tcp_client_backoff_resets_after_successful_run() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: 1,
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let (log, lines) = capturing();
+    // No server yet: the first connect fails and the backoff grows to 2 s.
+    let client = tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, log, sink())
+    .await
+    .expect("spawn succeeds; first connect fails");
+
+    // Bring the server up during the first (1 s) backoff so the second attempt connects and reads.
+    sleep(Duration::from_millis(500)).await;
+    let server = tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), srv_mem)
+        .spawn(sink())
+        .await
+        .expect("server failed to start");
+
+    // Let the client connect and get at least one read through (marks the run successful).
+    sleep(Duration::from_millis(2000)).await;
+    assert_eq!(
+        cli_mem
+            .read()
+            .read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+        vec![10, 20, 30, 40]
+    );
+
+    // Drop the server: the run ends with a transport error, and because it read successfully the
+    // backoff is reset to 1 s.
+    server.abort();
+    sleep(Duration::from_millis(1500)).await;
+
+    let logged = lines.lock().clone();
+    let first_success = logged
+        .iter()
+        .position(|l| l.contains("successful"))
+        .expect("expected a successful read");
+    let reconnect_after_success = logged[first_success..]
+        .iter()
+        .find(|l| l.contains("Reconnecting in"))
+        .expect("expected a reconnect log after the successful run");
+    // The backoff had already grown to 2 s from the first failed connect; the reset brings the
+    // post-success reconnect back to 1 s.
+    assert!(
+        reconnect_after_success.contains("in 1s"),
+        "post-success reconnect backoff was not reset to 1s: {reconnect_after_success}"
+    );
+
+    tx.send(Command::Terminate).await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(5), client).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 /// MB-R-048 — each read addresses the slave id carried by the operation, independent of any slave
 /// id configured on the transport (the TCP transport configures none).
 async fn tcp_client_addresses_operation_slave_id() {

--- a/ferrowl-ocpp/src/action/v2_1.rs
+++ b/ferrowl-ocpp/src/action/v2_1.rs
@@ -189,6 +189,23 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-002 — the 2.1 action table declares exactly 90 actions.
+    /// OC-R-007 — 2.1 is a strict superset of 2.0.1: every 2.0.1 action also exists in 2.1, and the 26 additional actions are additive.
+    fn ut_2_1_is_strict_superset_of_2_0_1() {
+        use crate::action::v2_0_1::V2_0_1;
+
+        let v201: std::collections::HashSet<_> = V2_0_1::action_names().iter().copied().collect();
+        let v21: std::collections::HashSet<_> = V2_1::action_names().iter().copied().collect();
+
+        assert_eq!(V2_1::action_names().len(), 90);
+        assert_eq!(V2_0_1::action_names().len(), 64);
+        // Every 2.0.1 action carries over into 2.1.
+        assert!(v201.is_subset(&v21));
+        // The extra 2.1 actions are purely additive: 90 − 64 = 26.
+        assert_eq!(v21.len() - v201.len(), 26);
+    }
+
+    #[test]
     /// OC-R-003 — the 2.1 CS- and CSMS-originated sets partition the table (disjoint and complete); CSMS actions carry connector scopes (OC-R-005).
     fn ut_csms_actions_partition_and_scopes() {
         use crate::action::ConnectorScope::*;

--- a/ferrowl-ocpp/src/correlation.rs
+++ b/ferrowl-ocpp/src/correlation.rs
@@ -82,6 +82,24 @@ mod tests {
     }
 
     #[tokio::test]
+    /// OC-R-028 — a CallError received in reply is surfaced to the caller as a rejection carrying the peer's code, description, and details verbatim.
+    async fn ut_call_error_reply_surfaces_verbatim() {
+        let p = PendingCalls::new();
+        let id = UniqueId("e".into());
+        let rx = p.register(id.clone());
+        let err = CallError {
+            code: CallErrorCode::SecurityError,
+            description: "nope".into(),
+            details: serde_json::json!({"why": "denied"}),
+        };
+        p.complete(&id, Err(err.clone()));
+        let got = rx.await.unwrap().unwrap_err();
+        assert_eq!(got.code, CallErrorCode::SecurityError);
+        assert_eq!(got.description, "nope");
+        assert_eq!(got.details, serde_json::json!({"why": "denied"}));
+    }
+
+    #[tokio::test]
     /// OC-R-022 — on teardown every pending outbound Call is failed with a rejection, so no caller waits forever.
     async fn ut_fail_all_notifies_waiters() {
         let p = PendingCalls::new();

--- a/ferrowl-ocpp/src/csms/mod.rs
+++ b/ferrowl-ocpp/src/csms/mod.rs
@@ -300,3 +300,21 @@ fn reject_unauthorized() -> ErrorResponse {
     *resp.status_mut() = StatusCode::UNAUTHORIZED;
     resp
 }
+
+#[cfg(test)]
+mod tests {
+    use super::identity_from_path;
+
+    #[test]
+    /// OC-R-044 — the charge-point identity is the last non-empty path segment of the URL.
+    fn ut_identity_is_last_non_empty_path_segment() {
+        assert_eq!(identity_from_path("/ocpp/CS001").as_deref(), Some("CS001"));
+        // A trailing slash is skipped to the previous non-empty segment.
+        assert_eq!(identity_from_path("/ocpp/CS002/").as_deref(), Some("CS002"));
+        // A single segment with no leading slash still works.
+        assert_eq!(identity_from_path("CP42").as_deref(), Some("CP42"));
+        // No non-empty segment yields no identity.
+        assert_eq!(identity_from_path("/"), None);
+        assert_eq!(identity_from_path(""), None);
+    }
+}

--- a/ferrowl-ocpp/src/ocppj/error_code.rs
+++ b/ferrowl-ocpp/src/ocppj/error_code.rs
@@ -50,3 +50,41 @@ impl CallErrorCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CallErrorCode;
+
+    /// The complete, spec-fixed set of ten codes.
+    const ALL: [CallErrorCode; 10] = [
+        CallErrorCode::NotImplemented,
+        CallErrorCode::NotSupported,
+        CallErrorCode::InternalError,
+        CallErrorCode::ProtocolError,
+        CallErrorCode::SecurityError,
+        CallErrorCode::FormationViolation,
+        CallErrorCode::PropertyConstraintViolation,
+        CallErrorCode::OccurenceConstraintViolation,
+        CallErrorCode::TypeConstraintViolation,
+        CallErrorCode::GenericError,
+    ];
+
+    #[test]
+    /// OC-R-012 — the errorCode is one of exactly ten spec-fixed codes, each round-tripping through its wire spelling.
+    fn ut_error_codes_are_exactly_ten_and_round_trip() {
+        assert_eq!(ALL.len(), 10);
+        for code in ALL {
+            assert_eq!(CallErrorCode::from_wire(code.as_str()), code);
+        }
+    }
+
+    #[test]
+    /// OC-R-012 — an unrecognized wire code is accepted and mapped to GenericError rather than failing the frame.
+    fn ut_unknown_wire_code_maps_to_generic_error() {
+        assert_eq!(
+            CallErrorCode::from_wire("SomeFutureCode"),
+            CallErrorCode::GenericError
+        );
+        assert_eq!(CallErrorCode::from_wire(""), CallErrorCode::GenericError);
+    }
+}

--- a/ferrowl-ocpp/src/ocppj/message.rs
+++ b/ferrowl-ocpp/src/ocppj/message.rs
@@ -74,3 +74,25 @@ impl OcppJMessage {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::UniqueId;
+
+    #[test]
+    /// OC-R-011 — every outbound Call generates a fresh UUID v4 unique id.
+    fn ut_generate_is_a_fresh_uuid_v4() {
+        let a = UniqueId::generate();
+        let b = UniqueId::generate();
+        assert_ne!(a.as_str(), b.as_str());
+        let parsed = uuid::Uuid::parse_str(a.as_str()).expect("generated id is a valid UUID");
+        assert_eq!(parsed.get_version_num(), 4);
+    }
+
+    #[test]
+    /// OC-R-011 — a unique id is an arbitrary string, preserved verbatim (so an inbound id can be echoed back on the reply).
+    fn ut_unique_id_preserves_arbitrary_string() {
+        let id = UniqueId::from("not-a-uuid-42".to_string());
+        assert_eq!(id.as_str(), "not-a-uuid-42");
+    }
+}

--- a/ferrowl-ocpp/src/security.rs
+++ b/ferrowl-ocpp/src/security.rs
@@ -427,7 +427,77 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-035 — a CS presents a client certificate for mutual TLS when, and only when, both the client cert and key files are configured.
+    fn ut_cs_client_cert_only_when_both_cert_and_key_set() {
+        let (cert_pem, key_pem) = cert_and_key_pem();
+        let cert = temp_pem("cs-cert", &cert_pem);
+        let key = temp_pem("cs-key", &key_pem);
+
+        // Both set and valid → the client-auth branch loads them and succeeds.
+        let both = CsTlsConfig {
+            ca_file: None,
+            client_cert_file: Some(cert),
+            client_key_file: Some(key),
+            insecure_skip_verify: false,
+        };
+        assert!(both.build_connector().is_ok());
+
+        // Only the cert set → the no-client-auth branch is taken; the cert is never loaded, so even
+        // a nonexistent path is ignored (no client certificate is presented).
+        let cert_only = CsTlsConfig {
+            ca_file: None,
+            client_cert_file: Some("/no/such/ferrowl-cert.pem".into()),
+            client_key_file: None,
+            insecure_skip_verify: false,
+        };
+        assert!(cert_only.build_connector().is_ok());
+
+        // Both set but missing on disk → the client-auth branch attempts to load and fails, proving
+        // the client certificate is loaded/presented exactly when both files are configured.
+        let both_missing = CsTlsConfig {
+            ca_file: None,
+            client_cert_file: Some("/no/such/ferrowl-cert.pem".into()),
+            client_key_file: Some("/no/such/ferrowl-key.pem".into()),
+            insecure_skip_verify: false,
+        };
+        assert!(both_missing.build_connector().is_err());
+    }
+
+    #[test]
+    /// OC-R-038 — a generated self-signed CSMS certificate carries the listener's host as a SAN, plus `localhost` when the host differs.
+    fn ut_self_signed_carries_host_and_localhost_sans() {
+        // DNS SAN names are encoded as ASCII (IA5String) inside the certificate DER.
+        let contains = |der: &[u8], needle: &[u8]| der.windows(needle.len()).any(|w| w == needle);
+
+        let (certs, _key) = generate_self_signed("evse.example").unwrap();
+        let der = certs[0].as_ref();
+        assert!(contains(der, b"evse.example"));
+        assert!(contains(der, b"localhost"));
+
+        // When the host already is localhost it is still present as a SAN.
+        let (certs, _key) = generate_self_signed("localhost").unwrap();
+        assert!(contains(certs[0].as_ref(), b"localhost"));
+    }
+
+    #[test]
+    /// OC-R-039 — a CSMS requiring client certificates with a configured client CA builds a server config carrying a client-cert verifier.
+    fn ut_require_client_cert_with_ca_builds_verifier() {
+        let (cert_pem, key_pem) = cert_and_key_pem();
+        let (ca_pem, _ca_key) = cert_and_key_pem();
+        let cfg = CsmsTlsConfig {
+            mode: CsmsTlsMode::Files {
+                cert_file: temp_pem("mtls-cert", &cert_pem),
+                key_file: temp_pem("mtls-key", &key_pem),
+            },
+            client_ca_file: Some(temp_pem("mtls-ca", &ca_pem)),
+            require_client_cert: true,
+        };
+        assert!(cfg.build_server_config("localhost").is_ok());
+    }
+
+    #[test]
     /// OC-R-041 — a self-signed CSMS builds a usable server TLS config in memory.
+    /// OC-R-037 — the CSMS server certificate may come from an ephemeral in-memory self-signed pair.
     fn ut_build_server_config_self_signed() {
         let cfg = CsmsTlsConfig {
             mode: CsmsTlsMode::SelfSigned,
@@ -453,6 +523,7 @@ mod tests {
 
     #[test]
     /// OC-R-041 — a CSMS builds its server TLS config from on-disk certificate/key files.
+    /// OC-R-037 — the CSMS server certificate may come from PEM files on disk.
     fn ut_build_server_config_from_files() {
         let (cert_pem, key_pem) = cert_and_key_pem();
         let cfg = CsmsTlsConfig {
@@ -468,6 +539,7 @@ mod tests {
 
     #[test]
     /// OC-R-029 — requiring client certificates without a configured CA file is rejected.
+    /// OC-R-039 — `require_client_cert` without a `client_ca_file` fails the server's start.
     fn ut_require_client_cert_without_ca_is_rejected() {
         let (cert_pem, key_pem) = cert_and_key_pem();
         let cfg = CsmsTlsConfig {

--- a/ferrowl-ocpp/tests/ws_loopback_security.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_security.rs
@@ -192,6 +192,7 @@ async fn basic_auth_rejects_missing_credentials() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// OC-R-034 — a CS trusts a certificate supplied via `ca_file`, completing a TLS loopback to the CSMS.
+/// OC-R-050 — when TLS is configured, the CSMS terminates TLS on the accepted socket before the WebSocket handshake (the CS reaches the OCPP layer only through the completed TLS session).
 async fn tls_loopback_over_self_signed_cert() {
     let key_pair = rcgen::KeyPair::generate().expect("keypair generation failed");
     let cert = rcgen::CertificateParams::new(vec!["127.0.0.1".to_owned()])

--- a/ferrowl-ocpp/tests/ws_loopback_v16.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v16.rs
@@ -799,3 +799,43 @@ async fn peer_close_ends_connection_and_fires_disconnect_hook() {
 
     let _ = client.terminate().await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-097 — a `ws://` CS endpoint connects in plaintext and ignores any configured TLS material (the scheme is authoritative).
+async fn ws_client_ignores_configured_tls_material() {
+    use ferrowl_ocpp::CsTlsConfig;
+
+    let server = start_server().await; // plain ws:// CSMS
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+
+    // TLS material is configured, but the ws:// scheme means it must be ignored and the connection
+    // made in plaintext. If it were honored, a TLS handshake over the plain socket would fail.
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: Some(CsTlsConfig {
+            ca_file: None,
+            client_cert_file: None,
+            client_key_file: None,
+            insecure_skip_verify: true,
+        }),
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("ws client should connect in plaintext, ignoring TLS material");
+
+    let hb = Action16::Heartbeat(serde_json::from_value(json!({})).unwrap());
+    assert!(matches!(
+        client.call(hb).await.unwrap(),
+        Response16::Heartbeat(_)
+    ));
+
+    client.terminate().await.expect("terminate");
+    server.terminate().await.expect("server terminate");
+}

--- a/ferrowl-ocpp/tests/ws_loopback_v16.rs
+++ b/ferrowl-ocpp/tests/ws_loopback_v16.rs
@@ -96,6 +96,12 @@ async fn first_connection(server: &csms::Server<V1_6>) -> csms::ConnectionId {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 /// OC-R-014 — the 1.6 connection is full-duplex: CS and CSMS each originate Calls on the same socket.
+/// OC-R-043 — the CS dials the full websocket URL advertising its version's subprotocol token (the CSMS only accepts it because the token matches).
+/// OC-R-045 — the CS accepts commands while connected: send a Call and await its typed reply, and terminate.
+/// OC-R-046 — the CS answers CSMS-originated Calls through its handler.
+/// OC-R-047 — terminating the CS tears the connection down and ends the client task successfully.
+/// OC-R-049 — the CSMS binds a TCP listener on a configured host/port (port 0 → OS-assigned) and its bound address is retrievable via `local_addr`.
+/// OC-R-056 — the CSMS handler is told which connection each Call arrived on (its `ConnectionId` argument).
 async fn cs_calls_csms_and_csms_calls_cs() {
     let server = start_server().await;
     let url = format!("ws://{}/ocpp/CS001", server.local_addr());
@@ -211,4 +217,585 @@ async fn malformed_call_with_recoverable_id_gets_call_error() {
     assert_eq!(v[2], "FormationViolation");
 
     server.terminate().await.expect("server terminate failed");
+}
+
+/// A CSMS whose handler records the actions it saw and can be told to sleep on Heartbeat, so tests
+/// can observe fire-and-forget delivery and that a slow handler does not block the read pump.
+#[derive(Clone)]
+struct RecordingCsms {
+    seen: Arc<std::sync::Mutex<Vec<String>>>,
+    slow_heartbeat: bool,
+}
+
+impl CsmsActionHandler<V1_6> for RecordingCsms {
+    async fn handle_call(
+        &self,
+        _conn: csms::ConnectionId,
+        action: Action16,
+    ) -> Result<Response16, CallError> {
+        match action {
+            Action16::Heartbeat(_) => {
+                if self.slow_heartbeat {
+                    sleep(Duration::from_millis(700)).await;
+                }
+                self.seen.lock().unwrap().push("Heartbeat".to_owned());
+                Ok(Response16::Heartbeat(
+                    serde_json::from_value(json!({ "currentTime": "2026-01-01T00:00:00Z" }))
+                        .unwrap(),
+                ))
+            }
+            Action16::StatusNotification(_) => {
+                self.seen
+                    .lock()
+                    .unwrap()
+                    .push("StatusNotification".to_owned());
+                Ok(Response16::StatusNotification(
+                    serde_json::from_value(json!({})).unwrap(),
+                ))
+            }
+            _ => Err(CallError::new(CallErrorCode::NotImplemented, "unsupported")),
+        }
+    }
+}
+
+/// Connect a raw websocket (advertising the 1.6 subprotocol) to `url`, bypassing the typed client so
+/// a test can send hand-crafted frames.
+async fn raw_connect(
+    url: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    let mut request = url.into_client_request().expect("bad url");
+    request
+        .headers_mut()
+        .insert("Sec-WebSocket-Protocol", "ocpp1.6".parse().unwrap());
+    let (ws, _) = tokio_tungstenite::connect_async(request)
+        .await
+        .expect("raw websocket connect failed");
+    ws
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-025 — a handler rejecting an inbound Call sends a CallError back and leaves the connection intact (a later Call still succeeds).
+async fn handler_rejection_is_call_error_and_keeps_connection() {
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("client failed to connect");
+
+    // TestCsms rejects Authorize (its `_` arm) with a CallError.
+    let authorize =
+        Action16::Authorize(serde_json::from_value(json!({ "idTag": "TAG1" })).unwrap());
+    assert!(client.call(authorize).await.is_err());
+
+    // The connection survived: a supported Call still works.
+    let hb = Action16::Heartbeat(serde_json::from_value(json!({})).unwrap());
+    assert!(matches!(
+        client.call(hb).await.unwrap(),
+        Response16::Heartbeat(_)
+    ));
+
+    client.terminate().await.expect("terminate");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-027 — an inbound Call whose payload fails to deserialize into the action's request type is answered with CallError `FormationViolation`.
+async fn bad_payload_is_formation_violation() {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let mut ws = raw_connect(&url).await;
+
+    // Valid frame + valid action name, but the payload is missing BootNotification's required fields.
+    ws.send(Message::text("[2, \"p1\", \"BootNotification\", {}]"))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("no reply")
+        .expect("stream closed")
+        .expect("ws error");
+    let v: serde_json::Value = serde_json::from_str(reply.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(v[0], 4, "expected a CallError");
+    assert_eq!(v[1], "p1");
+    assert_eq!(v[2], "FormationViolation");
+
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-024 — a malformed inbound frame that cannot be answered is logged and skipped without tearing the connection down.
+/// OC-R-013 — non-text frames (binary) are ignored rather than treated as OCPP-J payloads.
+async fn malformed_and_binary_frames_do_not_tear_down() {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message;
+
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let mut ws = raw_connect(&url).await;
+
+    // Unrecoverable text (not JSON) — logged and skipped, no reply, no teardown.
+    ws.send(Message::text("this is not json")).await.unwrap();
+    // A binary frame — ignored as a non-OCPP-J payload.
+    ws.send(Message::binary(vec![1u8, 2, 3])).await.unwrap();
+
+    // The connection still works: a valid Heartbeat Call is answered.
+    ws.send(Message::text("[2, \"ok1\", \"Heartbeat\", {}]"))
+        .await
+        .unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("no reply: connection was torn down")
+        .expect("stream closed")
+        .expect("ws error");
+    let v: serde_json::Value = serde_json::from_str(reply.into_text().unwrap().as_str()).unwrap();
+    assert_eq!(v[0], 3, "expected a CallResult");
+    assert_eq!(v[1], "ok1");
+
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-020 — an awaited outbound Call that the peer never answers in time is rejected once the reply timeout expires.
+async fn awaited_call_times_out() {
+    // Server whose Heartbeat handler sleeps well past the client's reply timeout.
+    let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
+        host: "127.0.0.1".to_owned(),
+        port: 0,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        RecordingCsms {
+            seen: Arc::new(std::sync::Mutex::new(Vec::new())),
+            slow_heartbeat: true,
+        },
+        sink(),
+    )
+    .await
+    .expect("server bind");
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+
+    // Short client timeout: the slow (700ms) handler cannot answer before it fires.
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 150,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("client connect");
+
+    let hb = Action16::Heartbeat(serde_json::from_value(json!({})).unwrap());
+    assert!(client.call(hb).await.is_err(), "call should have timed out");
+
+    client.terminate().await.expect("terminate");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-021 — a Call sent fire-and-forget (`notify`) delivers to the peer with no reply awaited by the caller.
+/// OC-R-016 — a slow handler does not block the read pump: a later Call is answered while an earlier fire-and-forget is still being handled.
+/// OC-R-015 — the two outbound frames (the fire and the awaited Call) are serialized through the single writer, so both arrive well-formed and are answered.
+async fn fire_and_forget_delivers_without_blocking_reads() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let server = csms::ServerBuilder::<V1_6>::new(csms::Config {
+        host: "127.0.0.1".to_owned(),
+        port: 0,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        RecordingCsms {
+            seen: seen.clone(),
+            slow_heartbeat: true,
+        },
+        sink(),
+    )
+    .await
+    .expect("server bind");
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("client connect");
+
+    // Fire a slow Heartbeat without awaiting, then immediately await a fast StatusNotification.
+    let hb = Action16::Heartbeat(serde_json::from_value(json!({})).unwrap());
+    client.notify(hb).await.expect("notify");
+    let status = Action16::StatusNotification(
+        serde_json::from_value(json!({
+            "connectorId": 1, "errorCode": "NoError", "status": "Available"
+        }))
+        .unwrap(),
+    );
+    // The status reply comes back even though the heartbeat handler is still sleeping — proving the
+    // read pump is not blocked by the in-flight slow handler.
+    assert!(matches!(
+        client.call(status).await.unwrap(),
+        Response16::StatusNotification(_)
+    ));
+
+    // Give the slow heartbeat time to finish; the fire-and-forget did reach the server.
+    sleep(Duration::from_millis(900)).await;
+    assert!(seen.lock().unwrap().iter().any(|a| a == "Heartbeat"));
+
+    client.terminate().await.expect("terminate");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-032 — a CSMS rejects an upgrade that does not advertise the version's subprotocol token (HTTP 400), and echoes the token on acceptance.
+async fn csms_requires_and_echoes_subprotocol() {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+
+    // No Sec-WebSocket-Protocol header → the upgrade is rejected.
+    let bare = url.clone().into_client_request().expect("bad url");
+    assert!(
+        tokio_tungstenite::connect_async(bare).await.is_err(),
+        "upgrade without the subprotocol token must be rejected"
+    );
+
+    // With the token → accepted, and the response echoes it.
+    let mut request = url.into_client_request().expect("bad url");
+    request
+        .headers_mut()
+        .insert("Sec-WebSocket-Protocol", "ocpp1.6".parse().unwrap());
+    let (_ws, resp) = tokio_tungstenite::connect_async(request)
+        .await
+        .expect("upgrade with the token should succeed");
+    assert_eq!(
+        resp.headers()
+            .get("sec-websocket-protocol")
+            .and_then(|v| v.to_str().ok()),
+        Some("ocpp1.6")
+    );
+
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-051 — each accepted connection gets an opaque, monotonically increasing id from 1; the charge-point identity is kept as metadata, not the key, so duplicate identities never collide.
+async fn connection_ids_are_monotonic_and_identity_is_metadata() {
+    let server = start_server().await;
+    let addr = server.local_addr();
+
+    // Two clients dialing the *same* charge-point identity path.
+    let make_client = || async {
+        cs::ClientBuilder::<V1_6>::new(cs::Config {
+            url: format!("ws://{addr}/ocpp/DUP"),
+            timeout_ms: 2000,
+            basic_auth: None,
+            tls: None,
+        })
+        .spawn(
+            TestCs {
+                remote_start_seen: Arc::new(AtomicBool::new(false)),
+            },
+            sink(),
+        )
+        .await
+        .expect("client connect")
+    };
+    let c1 = make_client().await;
+    let c2 = make_client().await;
+
+    // Wait for both to register.
+    for _ in 0..50 {
+        if server.registry().connection_ids().len() >= 2 {
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    let mut ids = server.registry().connection_ids();
+    ids.sort();
+    assert_eq!(
+        ids.len(),
+        2,
+        "both duplicate-identity clients registered separately"
+    );
+    // Ids start at 1 and increase; the two are distinct despite the shared identity.
+    assert!(ids[0] < ids[1]);
+    assert_eq!(ids[0], csms::ConnectionId(1));
+    // The identity is retained as metadata against each id.
+    assert_eq!(server.registry().identity(ids[0]).as_deref(), Some("DUP"));
+    assert_eq!(server.registry().identity(ids[1]).as_deref(), Some("DUP"));
+
+    c1.terminate().await.expect("terminate c1");
+    c2.terminate().await.expect("terminate c2");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-052 — a CSMS broadcasts a fire-and-forget Call to every live connection and can disconnect one connection.
+/// OC-R-054 — a connection is deregistered from the registry when its connection loop ends.
+async fn csms_broadcast_and_disconnect() {
+    use ferrowl_ocpp::csms::Command;
+
+    let seen_a = Arc::new(AtomicBool::new(false));
+    let seen_b = Arc::new(AtomicBool::new(false));
+    let server = start_server().await;
+    let addr = server.local_addr();
+
+    let mk = |flag: Arc<AtomicBool>| async move {
+        cs::ClientBuilder::<V1_6>::new(cs::Config {
+            url: format!("ws://{addr}/ocpp/CS"),
+            timeout_ms: 2000,
+            basic_auth: None,
+            tls: None,
+        })
+        .spawn(
+            TestCs {
+                remote_start_seen: flag,
+            },
+            sink(),
+        )
+        .await
+        .expect("client connect")
+    };
+    let ca = mk(seen_a.clone()).await;
+    let cb = mk(seen_b.clone()).await;
+
+    for _ in 0..50 {
+        if server.registry().connection_ids().len() >= 2 {
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    // Broadcast a server-initiated RemoteStartTransaction to every connected CS.
+    let remote_start = Action16::RemoteStartTransaction(
+        serde_json::from_value(json!({ "idTag": "TAG1" })).unwrap(),
+    );
+    server
+        .send(Command::Broadcast(remote_start))
+        .await
+        .expect("broadcast");
+    sleep(Duration::from_millis(300)).await;
+    assert!(seen_a.load(Ordering::SeqCst) && seen_b.load(Ordering::SeqCst));
+
+    // Disconnect one connection; the registry drops it when its loop ends.
+    let mut ids = server.registry().connection_ids();
+    ids.sort();
+    server
+        .send(Command::DisconnectConnection(ids[0]))
+        .await
+        .expect("disconnect");
+    let mut deregistered = false;
+    for _ in 0..50 {
+        if !server.registry().connection_ids().contains(&ids[0]) {
+            deregistered = true;
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    assert!(deregistered, "disconnected connection was not deregistered");
+
+    let _ = ca.terminate().await;
+    cb.terminate().await.expect("terminate cb");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-055 — a command addressing an unknown connection id fails that command alone (an awaited Call is rejected) and the server keeps running.
+async fn command_to_unknown_connection_fails_alone() {
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 2000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("client connect");
+    let conn = first_connection(&server).await;
+
+    // An awaited Call to a nonexistent id is rejected, but the server stays up.
+    let remote_start = Action16::RemoteStartTransaction(
+        serde_json::from_value(json!({ "idTag": "TAG1" })).unwrap(),
+    );
+    assert!(
+        server
+            .call(csms::ConnectionId(9999), remote_start.clone())
+            .await
+            .is_err()
+    );
+
+    // The real connection still works after the failed command.
+    let resp = server.call(conn, remote_start).await.expect("live call ok");
+    assert!(matches!(resp, Response16::RemoteStartTransaction(_)));
+
+    client.terminate().await.expect("terminate");
+    server.terminate().await.expect("server terminate");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-053 — terminating a CSMS ends the accept loop, so no further connections are accepted.
+async fn terminated_csms_stops_accepting() {
+    let server = start_server().await;
+    let addr = server.local_addr();
+    server.terminate().await.expect("server terminate");
+
+    // After termination the listener is gone: a new client cannot connect.
+    sleep(Duration::from_millis(100)).await;
+    let res = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url: format!("ws://{addr}/ocpp/CS001"),
+        timeout_ms: 1000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "no connection should be accepted after terminate"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-048 — a CS does not reconnect on its own: once the CSMS drops, the connection stays down.
+async fn cs_does_not_reconnect() {
+    let server = start_server().await;
+    let addr = server.local_addr();
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url: format!("ws://{addr}/ocpp/CS001"),
+        timeout_ms: 1000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        TestCs {
+            remote_start_seen: Arc::new(AtomicBool::new(false)),
+        },
+        sink(),
+    )
+    .await
+    .expect("client connect");
+
+    // Drop the server; the CS must not silently re-establish a connection.
+    server.terminate().await.expect("server terminate");
+    sleep(Duration::from_millis(300)).await;
+
+    // A Call now fails and keeps failing (no reconnect brought the link back).
+    let hb = Action16::Heartbeat(serde_json::from_value(json!({})).unwrap());
+    assert!(client.call(hb).await.is_err());
+
+    let _ = client.terminate().await;
+}
+
+/// A CS handler that records its connect/disconnect lifecycle hooks firing.
+#[derive(Clone)]
+struct HookCs {
+    connected: Arc<AtomicBool>,
+    disconnected: Arc<AtomicBool>,
+}
+
+impl CsActionHandler<V1_6> for HookCs {
+    async fn handle_call(&self, _action: Action16) -> Result<Response16, CallError> {
+        Err(CallError::new(CallErrorCode::NotImplemented, "unsupported"))
+    }
+    async fn on_connected(&self) {
+        self.connected.store(true, Ordering::SeqCst);
+    }
+    async fn on_disconnected(&self) {
+        self.disconnected.store(true, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// OC-R-023 — a peer's WebSocket close ends the connection: the connection is torn down and the CS's disconnect hook fires.
+/// OC-R-046 — the CS exposes connect and disconnect lifecycle hooks (both observed here).
+async fn peer_close_ends_connection_and_fires_disconnect_hook() {
+    let connected = Arc::new(AtomicBool::new(false));
+    let disconnected = Arc::new(AtomicBool::new(false));
+    let server = start_server().await;
+    let url = format!("ws://{}/ocpp/CS001", server.local_addr());
+    let client = cs::ClientBuilder::<V1_6>::new(cs::Config {
+        url,
+        timeout_ms: 1000,
+        basic_auth: None,
+        tls: None,
+    })
+    .spawn(
+        HookCs {
+            connected: connected.clone(),
+            disconnected: disconnected.clone(),
+        },
+        sink(),
+    )
+    .await
+    .expect("client connect");
+
+    // The connect hook fired on establishment.
+    for _ in 0..50 {
+        if connected.load(Ordering::SeqCst) {
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        connected.load(Ordering::SeqCst),
+        "connect hook did not fire"
+    );
+
+    // The CSMS closes: the connection ends and the disconnect hook fires.
+    server.terminate().await.expect("server terminate");
+    let mut fired = false;
+    for _ in 0..50 {
+        if disconnected.load(Ordering::SeqCst) {
+            fired = true;
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    assert!(fired, "disconnect hook did not fire on peer close");
+
+    let _ = client.terminate().await;
 }

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -280,6 +280,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-093 — sending a write command to an instance that is not running fails rather than being silently dropped.
     async fn send_command_never_started_is_not_running() {
         let instance = tcp_client_instance();
         let err = instance.send_command(Command::Terminate).await.unwrap_err();
@@ -291,6 +292,7 @@ mod tests {
     /// variant directly (both are in-crate types), which exercises exactly the same
     /// branch in `send_command` without any real I/O.
     #[tokio::test]
+    /// MB-R-093 — sending a write command to an instance whose role is a server fails with an error rather than being silently dropped.
     async fn send_command_on_server_is_invalid_operation() {
         let mut instance = tcp_client_instance();
         let task = tokio::spawn(async { Ok(()) });
@@ -308,6 +310,7 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-094 — stopping a client requests graceful termination and deactivates the instance.
     async fn graceful_stop_deactivates_instance() {
         let mut instance = tcp_client_instance();
         instance.start(sink(), sink()).await.expect("start");
@@ -315,6 +318,21 @@ mod tests {
 
         instance.stop().await.expect("stop");
         assert!(!instance.active());
+    }
+
+    #[tokio::test]
+    /// MB-R-094 — a stopped instance is restartable: after a graceful stop it can be started again.
+    async fn stopped_instance_is_restartable() {
+        let mut instance = tcp_client_instance();
+        instance.start(sink(), sink()).await.expect("first start");
+        assert!(instance.active());
+        instance.stop().await.expect("stop");
+        assert!(!instance.active());
+
+        // Restart the same instance.
+        instance.start(sink(), sink()).await.expect("restart");
+        assert!(instance.active());
+        instance.stop().await.expect("cleanup stop");
     }
 
     #[tokio::test]

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -520,6 +520,54 @@ mod tests {
         assert_eq!(got, vec![(0, 3), (50, 51)]);
     }
 
+    #[test]
+    /// MB-R-082 — with no explicit read_ranges for a function code, each register is read by its own request; registers are not merged across gaps.
+    fn ut_no_read_ranges_each_register_own_request() {
+        use super::build_read_operations;
+        use crate::config::device::ReadRanges;
+
+        // Three contiguous holding registers, no explicit ranges → three separate requests.
+        let regs = vec![
+            u16reg(1, Kind::HoldingRegister, 0, Access::ReadWrite),
+            u16reg(1, Kind::HoldingRegister, 1, Access::ReadWrite),
+            u16reg(1, Kind::HoldingRegister, 2, Access::ReadWrite),
+        ];
+        let ops = build_read_operations(&regs, &ReadRanges::default());
+        let mut got: Vec<_> = ops
+            .iter()
+            .map(|o| (o.range.start(), o.range.end()))
+            .collect();
+        got.sort_unstable();
+        assert_eq!(got, vec![(0, 1), (1, 2), (2, 3)]);
+    }
+
+    #[test]
+    /// MB-R-084 — address gaps inside a configured read_range but backed by no register are declared as read-only cells.
+    fn ut_explicit_read_coverage_declares_gap_cells() {
+        use super::explicit_read_coverage;
+        use crate::config::device::ReadRanges;
+
+        // Registers at 0 and 5 (each one word) inside holding range "0-10": the uncovered gaps
+        // between/around them become Read cells so a batched read spanning them can be stored.
+        let regs = vec![
+            u16reg(1, Kind::HoldingRegister, 0, Access::ReadWrite),
+            u16reg(1, Kind::HoldingRegister, 5, Access::ReadWrite),
+        ];
+        let ranges = ReadRanges {
+            holding: Some("0-10".to_string()),
+            ..Default::default()
+        };
+        let cov = explicit_read_coverage(&regs, &ranges);
+        // Every declared gap is a read-only cell.
+        assert!(
+            cov.iter()
+                .all(|(_, kind, _)| matches!(kind, MemKind::Read(_)))
+        );
+        let mut gaps: Vec<_> = cov.iter().map(|(_, _, r)| (r.start(), r.end())).collect();
+        gaps.sort_unstable();
+        assert_eq!(gaps, vec![(1, 5), (6, 11)]);
+    }
+
     // Replicates the server `:set`/edit write path + the table decode read path.
     #[test]
     /// MB-R-090 — writing a value to a fixed-address register on a server read-modify-writes it into the store, observable on read-back.

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -546,6 +546,98 @@ mod tests {
     }
 
     #[test]
+    /// MB-R-079 — a register definition's `default` value is encoded and written into the store at construction (bypassing cell access checks).
+    fn ut_default_value_written_into_store_at_construction() {
+        use super::ModbusModule;
+        use crate::config::{Endpoint, ModuleSpec, Role};
+        use ferrowl_modbus::{Key, SlaveKey};
+        use ferrowl_store::Range;
+
+        // `device_with_defs` seeds the fixed holding register "hold" at address 0 with default 7.
+        let device = device_with_defs();
+        let spec = ModuleSpec {
+            name: "srv".into(),
+            device: String::new(),
+            role: Role::Server,
+            endpoint: Endpoint::Tcp {
+                ip: "127.0.0.1".into(),
+                port: 5020,
+            },
+        };
+        let module = ModbusModule::new(&spec, &device);
+        let key = Key {
+            id: SlaveKey {
+                slave_id: 1,
+                kind: Kind::HoldingRegister,
+            },
+        };
+        let stored = module
+            .memory()
+            .read()
+            .read_unchecked(key, &Range::new(0, 1));
+        assert_eq!(stored, Some(vec![7]));
+    }
+
+    #[tokio::test]
+    /// MB-R-089 — reconfiguring a module's endpoint/role rebuilds the instance against the same store and preserves the stored register values.
+    async fn ut_reconfigure_preserves_stored_values() {
+        use super::ModbusModule;
+        use crate::config::device::ReadRanges;
+        use crate::config::{Endpoint, ModuleSpec, Role};
+        use ferrowl_modbus::{Key, SlaveKey};
+        use ferrowl_store::Range;
+
+        let device = device_with_defs();
+        let spec = ModuleSpec {
+            name: "srv".into(),
+            device: String::new(),
+            role: Role::Server,
+            endpoint: Endpoint::Tcp {
+                ip: "127.0.0.1".into(),
+                port: 5020,
+            },
+        };
+        let mut module = ModbusModule::new(&spec, &device);
+        let key = Key {
+            id: SlaveKey {
+                slave_id: 1,
+                kind: Kind::HoldingRegister,
+            },
+        };
+        // The store carries the default (7) at address 0.
+        assert_eq!(
+            module
+                .memory()
+                .read()
+                .read_unchecked(key.clone(), &Range::new(0, 1)),
+            Some(vec![7])
+        );
+
+        // Switch role (server → client) and endpoint; the stored value must survive.
+        let timing = ModbusModule::resolve_timing(&device);
+        module
+            .reconfigure(
+                &Endpoint::Tcp {
+                    ip: "127.0.0.1".into(),
+                    port: 5099,
+                },
+                Role::Client,
+                timing,
+                ReadRanges::default(),
+            )
+            .await
+            .expect("reconfigure");
+
+        assert_eq!(
+            module
+                .memory()
+                .read()
+                .read_unchecked(key, &Range::new(0, 1)),
+            Some(vec![7])
+        );
+    }
+
+    #[test]
     /// MB-R-076 — a module instance can be an RTU client, building its register set from the device config.
     fn ut_module_new_rtu_client() {
         use super::ModbusModule;

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -523,6 +523,34 @@ mod tests {
     }
 
     #[tokio::test]
+    /// MB-R-091 — a client write dispatches a Modbus write command (not a direct store write); the read-write register's store value is not updated by the `:set`.
+    async fn ut_client_fixed_write_dispatches_command_not_store() {
+        use ferrowl_modbus::{Key, SlaveKey};
+        use ferrowl_store::Range;
+
+        let mut client = view(Role::Client);
+        client.apply_add(edited("hold", holding(0), None)).await;
+
+        // The client path sends a Modbus write command; with no running instance the send fails,
+        // and either way a read-write register's store is not written directly by `:set`.
+        let result = client.set_register_value("hold", "5").await;
+        assert!(msg(&result).contains("failed")); // took the client send-command branch, not the server memory-write branch
+
+        let key = Key {
+            id: SlaveKey {
+                slave_id: 1,
+                kind: Kind::HoldingRegister,
+            },
+        };
+        let stored = client
+            .module
+            .memory()
+            .read()
+            .read_unchecked(key, &Range::new(0, 1));
+        assert_ne!(stored, Some(vec![5]));
+    }
+
+    #[tokio::test]
     async fn ut_set_register_value_unknown_warns() {
         let mut v = view(Role::Server);
         assert!(msg(&v.set_register_value("nope", "1").await).contains("unknown register"));

--- a/ferrowl/src/module/ocpp/client/backend.rs
+++ b/ferrowl/src/module/ocpp/client/backend.rs
@@ -433,6 +433,22 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-083 — a client module does not connect automatically; a freshly built backend is offline until an explicit start.
+    fn new_client_backend_is_offline_until_started() {
+        let backend = OcppClient::<ferrowl_ocpp::V1_6>::new();
+        assert!(!backend.is_online());
+    }
+
+    #[test]
+    /// OC-R-088 — message sequence numbers are strictly increasing and unique, the cursor a file-log tee uses to write each message at most once.
+    fn message_seqs_are_strictly_increasing() {
+        let a = next_seq();
+        let b = next_seq();
+        let c = next_seq();
+        assert!(a < b && b < c);
+    }
+
+    #[test]
     /// OC-R-087 — the in-memory message log is bounded to the most recent 200 messages, evicting oldest-first.
     fn push_capped_evicts_oldest_beyond_limit() {
         let mut buf = Vec::new();

--- a/ferrowl/src/module/ocpp/config/session.rs
+++ b/ferrowl/src/module/ocpp/config/session.rs
@@ -230,6 +230,32 @@ mod tests {
     }
 
     #[test]
+    /// OC-R-079 — a module instance is exactly one role (client XOR server) and speaks exactly one OCPP version.
+    /// OC-R-080 — the OCPP version (and role) is a property of the device config, not the session entry; `from_parts` sources them from the device config.
+    fn ut_version_and_role_come_from_device_config() {
+        use super::super::device::OcppDeviceConfig;
+
+        // The session entry (`OcppModuleSpec`) carries no version/role field — only the endpoint.
+        let module = OcppModuleSpec {
+            name: "cs".into(),
+            device: "dev.toml".into(),
+            protocol: OcppProtocol::Ws,
+            ip: "127.0.0.1".into(),
+            port: 9000,
+            path: String::new(),
+        };
+        let device = OcppDeviceConfig {
+            ocpp_version: OcppVersion::V2_1,
+            role: OcppRole::Server,
+            ..Default::default()
+        };
+        let spec = OcppSpec::from_parts(&module, &device);
+        // Exactly one version and one role, both sourced from the device config.
+        assert_eq!(spec.version, OcppVersion::V2_1);
+        assert_eq!(spec.role, OcppRole::Server);
+    }
+
+    #[test]
     /// OC-R-081 — the session entry carries the endpoint (scheme, ip, port, path), from which the connection URL is built.
     fn ut_protocol_display_and_url() {
         let spec = OcppSpec {

--- a/ferrowl/src/module/ocpp/config/session.rs
+++ b/ferrowl/src/module/ocpp/config/session.rs
@@ -197,6 +197,39 @@ mod tests {
     use super::*;
 
     #[test]
+    /// OC-R-001 — exactly the three OCPP versions (1.6, 2.0.1, 2.1) are supported, and each is reachable in both the client and server roles.
+    fn ut_three_versions_reachable_in_both_roles() {
+        // The three supported versions, each with its fixed wire token.
+        let versions = [
+            (OcppVersion::V1_6, "1.6"),
+            (OcppVersion::V2_0_1, "2.0.1"),
+            (OcppVersion::V2_1, "2.1"),
+        ];
+        for (version, wire) in versions {
+            assert_eq!(
+                serde_json::to_value(version).unwrap(),
+                serde_json::Value::String(wire.to_string())
+            );
+            // Every version pairs with either role in a module spec (both roles reachable).
+            for role in [OcppRole::Client, OcppRole::Server] {
+                let spec = OcppSpec {
+                    name: "m".into(),
+                    version,
+                    role,
+                    protocol: OcppProtocol::Ws,
+                    ip: "127.0.0.1".into(),
+                    port: 9000,
+                    path: String::new(),
+                    timeout_ms: None,
+                    security: OcppSecurityConfig::default(),
+                };
+                assert_eq!(spec.version, version);
+                assert_eq!(spec.role, role);
+            }
+        }
+    }
+
+    #[test]
     /// OC-R-081 — the session entry carries the endpoint (scheme, ip, port, path), from which the connection URL is built.
     fn ut_protocol_display_and_url() {
         let spec = OcppSpec {


### PR DESCRIPTION
## Why

The requirement-ID backfill left 35 Modbus and 50 OCPP requirements with no citing
test (#99). A requirement on `main` is meant to be a statement about code that
exists *and is tested*; these were untested. This works both lists: adds a citing
test where the code is correct, and — per `AGENTS.md` — would raise any spec/code
contradiction as its own task. None were found; every requirement worked was
correct-but-untested.

## What

66 of the 71 in-scope requirements now carry a test whose doc comment cites the ID.
(7 Modbus + 7 OCPP from the issue's lists had already been covered by #101/#102 since
it was filed.)

**Modbus — all 28:**
- `MB-R-001, 006, 024` — register five-property model, format width, ASCII invalid-UTF8 decode (unit).
- `MB-R-036–041, 044, 048` — client poll loop: runtime-mutable op list, round-robin, delay, tick, per-request timeout, read-only function codes, retry reset, per-op slave id (`tcp_loopback` integration).
- `MB-R-051, 052, 054, 056` — reconnect backoff constants/sequence + drop-non-terminate (unit), config re-read + backoff-reset-after-success (integration).
- `MB-R-065, 066, 069, 070, 074, 075` — serve any declared slave, request-received logging, TCP address error, concurrent accept; RTU serial-open failure (new `rtu_serial` tests).
- `MB-R-079, 082, 084, 089, 091, 093, 094` — default-at-construction, read-range grouping/gap cells, reconfigure preserves store, client write dispatches command, send-to-server/stopped errors, graceful stop + restartable.

**OCPP — 38 of 43:**
- `OC-R-001, 007` — three versions × both roles; 2.1 strict superset of 2.0.1 (+26).
- `OC-R-011, 012, 028` — UUIDv4 unique ids, the ten error codes + unknown→GenericError, CallError verbatim rejection.
- `OC-R-035, 037, 038, 039` — CS client-cert only-when-both, CSMS cert sources, self-signed SANs, require-client-cert CA.
- `OC-R-013, 015, 016, 020, 021, 023, 024, 025, 027, 032` — connection engine: non-text/malformed frames, single-writer serialization, per-call task, reply timeout, fire-and-forget, peer-close+disconnect hook, handler-reject CallError, FormationViolation, subprotocol reject/echo (`ws_loopback_v16`).
- `OC-R-043–056` — CS/CSMS roles: dial+token, commands, lifecycle hooks, port-0 bind, monotonic connection ids + identity-as-metadata, broadcast/disconnect, deregister-on-close, unknown-id failure, per-connection handler, no-auto-reconnect.
- `OC-R-050` — TLS terminated before handshake (cited on the existing TLS loopback).
- `OC-R-079, 080, 083, 088, 097` — one role/version from device config, client no-auto-connect, message-seq monotonicity, ws-ignores-TLS.

## How

Mostly citing doc comments on new tests directly above the `fn`; some IDs added to
existing tests that already exercised the behavior (e.g. the full-duplex loopback
carries `OC-R-014/043/045/046/047/049/056`). Behavior-only reachable through a live
transport got integration tests (`tcp_loopback`, `rtu_serial`, `ws_loopback_v16`);
pure logic got unit tests. No production code changed except test modules.

## Not covered — follow-up

5 OCPP requirements (`OC-R-062, 082, 084, 085, 086`) are correct but live inside async
view/tick-loop methods with no pure-function seam and no existing view test harness.
Covering them needs a dedicated `OcppClientView`/`ServerView` harness — tracked in #104
rather than forced with fragile tests here. None contradict the spec.

## Verification

`cargo test --workspace` (all green) · `cargo clippy --workspace --all-targets` (clean)
· `cargo fmt --check` (clean).

Closes #99
