### PR TITLE
Cover the 5 OCPP view-lifecycle requirements with citing tests

### DIFF
--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -896,4 +896,117 @@ mod tests {
             "Enter in close-confirm must close the config-key editor"
         );
     }
+
+    // --- Module lifecycle: connection loss / role-version switch -----------------------------
+
+    #[tokio::test]
+    /// OC-R-062 — losing the connection halts automatic transmission and resets the heartbeat
+    /// cadence counter.
+    async fn losing_connection_resets_heartbeat_and_halts_autotransmit() {
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        // Simulate having been connected with the heartbeat counter part-way to its next beat. The
+        // backend was never started, so it reports offline: this tick is the online→offline edge.
+        v.runtime.was_online = true;
+        v.runtime.heartbeat_tick = 7;
+        assert!(!v.backend.is_online());
+
+        v.refresh_impl().await;
+        assert_eq!(
+            v.runtime.heartbeat_tick, 0,
+            "connection loss must reset the heartbeat cadence counter"
+        );
+        assert!(!v.runtime.was_online, "the offline state must be recorded");
+
+        // While offline the auto-Heartbeat block is skipped, so the counter never advances — all
+        // automatic transmission stays halted.
+        v.refresh_impl().await;
+        assert_eq!(
+            v.runtime.heartbeat_tick, 0,
+            "no heartbeat may be scheduled while offline"
+        );
+    }
+
+    #[tokio::test]
+    /// OC-R-085 — changing role or OCPP version replaces the view; any other change reconfigures
+    /// the running instance in place, reconnecting only if it was connected.
+    async fn role_or_version_change_replaces_view_else_reconfigures_in_place() {
+        // Role change (client → server): the view is replaced.
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        let mut edited = v.spec.clone();
+        edited.role = OcppRole::Server;
+        v.deferred.setup = Some((edited, String::new()));
+        v.refresh_impl().await;
+        assert!(
+            v.take_replacement().is_some(),
+            "a role change must replace the view"
+        );
+
+        // OCPP version change: the view is replaced.
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        let mut edited = v.spec.clone();
+        edited.version = OcppVersion::V2_0_1;
+        v.deferred.setup = Some((edited, String::new()));
+        v.refresh_impl().await;
+        assert!(
+            v.take_replacement().is_some(),
+            "a version change must replace the view"
+        );
+
+        // Any other change (here the endpoint port): reconfigure in place. The instance was never
+        // connected, so it must not reconnect — no replacement, spec updated, still offline.
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        let mut edited = v.spec.clone();
+        edited.port = 4711;
+        v.deferred.setup = Some((edited.clone(), String::new()));
+        v.refresh_impl().await;
+        assert!(
+            v.take_replacement().is_none(),
+            "a non-role/version change must not replace the view"
+        );
+        assert_eq!(
+            v.spec, edited,
+            "the in-place reconfigure must adopt the spec"
+        );
+        assert!(
+            !v.backend.is_online(),
+            "an instance that was not connected must not reconnect on reconfigure"
+        );
+    }
+
+    #[tokio::test]
+    /// OC-R-086 — switching a client's OCPP version keeps its Lua scripts and warns that they may
+    /// call actions the new version lacks.
+    async fn version_switch_keeps_scripts_and_warns() {
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        v.device.scripts = vec![ScriptDef {
+            name: "sim".into(),
+            code: "-- noop".into(),
+            enabled: true,
+        }];
+        let mut edited = v.spec.clone();
+        edited.version = OcppVersion::V2_0_1;
+        v.deferred.setup = Some((edited, String::new()));
+        v.refresh_impl().await;
+
+        let replacement = v
+            .take_replacement()
+            .expect("version switch replaces the view");
+        let scripts = replacement.scripts().expect("client keeps its scripts");
+        assert!(
+            scripts.iter().any(|s| s.name == "sim"),
+            "the Lua scripts must be carried into the new-version view"
+        );
+
+        let warned = v
+            .log
+            .write()
+            .await
+            .peek_n(crate::app::LOG_SIZE)
+            .iter()
+            .any(|(_, _, line)| line.contains("may call actions the new version lacks"));
+        assert!(
+            warned,
+            "the version switch must warn about version-specific actions"
+        );
+    }
 }

--- a/ferrowl/src/module/ocpp/server/view/mod.rs
+++ b/ferrowl/src/module/ocpp/server/view/mod.rs
@@ -898,4 +898,55 @@ mod tests {
             "selection reset — sync_actions rebuilt the list with no selection present"
         );
     }
+
+    // --- Module lifecycle: listener rebuild / restart ---------------------------------------
+
+    #[tokio::test]
+    /// OC-R-082 — the listener configuration is rebuilt from the current module spec on every
+    /// start, so an edited security section takes effect on the next start without a stale copy.
+    async fn each_start_rebuilds_listener_from_current_spec() {
+        use crate::module::view::CommandResult;
+        let mut v = server_view();
+
+        // First start: plain ws, so the started message names no TLS fallback.
+        let CommandResult::Handled(Some((_, msg))) = v.handle_command_impl("start").await else {
+            panic!("start must report a message");
+        };
+        assert!(
+            !msg.contains("self-signed"),
+            "a plain listener must not report a self-signed certificate, got: {msg}"
+        );
+        assert!(v.backend.is_online());
+        assert!(v.backend.bound_addr().is_some());
+
+        // Edit the endpoint's security to wss (no certs → self-signed fallback), then restart.
+        // The rebound listener must reflect the *current* spec, not the stale plain copy.
+        v.spec.protocol = OcppProtocol::Wss;
+        let CommandResult::Handled(Some((_, msg))) = v.handle_command_impl("restart").await else {
+            panic!("restart must report a message");
+        };
+        assert!(
+            msg.contains("self-signed"),
+            "the restart must rebuild the listener from the edited spec, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    /// OC-R-084 — restarting a server stops the current instance, starts a new one from the
+    /// current spec, and discards every observed charging-station entry.
+    async fn restart_discards_observed_entries_and_rebinds() {
+        let mut v = server_view();
+        v.handle_command_impl("start").await;
+
+        // Observe a charging station: entry_index records it.
+        v.entry_index("CP1", Scope::CS, None);
+        assert!(!v.entries.is_empty(), "the observed entry must be recorded");
+
+        v.handle_command_impl("restart").await;
+        assert!(
+            v.entries.is_empty(),
+            "restart must discard every observed charging-station entry"
+        );
+        assert!(v.backend.is_online(), "restart must start a new instance");
+    }
 }


### PR DESCRIPTION
## Why

The requirement-ID backfill (#99) left 5 OCPP requirements uncovered — correct, but each lives inside an async view/tick-loop method with no pure-function seam, so they were split out to #104. This backs each with a passing test on `main`.

## What

Five citing tests, one per requirement. No behavior change; no spec change.

- **OC-R-062** — connection loss resets the heartbeat cadence counter and halts automatic transmission.
- **OC-R-082** — every start rebuilds the listener from the current spec (edited security takes effect, no stale copy).
- **OC-R-084** — restarting a server stops the old instance, starts a new one, and discards observed CS entries.
- **OC-R-085** — a role/version change replaces the view; any other change reconfigures in place, reconnecting only if it was connected.
- **OC-R-086** — a client version switch keeps its Lua scripts and warns they may call actions the new version lacks.

## How it was resolved

The issue anticipated building a reusable view harness. None was needed — both view test modules already have constructors (`client_view::<V>()`, `server_view()`) plus `entry_index`, so the tests drive the existing async `refresh_impl` / command flow directly. OC-R-062/085/086 exercise the client `refresh_impl` setup/offline paths; OC-R-082/084 drive the server `:start`/`:restart` commands and assert on the reported TLS binding and the observed-entry list.

## Verification

`cargo test -p ferrowl` → 714 unit/bin + 2 headless pass, 0 fail. `clippy -D warnings` and `fmt --check` clean.

Closes #104