### PR TITLE
Add process-level and in-crate tests for the CLI, headless runner, and app-free shell

### DIFF
--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -598,6 +598,34 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-044 — a long line is truncated to the per-line cap, and the total-written counter is
+    /// monotonic across ring eviction.
+    fn ut_log_truncates_long_lines_and_counts_monotonically() {
+        let mut ring = LogRing::init();
+        // A line over the cap is stored truncated to exactly LOG_MAX_LINE characters.
+        ring.write(Level::Info, &"x".repeat(LOG_MAX_LINE + 50));
+        assert_eq!(ring.peek_n(1)[0].2.chars().count(), LOG_MAX_LINE);
+
+        // Writing past the ring capacity evicts oldest entries, but `written()` keeps counting.
+        for i in 0..(LOG_SIZE as u64 + 10) {
+            ring.write(Level::Info, &format!("l{i}"));
+        }
+        assert_eq!(ring.written(), 1 + LOG_SIZE as u64 + 10);
+        // The ring itself retains only its bounded capacity.
+        assert_eq!(ring.peek_n(LOG_SIZE + 100).len(), LOG_SIZE);
+    }
+
+    #[test]
+    /// UI-R-050 — the color scheme is a single compile-time constant selected by build feature,
+    /// never switched at runtime.
+    fn ut_color_scheme_is_compile_time_constant() {
+        // Usable in a `const` context ⇒ resolved at compile time; a runtime-switchable value
+        // could not appear here. Exactly one such constant exists, chosen by build feature.
+        const SCHEME: ferrowl_ui::ColorScheme = ferrowl_ui::COLOR_SCHEME;
+        let _ = SCHEME.bg;
+    }
+
+    #[test]
     /// UI-R-045 — a configured file sink buffers lines and flushes them to disk on flush/teardown, timestamped.
     fn log_ring_persists_lines_to_file_sink() {
         let dir = std::env::temp_dir();

--- a/ferrowl/src/cli/headless.rs
+++ b/ferrowl/src/cli/headless.rs
@@ -705,6 +705,8 @@ mod tests {
     #[tokio::test]
     /// CL-R-020 — the runner builds and starts each module (without touching the terminal) and
     /// drains its log to the output stream.
+    /// CL-R-022 — the loop refreshes every module each tick and drains its newly appended log
+    /// lines to the output.
     async fn ut_run_starts_modules_and_drains_output() {
         let mut args = modbus_run_args("starts", free_port(), 1);
         let log_file = std::env::temp_dir()

--- a/ferrowl/src/cli/headless.rs
+++ b/ferrowl/src/cli/headless.rs
@@ -639,4 +639,158 @@ mod tests {
             "no session source should appear in the log when no script is enabled, got:\n{contents}"
         );
     }
+
+    // --- Run lifecycle, exit codes, and the output contract ----------------------------------
+
+    /// A device config on disk for a headless module fixture.
+    fn write_device(tag: &str) -> String {
+        use ferrowl_util::convert::{Converter, FileType};
+        let p = std::env::temp_dir().join(format!("ferrowl_cl_{tag}_device.toml"));
+        Converter::save(
+            &holding_device_config(),
+            p.to_str().unwrap(),
+            FileType::Toml,
+        )
+        .unwrap();
+        p.to_str().unwrap().to_string()
+    }
+
+    /// A `RunArgs` starting one modbus TCP server module on `port` for `duration` seconds.
+    fn modbus_run_args(tag: &str, port: u16, duration: u64) -> RunArgs {
+        let device = write_device(tag);
+        RunArgs {
+            sessions: vec![],
+            modules: vec![format!(
+                "name=m,device={device},transport=tcp,ip=127.0.0.1,port={port},role=server"
+            )],
+            ocpp: vec![],
+            duration: Some(duration),
+            log_file: None,
+            exit_on_error: false,
+        }
+    }
+
+    /// Grab an ephemeral port and release it, so a fixture can bind it deterministically.
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    #[tokio::test]
+    /// CL-R-021 — the headless runner treats a module's device-config load failure as fatal to
+    /// startup, rather than skipping the module like the TUI.
+    async fn ut_build_modules_fails_hard_on_bad_device() {
+        let mut args = modbus_run_args("badbuild", free_port(), 1);
+        args.modules = vec![
+            "name=m,device=/no/such/device.toml,transport=tcp,ip=127.0.0.1,port=0,role=server"
+                .into(),
+        ];
+        assert!(build_modules(&args).await.is_err());
+    }
+
+    #[tokio::test]
+    /// CL-R-030 — a setup failure (a module's device config fails to load) makes the run exit 1.
+    async fn ut_run_returns_one_on_setup_failure() {
+        let mut args = modbus_run_args("setupfail", free_port(), 1);
+        args.modules = vec![
+            "name=m,device=/no/such/device.toml,transport=tcp,ip=127.0.0.1,port=0,role=server"
+                .into(),
+        ];
+        assert_eq!(run(&args).await, 1);
+    }
+
+    #[tokio::test]
+    /// CL-R-020 — the runner builds and starts each module (without touching the terminal) and
+    /// drains its log to the output stream.
+    async fn ut_run_starts_modules_and_drains_output() {
+        let mut args = modbus_run_args("starts", free_port(), 1);
+        let log_file = std::env::temp_dir()
+            .join("ferrowl_cl_starts.log")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let _ = std::fs::remove_file(&log_file);
+        args.log_file = Some(log_file.clone());
+
+        assert_eq!(run(&args).await, 0);
+        let contents = std::fs::read_to_string(&log_file).unwrap();
+        assert!(
+            contents.contains("m |"),
+            "expected drained lines tagged with the module name, got:\n{contents}"
+        );
+    }
+
+    #[tokio::test]
+    /// CL-R-024 — a --duration run exits cleanly once the deadline is reached.
+    /// CL-R-032 — such a run, with no exit-code-2 condition, returns exit code 0.
+    async fn ut_run_duration_deadline_exits_zero() {
+        let args = modbus_run_args("deadline", free_port(), 1);
+        assert_eq!(run(&args).await, 0);
+    }
+
+    #[tokio::test]
+    /// CL-R-026 — on loop exit the runner stops every module: a second run rebinds the same port,
+    /// which only succeeds if the first run released it.
+    async fn ut_run_stops_modules_on_exit() {
+        let port = free_port();
+        assert_eq!(run(&modbus_run_args("stop1", port, 1)).await, 0);
+        // If the first run had not stopped its listener, this bind (inside start) would fail.
+        assert_eq!(run(&modbus_run_args("stop2", port, 1)).await, 0);
+    }
+
+    #[tokio::test]
+    /// CL-R-031 — with --exit-on-error set, a `[sim]`-prefixed error line makes the run exit 2.
+    async fn ut_run_exit_on_error_returns_two() {
+        use ferrowl_util::convert::{Converter, FileType};
+        let session = config::Session {
+            version: None,
+            modules: vec![],
+            scripts: vec![ScriptDef {
+                name: "boom".into(),
+                code: "error(\"boom\")".into(),
+                enabled: true,
+            }],
+            interval: 0.05,
+        };
+        let path = std::env::temp_dir().join("ferrowl_cl_exit_on_error_session.toml");
+        Converter::save(&session, path.to_str().unwrap(), FileType::Toml).unwrap();
+        let args = RunArgs {
+            sessions: vec![path.to_str().unwrap().to_string()],
+            modules: vec![],
+            ocpp: vec![],
+            duration: Some(5),
+            log_file: None,
+            exit_on_error: true,
+        };
+        assert_eq!(run(&args).await, 2);
+    }
+
+    #[tokio::test]
+    /// CL-R-041 — --log-file is opened create-and-append: an existing file is appended to, not
+    /// truncated.
+    async fn ut_log_file_is_appended_not_truncated() {
+        let log_file = std::env::temp_dir()
+            .join("ferrowl_cl_append.log")
+            .to_str()
+            .unwrap()
+            .to_string();
+        std::fs::write(&log_file, "PREEXISTING\n").unwrap();
+
+        let mut args = modbus_run_args("append", free_port(), 1);
+        args.log_file = Some(log_file.clone());
+        assert_eq!(run(&args).await, 0);
+
+        let contents = std::fs::read_to_string(&log_file).unwrap();
+        assert!(
+            contents.starts_with("PREEXISTING\n"),
+            "the pre-existing content must be preserved, got:\n{contents}"
+        );
+        assert!(
+            contents.contains("m |"),
+            "new drained lines must be appended, got:\n{contents}"
+        );
+    }
 }

--- a/ferrowl/src/cli/mod.rs
+++ b/ferrowl/src/cli/mod.rs
@@ -691,4 +691,59 @@ mod tests {
         assert_ne!(e.kind(), ErrorKind::DisplayHelp);
         assert_eq!(e.exit_code(), 2);
     }
+
+    // --- Config envelope: module-entry type dispatch and required fields ------------------
+
+    /// Save `modules` as a session file and resolve it through [`CliArgs::module_specs`].
+    fn resolve_session(
+        tag: &str,
+        modules: Vec<serde_json::Value>,
+    ) -> Result<Vec<ModuleSpec>, String> {
+        use ferrowl_util::convert::{Converter, FileType};
+        let session = config::Session {
+            version: None,
+            modules,
+            scripts: vec![],
+            interval: 1.0,
+        };
+        let path = std::env::temp_dir().join(format!("ferrowl_cli_{tag}.toml"));
+        Converter::save(&session, path.to_str().unwrap(), FileType::Toml).unwrap();
+        let args = CliArgs {
+            command: None,
+            modules: vec![],
+            sessions: vec![path.to_str().unwrap().to_string()],
+            devices: vec![],
+            demo: false,
+        };
+        args.module_specs()
+    }
+
+    #[test]
+    /// CS-R-013 — a module entry whose `type` is neither modbus nor ocpp aborts session resolution.
+    fn ut_unknown_module_type_aborts_resolution() {
+        let err = resolve_session(
+            "unknown_type",
+            vec![serde_json::json!({"type": "plc", "name": "x"})],
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("unsupported module type"),
+            "expected a hard error, got: {err}"
+        );
+    }
+
+    #[test]
+    /// CS-R-051 — a module instance missing a schema-required field fails to load.
+    fn ut_module_missing_required_field_errors() {
+        let mut module =
+            serde_json::to_value(create_module_spec_by_device("x".into(), "d.toml".into()))
+                .unwrap();
+        // Drop the required `name`, keep the modbus tag.
+        module.as_object_mut().unwrap().remove("name");
+        module
+            .as_object_mut()
+            .unwrap()
+            .insert("type".into(), "modbus".into());
+        assert!(resolve_session("missing_name", vec![module]).is_err());
+    }
 }

--- a/ferrowl/src/cli/mod.rs
+++ b/ferrowl/src/cli/mod.rs
@@ -603,4 +603,92 @@ mod tests {
         assert_eq!(ocpp[0].name, "cs");
         assert_eq!(ocpp[0].port, 9000);
     }
+
+    // --- Argument surface: version/help, subcommands, flag scoping, parse errors ----------
+
+    #[test]
+    /// CL-R-001 — --version and --help print and exit 0, taking precedence over starting the TUI.
+    fn ut_version_and_help_exit_zero() {
+        use clap::error::ErrorKind;
+        let v = CliArgs::try_parse_from(["ferrowl", "--version"]).unwrap_err();
+        assert_eq!(v.kind(), ErrorKind::DisplayVersion);
+        assert_eq!(v.exit_code(), 0);
+        let h = CliArgs::try_parse_from(["ferrowl", "--help"]).unwrap_err();
+        assert_eq!(h.kind(), ErrorKind::DisplayHelp);
+        assert_eq!(h.exit_code(), 0);
+    }
+
+    #[test]
+    /// CL-R-010 — the two subcommands dispatch, replacing the default (start-the-TUI) action.
+    fn ut_subcommands_dispatch() {
+        assert!(matches!(
+            CliArgs::parse_from(["ferrowl", "run"]).command,
+            Some(SubCommand::Run(_))
+        ));
+        assert!(matches!(
+            CliArgs::parse_from(["ferrowl", "migrate", "-i", "a.toml", "-o", "b.toml"]).command,
+            Some(SubCommand::Migrate(_))
+        ));
+        // No subcommand → default action (the TUI); `command` stays None.
+        assert!(CliArgs::parse_from(["ferrowl"]).command.is_none());
+    }
+
+    #[test]
+    /// CL-R-011 — the migrate subcommand requires both --input and --output.
+    fn ut_migrate_requires_input_and_output() {
+        assert!(CliArgs::try_parse_from(["ferrowl", "migrate"]).is_err());
+        assert!(CliArgs::try_parse_from(["ferrowl", "migrate", "-i", "a.toml"]).is_err());
+        assert!(CliArgs::try_parse_from(["ferrowl", "migrate", "-o", "b.toml"]).is_err());
+        match CliArgs::parse_from(["ferrowl", "migrate", "-i", "a.toml", "-o", "b.toml"]).command {
+            Some(SubCommand::Migrate(m)) => {
+                assert_eq!(m.input, "a.toml");
+                assert_eq!(m.output, "b.toml");
+            }
+            _ => panic!("expected migrate"),
+        }
+    }
+
+    #[test]
+    /// CL-R-014 — --ocpp is accepted only on run; --device only on the top-level command.
+    fn ut_ocpp_and_device_flag_scoping() {
+        assert!(CliArgs::try_parse_from(["ferrowl", "--ocpp", "name=cs,device=d,port=1"]).is_err());
+        assert!(
+            CliArgs::try_parse_from(["ferrowl", "run", "--ocpp", "name=cs,device=d,port=1"])
+                .is_ok()
+        );
+        assert!(CliArgs::try_parse_from(["ferrowl", "run", "--device", "d.toml"]).is_err());
+        assert!(CliArgs::try_parse_from(["ferrowl", "--device", "d.toml"]).is_ok());
+    }
+
+    #[test]
+    /// CL-R-015 — --exit-on-error exists only on the run subcommand.
+    fn ut_exit_on_error_is_run_only() {
+        assert!(CliArgs::try_parse_from(["ferrowl", "--exit-on-error"]).is_err());
+        assert!(CliArgs::try_parse_from(["ferrowl", "run", "--exit-on-error"]).is_ok());
+    }
+
+    #[test]
+    /// CL-R-016 — top-level values supplied alongside a run subcommand do not reach the runner.
+    fn ut_run_ignores_top_level_values() {
+        let args = CliArgs::parse_from(["ferrowl", "--module", "name=m,device=d,port=1", "run"]);
+        assert_eq!(args.modules, vec!["name=m,device=d,port=1".to_string()]);
+        match args.command {
+            Some(SubCommand::Run(run)) => {
+                assert!(
+                    run.modules.is_empty(),
+                    "run must not see the top-level --module"
+                );
+            }
+            _ => panic!("expected run"),
+        }
+    }
+
+    #[test]
+    /// CL-R-035 — an argument-parsing error exits with the parser's usage exit code (2).
+    fn ut_arg_parse_error_exits_two() {
+        use clap::error::ErrorKind;
+        let e = CliArgs::try_parse_from(["ferrowl", "--bogus-flag"]).unwrap_err();
+        assert_ne!(e.kind(), ErrorKind::DisplayHelp);
+        assert_eq!(e.exit_code(), 2);
+    }
 }

--- a/ferrowl/src/config/mod.rs
+++ b/ferrowl/src/config/mod.rs
@@ -134,6 +134,19 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-052 — a field present in a file but absent from the schema is ignored on load.
+    fn ut_load_ignores_unknown_field() {
+        let path = tmp("ferrowl_cfgmod_unknown_field.toml");
+        std::fs::write(
+            &path,
+            "bogus_unknown_field = 42\n[definitions.reg]\ntype = \"U16\"\n",
+        )
+        .unwrap();
+        let device = load_device(&path).unwrap();
+        assert!(device.definitions.contains_key("reg"));
+    }
+
+    #[test]
     fn ut_config_error_display() {
         assert!(
             ConfigError::UnknownFormat("p".into())

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -398,11 +398,38 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::demo_session_script;
+    use super::{build_tabs, demo_session_script};
+    use crate::cli::{CliArgs, create_module_spec_by_device};
+    use crate::config::{self, OcppModuleSpec, Session};
     use crate::registry::ModuleRegistry;
     use ferrowl_lua::ContextBuilder;
     use ferrowl_lua::module::ModuleDirModule;
+    use ferrowl_util::convert::{Converter, FileType};
     use std::sync::Arc;
+
+    fn demo_args(modules: Vec<String>, devices: Vec<String>) -> CliArgs {
+        CliArgs {
+            command: None,
+            modules,
+            sessions: vec![],
+            devices,
+            demo: true,
+        }
+    }
+
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn save_session(tag: &str, session: &Session) -> String {
+        let path = std::env::temp_dir().join(format!("ferrowl_main_{tag}.toml"));
+        Converter::save(session, path.to_str().unwrap(), FileType::Toml).unwrap();
+        path.to_str().unwrap().to_string()
+    }
 
     // The demo session script must at least parse and run cleanly against an empty module
     // registry (no modules -> the loop body never executes, so C_Log is never touched).
@@ -420,5 +447,98 @@ mod tests {
             .expect("demo session script must parse");
         ctx.call_all()
             .expect("demo session script must run on an empty registry");
+    }
+
+    #[tokio::test]
+    /// CL-R-006 — --demo starts exactly eight tabs (two modbus, six ocpp) plus one example
+    /// session-level script.
+    async fn ut_demo_builds_eight_tabs_and_a_session_script() {
+        let tabs = build_tabs(&demo_args(vec![], vec![])).await.unwrap();
+        assert_eq!(tabs.len(), 8, "the demo set is exactly eight tabs");
+        assert!(
+            !demo_session_script().code.is_empty(),
+            "the demo session ships one example script"
+        );
+    }
+
+    #[tokio::test]
+    /// CL-R-005 — under --demo, --module/--session/--device are ignored for building tabs.
+    async fn ut_demo_ignores_module_and_device() {
+        let args = demo_args(
+            vec!["name=x,device=d.toml,port=1".into()],
+            vec!["dev.toml".into()],
+        );
+        let tabs = build_tabs(&args).await.unwrap();
+        assert_eq!(
+            tabs.len(),
+            8,
+            "demo ignores --module/--device: still exactly the demo set"
+        );
+    }
+
+    #[tokio::test]
+    /// CS-R-053 — a session instance whose device config is missing is skipped, not fatal.
+    async fn ut_missing_device_is_skipped_not_fatal() {
+        let mut module = serde_json::to_value(create_module_spec_by_device(
+            "mb".into(),
+            "/no/such/dev.toml".into(),
+        ))
+        .unwrap();
+        module
+            .as_object_mut()
+            .unwrap()
+            .insert("type".into(), "modbus".into());
+        let session = Session {
+            version: None,
+            modules: vec![module],
+            scripts: vec![],
+            interval: 1.0,
+        };
+        let args = CliArgs {
+            command: None,
+            modules: vec![],
+            sessions: vec![save_session("skip", &session)],
+            devices: vec![],
+            demo: false,
+        };
+        let tabs = build_tabs(&args).await.unwrap();
+        assert!(tabs.is_empty(), "the missing-device instance is skipped");
+    }
+
+    #[tokio::test]
+    /// CS-R-053 — a blank device path is a quick-start on the default device, built not skipped.
+    async fn ut_blank_device_builds_on_default() {
+        let mut module = serde_json::to_value(OcppModuleSpec {
+            name: "cs".into(),
+            device: String::new(),
+            protocol: config::ocpp::OcppProtocol::Ws,
+            ip: "127.0.0.1".into(),
+            port: free_port(),
+            path: String::new(),
+        })
+        .unwrap();
+        module
+            .as_object_mut()
+            .unwrap()
+            .insert("type".into(), "ocpp".into());
+        let session = Session {
+            version: None,
+            modules: vec![module],
+            scripts: vec![],
+            interval: 1.0,
+        };
+        let args = CliArgs {
+            command: None,
+            modules: vec![],
+            sessions: vec![save_session("blank", &session)],
+            devices: vec![],
+            demo: false,
+        };
+        let tabs = build_tabs(&args).await.unwrap();
+        assert_eq!(
+            tabs.len(),
+            1,
+            "a blank device path builds on the default config"
+        );
     }
 }

--- a/ferrowl/src/registry.rs
+++ b/ferrowl/src/registry.rs
@@ -282,6 +282,21 @@ mod tests {
         );
     }
 
+    #[test]
+    /// UI-R-004 — tab display names are unique at all times: repeats of a name are auto-suffixed
+    /// so no two tabs ever collide.
+    fn ut_tab_names_are_unique_after_dedupe() {
+        let names = vec![
+            "Modbus".to_string(),
+            "Modbus".to_string(),
+            "Modbus".to_string(),
+        ];
+        let out = dedupe_names(&names);
+        let unique: std::collections::HashSet<_> = out.iter().collect();
+        assert_eq!(unique.len(), out.len(), "every tab name must be distinct");
+        assert_eq!(out, vec!["Modbus", "Modbus (2)", "Modbus (3)"]);
+    }
+
     // --- End-to-end through a real Lua context ----------------------------------
 
     use ferrowl_codec::format::{BitField, Endian, Resolution};

--- a/ferrowl/tests/cli.rs
+++ b/ferrowl/tests/cli.rs
@@ -1,0 +1,112 @@
+//! Subprocess tests for the ferrowl **process** CLI: SIGINT shutdown, `migrate` exit codes, and
+//! the stderr-diagnostics contract. These drive the compiled binary because the behaviors are
+//! genuinely process-level (async signal handling, `std::process::exit`, stdout/stderr
+//! separation) and cannot be observed by calling a library function.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferrowl"))
+}
+
+fn evse_device() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/../configs/evse.toml")
+}
+
+#[test]
+/// CL-R-025 — a SIGINT (Ctrl-C) during a headless run ends the loop as a clean shutdown (exit 0).
+fn it_sigint_is_a_clean_shutdown() {
+    let module = format!(
+        "name=sig,device={},transport=tcp,ip=127.0.0.1,port=15931,role=server",
+        evse_device()
+    );
+    // No --duration: the run loops until interrupted.
+    let mut child = bin()
+        .args(["run", "--module", &module])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn ferrowl run");
+
+    // Let it build the module and enter the tick loop before signalling.
+    std::thread::sleep(Duration::from_millis(800));
+    assert!(
+        Command::new("kill")
+            .args(["-INT", &child.id().to_string()])
+            .status()
+            .expect("send SIGINT")
+            .success()
+    );
+
+    let status = child.wait().expect("wait for ferrowl");
+    assert_eq!(status.code(), Some(0), "SIGINT must be a clean exit 0");
+}
+
+#[test]
+/// CL-R-033 — migrate exits 1 on failure (unrecognized extension) and 0 on success, never 2.
+/// CL-R-012 — migrate is dispatched directly, exiting with its own code without starting the TUI
+/// or a headless run.
+fn it_migrate_exit_codes() {
+    let dir = std::env::temp_dir();
+
+    // Failure: an input path whose extension is neither .toml nor .json.
+    let bad = bin()
+        .args([
+            "migrate",
+            "-i",
+            "/tmp/ferrowl_migrate_input.bin",
+            "-o",
+            dir.join("ferrowl_migrate_bad_out.toml").to_str().unwrap(),
+        ])
+        .output()
+        .expect("run migrate");
+    assert_eq!(bad.status.code(), Some(1), "unknown extension must exit 1");
+    assert!(
+        String::from_utf8_lossy(&bad.stderr)
+            .to_lowercase()
+            .contains("error"),
+        "a diagnostic beginning `error:` must be written to stderr"
+    );
+
+    // Success: a default (empty) legacy config converts and is written out.
+    let input = dir.join("ferrowl_migrate_input.toml");
+    std::fs::write(&input, "").unwrap();
+    let output = dir.join("ferrowl_migrate_out.toml");
+    let ok = bin()
+        .args([
+            "migrate",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run migrate");
+    assert_eq!(
+        ok.status.code(),
+        Some(0),
+        "a successful migration must exit 0; stderr: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+}
+
+#[test]
+/// CL-R-042 — setup/fatal diagnostics go to stderr, keeping stdout as the drained-log stream.
+fn it_fatal_diagnostics_go_to_stderr() {
+    let module =
+        "name=x,device=/no/such/device.toml,transport=tcp,ip=127.0.0.1,port=15932,role=server";
+    let out = bin()
+        .args(["run", "--module", module, "--duration", "1"])
+        .output()
+        .expect("run ferrowl");
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("Error:"),
+        "the fatal diagnostic must be on stderr"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("Error:"),
+        "stdout must stay the machine-readable log stream, free of the diagnostic"
+    );
+}


### PR DESCRIPTION
## Why

The requirement-ID backfill surfaced a cluster of CLI, headless-runner, config-loading, and TUI app-shell requirements that describe shipped behavior but had no citing test. This backs the in-crate-reachable subset with tests; the remaining app-shell cluster is tracked separately (see below).

## Scope split

Investigation found the TUI app-shell input/nav/command/quit/tick requirements cannot be unit-tested as-is: `App::new()` builds an `AlternateScreen`, whose constructor calls `enable_raw_mode()`, which errors under `cargo test` (no controlling terminal). So `App` cannot be constructed in a test. That cluster — and the App-terminal decoupling it needs — was split to #108, and #98 was trimmed to the subset reachable without it.

## What

27 requirements, each with at least one citing test. No behavior change; no spec change.

- **CLI argument surface** (clap `try_parse_from`): CL-R-001, 010, 011, 014, 015, 016, 035.
- **Headless run lifecycle, exit codes, output contract** (`headless::run`): CL-R-020, 021, 022, 024, 026, 030, 031, 032, 041.
- **Demo tab set** (`build_tabs`): CL-R-005, 006.
- **Config loading**: CS-R-013, 051, 052, 053.
- **App-free TUI**: UI-R-004, 044, 050.
- **Subprocess** (new `ferrowl/tests/cli.rs`): CL-R-012, 025, 033, 042.

## How it was resolved

The seams already existed: clap's `CliArgs::try_parse_from` exercises the argument surface (version/help/parse-error exit codes, flag scoping) without a subprocess; `headless::run(&RunArgs) -> i32` returns the exit code and writes the log file, so the run lifecycle and output contract are driven in-crate; `build_tabs(&CliArgs)` builds the demo set and the missing-device skip path; the config loaders cover type dispatch and required/unknown fields. Only the genuinely process-level behaviors — SIGINT shutdown, `migrate`'s direct `process::exit`, and stdout/stderr separation — need the real binary, driven from a small `tests/cli.rs` (SIGINT via `kill -INT`, no new dependency).

## Verification

`cargo test -p ferrowl` → 738 unit/bin + 3 `tests/cli.rs` + 2 `tests/headless.rs` pass, 0 fail. `clippy --all-targets -D warnings` and `fmt --check` clean.

Closes #98