### PR TITLE
Record which requirements are intentionally not unit-tested

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -69,6 +69,44 @@ Not every area needs every file; add and drop based on need.
 | `data-contract.md` | Wire and file formats: register model and data formats, payload shapes, config schema. |
 | `edge-cases.md` | Boundary behavior, error semantics, and stated known limitations. |
 
+## Requirements intentionally not unit-tested
+
+Most requirements are pinned by a test whose doc comment cites the ID (`MB-R-*`,
+`OC-R-*`, …). A minority are **deliberately** left without a dedicated test — they
+are not gaps. This list records that decision so it is not re-discovered as one.
+Two kinds qualify; nothing else does.
+
+**1. Design-posture, platform, CI, and versioning statements.** These assert facts
+about the build or the design, not runtime behavior a `shall` test could observe:
+
+- `NF-R-001`, `NF-R-002`, `NF-R-003` — which platforms/toolchain CI builds.
+- `NF-R-010` — the "no benchmarks asserted; hot path stays on `parking_lot`" posture.
+- `NF-R-040` — crates versioned in lockstep.
+- `NF-R-041` — the testing conventions themselves.
+
+**2. Cross-cutting restatements whose behavior is asserted under the owning area.**
+The requirement is real but its test lives with the per-area requirement that owns
+the behavior, cited by *that* ID:
+
+- `NF-R-011` — Lua sim on its own OS thread → exercised by the `scripting/` sim tests.
+- `NF-R-020` — Modbus reconnect backoff → `MB-R-050`/`MB-R-051`/`MB-R-052`.
+- `NF-R-021` — OCPP no auto-reconnect → `OC-R-048`.
+- `NF-R-022` — a Lua error never crashes its host → `SC-R-032`.
+- `NF-R-030` — OCPP TLS / Basic Auth → the OCPP security tests (`OC-R-029`–`041`).
+- `NF-R-031` — Lua sandbox → `SC-R-006`/`SC-R-007`.
+
+**Config envelope, exercised by the config round-trip (serde) tests rather than
+asserted per field:** `CS-R-001`, `CS-R-010`, `CS-R-015`, `CS-R-016`, `CS-R-018`,
+`CS-R-020`, `CS-R-021`, `CS-R-022`, `CS-R-034`. These describe the *shape* of a
+valid session/device file (which fields exist, which are informational, default
+omission); a save→load→compare round-trip covers them collectively, so they carry
+no per-ID test. The behavioral envelope requirements (save/load, `migrate`) are
+tested on their own.
+
+Anything **not** on this list is expected to carry a citing test. If a requirement
+here later gains observable behavior worth pinning directly, remove it from the list
+and add the test.
+
 ## Keeping specs true
 
 Before changing code in an area, read that area's `requirements.md`. If the change


### PR DESCRIPTION
## Why

The requirement-ID backfill (#99) confirmed a set of requirements that carry **no
dedicated test by design** — platform / CI / versioning / design-posture statements,
cross-cutting restatements whose behavior is asserted under the owning per-area
requirement, and the config-envelope requirements exercised collectively by the
config round-trip tests. Recording the decision keeps this set from being
re-discovered as a coverage gap later.

## What

Adds a `## Requirements intentionally not unit-tested` section to
`docs/specs/README.md`, grouped by why each requirement is not pinned by its own
citing test:

- **Design-posture / platform / CI / versioning facts** — `NF-R-001,002,003,010,040,041`.
- **Cross-cutting restatements, tested under the owning ID** — `NF-R-011` (scripting sim tests), `NF-R-020` (`MB-R-050/051/052`), `NF-R-021` (`OC-R-048`), `NF-R-022` (`SC-R-032`), `NF-R-030` (OCPP security tests), `NF-R-031` (`SC-R-006/007`).
- **Config envelope via the round-trip serde tests** — `CS-R-001,010,015,016,018,020,021,022,034`.

Anything not on the list is expected to carry a citing test; the note says so, and
says to remove an entry (and add the test) if it later gains observable behavior
worth pinning directly.

## Verification

Docs-only — no code or test change. Every claim was checked against the specs and the
test suite before writing: all 12 NF-R and 9 CS-R exist; the 9 CS-R are genuinely
uncited while the other config requirements (save/load, `migrate`) are tested; the
referenced `SC-R-006/007/032` and OCPP security tests exist; config serde round-trip
tests exist.

Closes #100
