### PR TITLE
Make App's screen generic so it can be mocked in tests

### DIFF
--- a/ferrowl-ui/src/lib.rs
+++ b/ferrowl-ui/src/lib.rs
@@ -17,7 +17,7 @@ pub mod traits;
 pub mod widgets;
 pub use border::Border;
 pub use event_result::EventResult;
-pub use screen::AlternateScreen;
+pub use screen::{AlternateScreen, DrawSurface};
 
 use ratatui::style::Color;
 

--- a/ferrowl-ui/src/screen.rs
+++ b/ferrowl-ui/src/screen.rs
@@ -64,6 +64,26 @@ where
     }
 }
 
+/// A terminal-like surface `App` can render a frame onto. Abstracts the single
+/// method `App` calls on its screen (`draw`) so a test double backed by
+/// ratatui's `TestBackend` can be injected in place of a real terminal.
+pub trait DrawSurface {
+    /// Renders one frame via the given callback.
+    fn draw<F: FnOnce(&mut Frame)>(&mut self, render: F) -> std::io::Result<()>;
+}
+
+impl<W> DrawSurface for AlternateScreen<W>
+where
+    W: Write + Init,
+{
+    fn draw<F: FnOnce(&mut Frame)>(&mut self, render: F) -> std::io::Result<()> {
+        // Inherent method (returns a `CompletedFrame` we discard); named
+        // explicitly to avoid resolving to this trait method.
+        AlternateScreen::draw(self, render)?;
+        Ok(())
+    }
+}
+
 impl<W> Drop for AlternateScreen<W>
 where
     W: Write + Init,

--- a/ferrowl/src/app/commands.rs
+++ b/ferrowl/src/app/commands.rs
@@ -6,7 +6,7 @@ use ferrowl_util::convert::{Converter, FileType};
 use crate::config::Session;
 use crate::module::view::CommandResult;
 
-use super::{App, Level};
+use super::{App, DrawSurface, Level};
 
 /// Pure validation: usable index or error text. Unit-testable without an App.
 fn validate_copy_index(
@@ -29,7 +29,7 @@ fn validate_copy_index(
     Ok(idx)
 }
 
-impl App {
+impl<S: DrawSurface> App<S> {
     /// Execute a parsed `:` command. Returns `true` when the app should quit.
     pub(super) async fn run_command(&mut self, input: &str) -> bool {
         use crate::command::Cmd;

--- a/ferrowl/src/app/keys.rs
+++ b/ferrowl/src/app/keys.rs
@@ -8,7 +8,7 @@ use ferrowl_ui::traits::{HandleEvents, SetFocus};
 
 use crate::app::{DIGIT_CHORD_TIMEOUT, KeyMode};
 
-use super::{App, Focus};
+use super::{App, DrawSurface, Focus};
 
 /// Result of feeding one digit into the `Ctrl+t` tab-jump chord.
 #[derive(Debug, PartialEq, Eq)]
@@ -42,7 +42,7 @@ fn digit_outcome(pending: Option<usize>, d: usize, ntabs: usize) -> DigitOutcome
     }
 }
 
-impl App {
+impl<S: DrawSurface> App<S> {
     pub(super) async fn handle_command_key(
         &mut self,
         modifiers: KeyModifiers,

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -13,8 +13,8 @@ mod render;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ferrowl_lua::module::ModuleDirectory;
 use ferrowl_ring::Ring;
-use ferrowl_ui::AlternateScreen;
 use ferrowl_ui::traits::SetFocus;
+use ferrowl_ui::{AlternateScreen, DrawSurface};
 use ferrowl_ui_derive::{Focus, focusable};
 use ratatui::{buffer::Buffer, layout::Rect};
 use std::io::Stdout;
@@ -267,8 +267,8 @@ pub enum KeyMode {
 
 /// Top-level application: owns the terminal and all module tabs, and runs the async
 /// event/redraw loop inside the tokio runtime.
-pub struct App {
-    screen: AlternateScreen<Stdout>,
+pub struct App<S: DrawSurface = AlternateScreen<Stdout>> {
+    screen: S,
     tabs: Vec<Tab>,
     active: usize,
     focus: Focus,
@@ -300,8 +300,27 @@ fn is_empty_shell(tab_count: usize, modal_open: bool) -> bool {
     tab_count == 0 && !modal_open
 }
 
-impl App {
+impl App<AlternateScreen<Stdout>> {
+    /// Builds the app on the real terminal (raw mode, alternate screen).
     pub fn new(
+        tabs: Vec<Tab>,
+        session_scripts: Vec<ScriptDef>,
+        session_interval: Duration,
+    ) -> std::io::Result<Self> {
+        Self::with_screen(
+            AlternateScreen::new()?,
+            tabs,
+            session_scripts,
+            session_interval,
+        )
+    }
+}
+
+impl<S: DrawSurface> App<S> {
+    /// Builds the app on an injected screen. `new` wraps this with the real
+    /// terminal; tests pass a `DrawSurface` mock.
+    pub(crate) fn with_screen(
+        screen: S,
         tabs: Vec<Tab>,
         session_scripts: Vec<ScriptDef>,
         session_interval: Duration,
@@ -323,7 +342,7 @@ impl App {
         session_sim.set_interval(session_interval);
         session_sim.set_scripts(session_scripts.clone());
         let mut app = Self {
-            screen: AlternateScreen::new()?,
+            screen,
             tabs,
             active: 0,
             focus,
@@ -660,5 +679,39 @@ mod tests {
         // Lines are timestamped.
         assert!(contents.trim_start().starts_with('['));
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// A `DrawSurface` test double backed by ratatui's `TestBackend`, letting an `App` be built
+    /// and drawn headlessly (no real terminal). Records how many frames it was asked to render.
+    struct MockScreen {
+        term: ratatui::Terminal<ratatui::backend::TestBackend>,
+        draws: usize,
+    }
+
+    impl MockScreen {
+        fn new() -> Self {
+            let term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 40)).unwrap();
+            Self { term, draws: 0 }
+        }
+    }
+
+    impl DrawSurface for MockScreen {
+        fn draw<F: FnOnce(&mut ratatui::Frame)>(&mut self, render: F) -> std::io::Result<()> {
+            self.term
+                .draw(render)
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            self.draws += 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    /// The generic screen seam lets an `App` be built on a mock surface and drawn without a real
+    /// terminal; `draw` succeeds and the mock records the frame.
+    fn ut_app_draws_onto_mock_screen() {
+        let mut app =
+            App::with_screen(MockScreen::new(), vec![], vec![], Duration::from_secs(1)).unwrap();
+        app.draw().unwrap();
+        assert_eq!(app.screen.draws, 1);
     }
 }

--- a/ferrowl/src/app/overlay.rs
+++ b/ferrowl/src/app/overlay.rs
@@ -9,9 +9,9 @@ use crate::module::modbus::setup::ModbusSetupView;
 use crate::module::type_select::TypeSelectDialog;
 use crate::module::view::ModuleView;
 
-use super::{App, Focus, Level, Overlay, Tab};
+use super::{App, DrawSurface, Focus, Level, Overlay, Tab};
 
-impl App {
+impl<S: DrawSurface> App<S> {
     pub(super) async fn handle_dialog_key(
         &mut self,
         modifiers: KeyModifiers,


### PR DESCRIPTION
## Background

`App` hard-coded its terminal as `screen: AlternateScreen<Stdout>`, whose constructor grabs the real terminal (raw mode, alternate screen, mouse capture). As a result `App` could not be built in a test and was never constructed in one — the whole event/redraw loop, key handling, overlays and commands had no `App`-level test coverage.

## What changed

`App` touches its screen through exactly one method: `screen.draw(closure)`. That single call is abstracted behind a new `DrawSurface` trait in `ferrowl-ui`, implemented for `AlternateScreen<W>`. `App` is now generic over it:

```rust
pub struct App<S: DrawSurface = AlternateScreen<Stdout>> { screen: S, ... }
```

The **default type parameter** keeps every existing call site unchanged — `App::new` and `main.rs` still infer `S = AlternateScreen<Stdout>` with no annotation. The constructor is split:

- `impl App<AlternateScreen<Stdout>>` — `new(...)` builds the real terminal, then delegates to `with_screen`.
- `impl<S: DrawSurface> App<S>` — `with_screen(screen, ...)` holds the shared construction body; tests pass a mock.

The four `impl App` blocks (`mod`, `overlay`, `keys`, `commands`) become `impl<S: DrawSurface> App<S>`.

## Test

Adds a `TestBackend`-backed `MockScreen` (the workspace's existing headless-render pattern) and `ut_app_draws_onto_mock_screen` — builds an `App` on the mock and drives one `draw`, asserting success and that the frame was recorded. First test to construct `App` at all; serves as the template for future `App` tests.

## Scope

Pure test-seam refactor — no observable behavior change, so `docs/specs` is untouched and no spec gate applies. The new test verifies an internal seam no requirement governs, so it is left untagged per `AGENTS.md`.

## Verification

- `cargo test --workspace` — pass (new test green)
- `cargo clippy --workspace` — clean
- `cargo fmt --check` — clean