### PR TITLE
Make the App shell unit-testable and cover the nav/command/quit/:write requirements

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -83,6 +83,12 @@ about the build or the design, not runtime behavior a `shall` test could observe
 - `NF-R-010` — the "no benchmarks asserted; hot path stays on `parking_lot`" posture.
 - `NF-R-040` — crates versioned in lockstep.
 - `NF-R-041` — the testing conventions themselves.
+- `UI-R-001` — alt-screen + raw-mode entry and terminal restore on normal, error, and panic
+  exit. The restore path calls into the real terminal (`enable_raw_mode`/`disable_raw_mode`),
+  which errors or panics under `cargo test` because there is no controlling tty — the exact
+  reason `App` renders through the `DrawSurface` seam. The seam is exercised headlessly
+  (`ut_app_draws_onto_mock_screen`), but the raw-mode/panic-hook control itself is a
+  terminal-platform fact no `shall` test can observe.
 
 **2. Cross-cutting restatements whose behavior is asserted under the owning area.**
 The requirement is real but its test lives with the per-area requirement that owns

--- a/ferrowl/src/app/commands.rs
+++ b/ferrowl/src/app/commands.rs
@@ -190,4 +190,181 @@ mod tests {
         );
         assert_eq!(validate_copy_index(Some(2), 3, 0), Ok(2));
     }
+
+    use crate::app::Focus;
+    use crate::app::testkit::{MockView, build_app};
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use serde_json::json;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A fresh, empty temp directory unique to this test run (so a `:write` there can be checked
+    /// for exactly the files it produced).
+    fn fresh_dir(tag: &str) -> PathBuf {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ferrowl_{tag}_{}_{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    /// UI-R-015 — in command mode `Esc` cancels (discards the buffer, restores content focus),
+    /// `Enter` submits the trimmed buffer, and an empty submission is a no-op.
+    async fn ut_command_mode_esc_cancels_enter_submits_trimmed_empty_noop() {
+        // Enter submits the buffer trimmed: the active view sees the command without surrounding
+        // whitespace.
+        let (v, handle) = MockView::pair("a");
+        let mut app = build_app(vec![v.boxed()]);
+        app.focus = Focus::Command;
+        app.command.state.set_input("  frobnicate  ".to_string());
+        let quit = app
+            .handle_command_key(KeyModifiers::empty(), KeyCode::Enter)
+            .await;
+        assert!(!quit);
+        assert_eq!(handle.commands(), vec!["frobnicate".to_string()]);
+        assert_eq!(
+            app.focus,
+            Focus::Content,
+            "content focus restored after submit"
+        );
+
+        // Esc discards the buffer without submitting and restores content focus.
+        let (v, handle) = MockView::pair("a");
+        let mut app = build_app(vec![v.boxed()]);
+        app.focus = Focus::Command;
+        app.command.state.set_input("frobnicate".to_string());
+        app.handle_command_key(KeyModifiers::empty(), KeyCode::Esc)
+            .await;
+        assert_eq!(app.focus, Focus::Content);
+        assert_eq!(app.command.state.input(), "", "buffer discarded on cancel");
+        assert!(handle.commands().is_empty(), "Esc does not submit");
+
+        // An empty (whitespace-only) submission does nothing.
+        let (v, handle) = MockView::pair("a");
+        let mut app = build_app(vec![v.boxed()]);
+        app.focus = Focus::Command;
+        app.command.state.set_input("   ".to_string());
+        let quit = app
+            .handle_command_key(KeyModifiers::empty(), KeyCode::Enter)
+            .await;
+        assert!(!quit);
+        assert!(handle.commands().is_empty(), "empty submit is a no-op");
+        assert_eq!(app.focus, Focus::Content);
+    }
+
+    #[tokio::test]
+    /// UI-R-019 — `:quit` closes the active tab (stopping its module first) and quits only when it
+    /// is the last tab; `:qall` quits immediately regardless of tab count.
+    async fn ut_quit_closes_active_tab_qall_quits_immediately() {
+        let (a, ha) = MockView::pair("a");
+        let (b, _hb) = MockView::pair("b");
+        let mut app = build_app(vec![a.boxed(), b.boxed()]);
+
+        // With two tabs, :quit closes the active one (stopping it) but does not quit the app.
+        assert!(!app.run_command("quit").await);
+        assert_eq!(app.tabs.len(), 1);
+        assert!(
+            ha.commands().contains(&"stop".to_string()),
+            "the closed tab's module was stopped before removal"
+        );
+        assert_eq!(app.tabs[0].name, "b", "the surviving tab becomes active");
+
+        // On the last remaining tab, :quit quits the app.
+        assert!(app.run_command("quit").await);
+
+        // :qall quits immediately without closing tabs one by one.
+        let (x, _hx) = MockView::pair("x");
+        let (y, _hy) = MockView::pair("y");
+        let mut app = build_app(vec![x.boxed(), y.boxed()]);
+        assert!(app.run_command("qall").await);
+        assert_eq!(
+            app.tabs.len(),
+            2,
+            ":qall signals quit without removing tabs"
+        );
+    }
+
+    #[tokio::test]
+    /// CS-R-030 — `:write` saves the current instances as a session file, defaulting the target to
+    /// `session.toml` and choosing the encoding from the path extension.
+    async fn ut_write_defaults_to_session_toml_and_encodes_by_extension() {
+        let dir = fresh_dir("cs030");
+
+        // Default target is session.toml, resolved relative to the working directory.
+        let toml_path = dir.join("session.toml");
+        let (v, _h) = MockView::pair("m");
+        let mut app = build_app(vec![v.with_session_spec(json!({"type": "mock"})).boxed()]);
+        app.run_command(&format!("write {}", toml_path.to_str().unwrap()))
+            .await;
+        assert!(toml_path.exists(), "explicit .toml target written");
+
+        // The default name is exactly "session.toml".
+        assert_eq!(
+            crate::command::parse("write"),
+            crate::command::Cmd::Write(None),
+            ":write with no argument carries no path, so the default applies",
+        );
+
+        // A .json extension selects JSON encoding.
+        let json_path = dir.join("out.json");
+        let (v, _h) = MockView::pair("m");
+        let mut app = build_app(vec![v.with_session_spec(json!({"type": "mock"})).boxed()]);
+        app.run_command(&format!("write {}", json_path.to_str().unwrap()))
+            .await;
+        let text = std::fs::read_to_string(&json_path).unwrap();
+        assert!(
+            text.trim_start().starts_with('{'),
+            "JSON encoding from .json"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    /// CS-R-031 — a save persists configuration only, never live runtime state: the written
+    /// modules are exactly each view's config spec.
+    async fn ut_write_persists_config_not_runtime_state() {
+        let dir = fresh_dir("cs031");
+        let spec = json!({"type": "mock", "addr": "127.0.0.1:5020"});
+        let (v, _h) = MockView::pair("m");
+        let mut app = build_app(vec![v.with_session_spec(spec.clone()).boxed()]);
+        let path = dir.join("s.toml");
+        let ps = path.to_str().unwrap();
+        app.run_command(&format!("write {ps}")).await;
+
+        let loaded = crate::config::load_session(ps).unwrap();
+        assert_eq!(
+            loaded.modules,
+            vec![spec],
+            "saved modules are the view's config spec with no runtime fields added"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    /// CS-R-032 — a `:write` writes the session file and nothing else: no device-config file is
+    /// emitted alongside it.
+    async fn ut_write_emits_only_the_session_file() {
+        let dir = fresh_dir("cs032");
+        let (v, _h) = MockView::pair("m");
+        let mut app = build_app(vec![v.with_session_spec(json!({"type": "mock"})).boxed()]);
+        let path = dir.join("only.toml");
+        app.run_command(&format!("write {}", path.to_str().unwrap()))
+            .await;
+
+        let files: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            files,
+            vec!["only.toml".to_string()],
+            "only the session file"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/ferrowl/src/app/keys.rs
+++ b/ferrowl/src/app/keys.rs
@@ -275,4 +275,109 @@ mod tests {
     fn leading_zero_jumps_immediately_even_with_many_tabs() {
         assert_eq!(digit_outcome(None, 0, 25), DigitOutcome::Jump(0));
     }
+
+    use crate::app::testkit::{MockView, build_app};
+
+    /// Feed `Ctrl+<lead>` then `key` through the nav handler as a two-key chord.
+    fn chord(app: &mut App<crate::app::testkit::MockScreen>, lead: char, key: KeyCode) {
+        app.handle_nav_key(KeyModifiers::CONTROL, KeyCode::Char(lead));
+        app.handle_nav_key(KeyModifiers::empty(), key);
+    }
+
+    fn app_with(names: &[&str]) -> App<crate::app::testkit::MockScreen> {
+        build_app(names.iter().map(|n| MockView::pair(n).0.boxed()).collect())
+    }
+
+    #[test]
+    /// UI-R-006 — the `:` command line removes focus from the content pane while open and restores
+    /// it on close, and every transition routes through the single focus choke point.
+    fn ut_command_line_removes_and_restores_content_focus() {
+        let mut app = app_with(&["a"]);
+        assert!(app.tabs[0].view.is_focused(), "content starts focused");
+        assert!(
+            !app.tabs[0].is_log_focused(),
+            "focus is content, not log — never both"
+        );
+
+        app.enter_command();
+        assert_eq!(app.focus, Focus::Command);
+        assert!(
+            !app.tabs[0].view.is_focused(),
+            "content unfocused while command open"
+        );
+
+        app.exit_command();
+        assert_eq!(app.focus, Focus::Content);
+        assert!(
+            app.tabs[0].view.is_focused(),
+            "content focus restored on close"
+        );
+    }
+
+    #[test]
+    /// UI-R-009 — the `Ctrl+w` chord toggles focus between the active tab's content view and its
+    /// log pane.
+    fn ut_ctrl_w_chord_toggles_content_and_log_focus() {
+        let mut app = app_with(&["a"]);
+        assert!(!app.tabs[0].is_log_focused());
+
+        chord(&mut app, 'w', KeyCode::Char('j'));
+        assert!(
+            app.tabs[0].is_log_focused(),
+            "Ctrl+w j moves focus to the log pane"
+        );
+
+        chord(&mut app, 'w', KeyCode::Char('k'));
+        assert!(
+            !app.tabs[0].is_log_focused(),
+            "Ctrl+w k moves focus back to content"
+        );
+    }
+
+    #[test]
+    /// UI-R-010 — the `Ctrl+t` chord: `l`/`h` step to the next/previous tab wrapping at the ends,
+    /// and a digit begins an index jump.
+    fn ut_ctrl_t_chord_switches_tabs_wrapping_and_by_digit() {
+        let mut app = app_with(&["a", "b", "c"]);
+        assert_eq!(app.active, 0);
+
+        chord(&mut app, 't', KeyCode::Char('l'));
+        assert_eq!(app.active, 1, "l advances");
+        chord(&mut app, 't', KeyCode::Char('l'));
+        chord(&mut app, 't', KeyCode::Char('l'));
+        assert_eq!(app.active, 0, "l wraps past the last tab");
+
+        chord(&mut app, 't', KeyCode::Char('h'));
+        assert_eq!(app.active, 2, "h wraps past the first tab");
+
+        chord(&mut app, 't', KeyCode::Char('1'));
+        assert_eq!(app.active, 1, "a digit jumps straight to that index");
+    }
+
+    #[test]
+    /// UI-R-012 — a jump to an out-of-range or already-active index is a silent no-op, and tab
+    /// switching is safe with zero or one tabs.
+    fn ut_tab_jump_out_of_range_or_active_is_a_noop_and_safe_at_edges() {
+        let mut app = app_with(&["a", "b"]);
+        app.switch_tab(9);
+        assert_eq!(app.active, 0, "out-of-range index ignored");
+        app.switch_tab(0);
+        assert_eq!(app.active, 0, "already-active index ignored");
+        app.switch_tab(1);
+        assert_eq!(app.active, 1, "valid index switches");
+
+        // One tab: every switch is a no-op, no panic.
+        let mut one = app_with(&["only"]);
+        one.switch_tab(3);
+        one.next_tab();
+        one.prev_tab();
+        assert_eq!(one.active, 0);
+
+        // Zero tabs (startup selector open): switching must not panic.
+        let mut none = build_app(vec![]);
+        none.switch_tab(0);
+        none.next_tab();
+        none.prev_tab();
+        assert_eq!(none.active, 0);
+    }
 }

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -9,6 +9,8 @@ mod help;
 mod keys;
 mod overlay;
 mod render;
+#[cfg(test)]
+mod testkit;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ferrowl_lua::module::ModuleDirectory;
@@ -681,34 +683,11 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// A `DrawSurface` test double backed by ratatui's `TestBackend`, letting an `App` be built
-    /// and drawn headlessly (no real terminal). Records how many frames it was asked to render.
-    struct MockScreen {
-        term: ratatui::Terminal<ratatui::backend::TestBackend>,
-        draws: usize,
-    }
-
-    impl MockScreen {
-        fn new() -> Self {
-            let term = ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 40)).unwrap();
-            Self { term, draws: 0 }
-        }
-    }
-
-    impl DrawSurface for MockScreen {
-        fn draw<F: FnOnce(&mut ratatui::Frame)>(&mut self, render: F) -> std::io::Result<()> {
-            self.term
-                .draw(render)
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
-            self.draws += 1;
-            Ok(())
-        }
-    }
-
     #[test]
     /// The generic screen seam lets an `App` be built on a mock surface and drawn without a real
     /// terminal; `draw` succeeds and the mock records the frame.
     fn ut_app_draws_onto_mock_screen() {
+        use super::testkit::MockScreen;
         let mut app =
             App::with_screen(MockScreen::new(), vec![], vec![], Duration::from_secs(1)).unwrap();
         app.draw().unwrap();

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -164,7 +164,7 @@ impl LogRing {
 
 /// Which top-level surface receives input. The content↔log split lives inside the active [`Tab`]
 /// (its `#[derive(Focus)]` enum), so `App` only tracks the modal layer.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Focus {
     /// The active tab's content/log panes (the tab decides which of the two).
     Content,
@@ -687,6 +687,34 @@ mod tests {
         // Lines are timestamped.
         assert!(contents.trim_start().starts_with('['));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    /// UI-R-003 — the app owns an ordered tab list with one active index; switching the active tab
+    /// changes only the index, leaving the order intact.
+    fn ut_ordered_tab_list_with_single_active_index() {
+        use super::testkit::{MockView, build_app};
+        let mut app = build_app(
+            ["a", "b", "c"]
+                .iter()
+                .map(|n| MockView::pair(n).0.boxed())
+                .collect(),
+        );
+        let names: Vec<String> = app.tabs.iter().map(|t| t.name.clone()).collect();
+        assert_eq!(names, ["a", "b", "c"]);
+        assert_eq!(
+            app.active, 0,
+            "exactly one active tab, defaulting to the first"
+        );
+
+        app.switch_tab(2);
+        assert_eq!(app.active, 2);
+        let names_after: Vec<String> = app.tabs.iter().map(|t| t.name.clone()).collect();
+        assert_eq!(
+            names_after,
+            ["a", "b", "c"],
+            "switching does not reorder tabs"
+        );
     }
 
     #[test]

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -297,6 +297,12 @@ pub struct App<S: DrawSurface = AlternateScreen<Stdout>> {
     session_sim: SessionSim,
 }
 
+/// UI-R-007: only key **press** events drive command/navigation; release and repeat kinds are
+/// ignored. Factored out of the run loop so the filter is testable without a real event source.
+fn should_act_on(kind: KeyEventKind) -> bool {
+    kind == KeyEventKind::Press
+}
+
 /// UI-R-057: no tab and no open modal layer ⇒ nothing to interact with, so exit.
 fn is_empty_shell(tab_count: usize, modal_open: bool) -> bool {
     tab_count == 0 && !modal_open
@@ -419,7 +425,7 @@ impl<S: DrawSurface> App<S> {
             self.draw()?;
 
             match tokio::time::timeout(REDRAW_INTERVAL, rx.recv()).await {
-                Ok(Some(Event::Key(key))) if key.kind == KeyEventKind::Press => {
+                Ok(Some(Event::Key(key))) if should_act_on(key.kind) => {
                     if self.handle_key(key.modifiers, key.code).await {
                         break;
                     }
@@ -681,6 +687,15 @@ mod tests {
         // Lines are timestamped.
         assert!(contents.trim_start().starts_with('['));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    /// UI-R-007 — only key press events are acted upon; release and repeat kinds are ignored for
+    /// command/navigation purposes.
+    fn ut_only_key_press_events_are_acted_on() {
+        assert!(should_act_on(KeyEventKind::Press));
+        assert!(!should_act_on(KeyEventKind::Release));
+        assert!(!should_act_on(KeyEventKind::Repeat));
     }
 
     #[test]

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -718,6 +718,25 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-020 — while the command line is focused, the help popup lists both the app-level
+    /// commands and the active view's advertised module commands.
+    fn ut_command_help_lists_app_and_active_view_commands() {
+        use super::testkit::{MOCK_COMMAND, MockView, build_app};
+        let (v, _h) = MockView::pair("a");
+        let mut app = build_app(vec![v.boxed()]);
+        // The popup only renders while the command line holds focus.
+        app.focus = Focus::Command;
+        app.draw().unwrap();
+        let text = app.screen.text();
+        assert!(text.contains("quit"), "app-level command listed");
+        assert!(text.contains("save"), "app-level :write/:save listed");
+        assert!(
+            text.contains(MOCK_COMMAND),
+            "active view's module command merged into the popup"
+        );
+    }
+
+    #[test]
     /// UI-R-007 — only key press events are acted upon; release and repeat kinds are ignored for
     /// command/navigation purposes.
     fn ut_only_key_press_events_are_acted_on() {

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -755,4 +755,93 @@ mod tests {
         app.draw().unwrap();
         assert_eq!(app.screen.draws, 1);
     }
+
+    #[test]
+    /// UI-R-002 — the screen is laid out top-to-bottom: a one-row tab bar on top, then the content
+    /// area, then the log pane, with the one-row command line on the bottom.
+    fn ut_layout_is_tab_bar_top_command_line_bottom() {
+        use super::testkit::{MockView, build_app};
+        let mut app = build_app(vec![MockView::pair("alpha").0.boxed()]);
+        app.draw().unwrap();
+        let buf = app.screen.buffer();
+        let (w, h) = (buf.area.width, buf.area.height);
+        let row = |y: u16| -> String { (0..w).map(|x| buf[(x, y)].symbol()).collect() };
+
+        assert!(row(0).contains("[0] alpha"), "tab bar is the top row");
+        assert!(
+            !row(1).contains("[0] alpha"),
+            "the tab bar is a single row, not repeated below"
+        );
+        assert!(
+            row(h - 1).contains(":  command"),
+            "the command line is the bottom row"
+        );
+    }
+
+    #[tokio::test]
+    /// UI-R-040 — every tick polls all tabs' views to refresh, not just the active one, so
+    /// background modules stay current.
+    async fn ut_tick_refreshes_all_tabs_including_background() {
+        use super::testkit::{MockView, build_app};
+        let (a, ha) = MockView::pair("a");
+        let (b, hb) = MockView::pair("b");
+        let (c, hc) = MockView::pair("c");
+        let mut app = build_app(vec![a.boxed(), b.boxed(), c.boxed()]);
+
+        app.refresh_snapshot().await;
+        assert_eq!(ha.refreshes(), 1, "active tab refreshed");
+        assert_eq!(hb.refreshes(), 1, "background tab refreshed");
+        assert_eq!(hc.refreshes(), 1, "background tab refreshed");
+
+        app.refresh_snapshot().await;
+        assert_eq!(hb.refreshes(), 2, "each tick refreshes again");
+    }
+
+    #[test]
+    /// UI-R-041 — the UI redraws on every tick, and the idle redraw timeout is ≈100 ms.
+    fn ut_redraw_each_tick_and_idle_interval_is_100ms() {
+        use super::testkit::{MockView, build_app};
+        assert_eq!(REDRAW_INTERVAL, Duration::from_millis(100));
+        let mut app = build_app(vec![MockView::pair("a").0.boxed()]);
+        let before = app.screen.draws;
+        app.draw().unwrap();
+        app.draw().unwrap();
+        assert_eq!(app.screen.draws, before + 2, "each tick draws a frame");
+    }
+
+    #[tokio::test]
+    /// UI-R-042 — a pending view replacement is applied on the next tick, carrying over the tab's
+    /// log channel and focus and rebuilding the session-module registry.
+    async fn ut_pending_view_replacement_applied_on_next_tick() {
+        use super::testkit::{MockView, build_app};
+        use std::sync::Arc;
+
+        let replacement = {
+            let (r, _hr) = MockView::pair("replacement");
+            r.with_host("mock").boxed()
+        };
+        let (orig, _ho) = MockView::pair("original");
+        let orig = orig.with_replacement(replacement).with_host("mock").boxed();
+        let mut app = build_app(vec![orig]);
+
+        assert!(app.tabs[0].view.is_focused(), "active tab starts focused");
+        assert_eq!(app.registry.list(), vec!["original".to_string()]);
+
+        app.refresh_snapshot().await;
+
+        assert_eq!(app.tabs[0].view.name(), "replacement", "view swapped");
+        assert!(
+            app.tabs[0].view.is_focused(),
+            "focus carried onto the replacement view"
+        );
+        assert!(
+            Arc::ptr_eq(&app.tabs[0].log, &app.tabs[0].view.log()),
+            "tab's log channel tracks the replacement view"
+        );
+        assert_eq!(
+            app.registry.list(),
+            vec!["replacement".to_string()],
+            "session-module registry rebuilt from the new tab set"
+        );
+    }
 }

--- a/ferrowl/src/app/testkit.rs
+++ b/ferrowl/src/app/testkit.rs
@@ -1,0 +1,275 @@
+//! Test doubles for driving `App` headlessly.
+//!
+//! Two seams the shell talks to are faked here so the nav/command/quit/tick behavior on `App`
+//! can be exercised without a terminal or a real module:
+//! - [`MockScreen`] — a [`DrawSurface`] backed by ratatui's `TestBackend`, so `App::draw` renders
+//!   into an inspectable cell buffer instead of a tty.
+//! - [`MockView`] — a [`ModuleView`] that records the calls `App` makes (`refresh`,
+//!   `handle_command`) and lets a test pre-load a replacement, a session spec, and a module host.
+//!
+//! Shared under `#[cfg(test)]` because the nav (`keys`), command (`commands`) and tick (`mod`)
+//! tests all need the same doubles.
+//!
+//! `dead_code` is allowed module-wide: this is a fixture toolbox whose builders are each consumed
+//! by only a subset of the tests, so an unused method here means "no test needs that knob yet",
+//! not a real dead branch.
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use ferrowl_lua::module::ModuleHost;
+use ferrowl_ui::traits::{IsFocus, SetFocus};
+use ferrowl_ui::{DrawSurface, EventResult};
+use mlua::{AnyUserData, Lua, Result as LuaResult};
+use ratatui::Frame;
+use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+
+use super::{App, LogRing};
+use crate::config::script::ScriptDef;
+use crate::module::view::{
+    CommandDescriptor, CommandFuture, CommandResult, ModuleView, RefreshFuture, SharedLog,
+};
+
+/// A `DrawSurface` test double backed by ratatui's `TestBackend`, letting an `App` be built and
+/// drawn headlessly (no real terminal). Records how many frames it rendered and exposes the cell
+/// buffer so layout/help tests can assert on what was painted.
+pub(super) struct MockScreen {
+    term: ratatui::Terminal<TestBackend>,
+    pub(super) draws: usize,
+}
+
+impl MockScreen {
+    pub(super) fn new() -> Self {
+        Self::with_size(120, 40)
+    }
+
+    pub(super) fn with_size(w: u16, h: u16) -> Self {
+        let term = ratatui::Terminal::new(TestBackend::new(w, h)).unwrap();
+        Self { term, draws: 0 }
+    }
+
+    /// The last rendered frame's cell buffer.
+    pub(super) fn buffer(&self) -> &Buffer {
+        self.term.backend().buffer()
+    }
+
+    /// Concatenate the buffer's cells into one string (row-major), for substring assertions.
+    pub(super) fn text(&self) -> String {
+        let buf = self.buffer();
+        buf.content().iter().map(|c| c.symbol()).collect()
+    }
+}
+
+impl DrawSurface for MockScreen {
+    fn draw<F: FnOnce(&mut Frame)>(&mut self, render: F) -> std::io::Result<()> {
+        self.term
+            .draw(render)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        self.draws += 1;
+        Ok(())
+    }
+}
+
+/// A `ModuleHost` double: the smallest thing `App::rebuild_registry` needs to place a module in
+/// the session registry. Reports a configurable kind/role; grants no Lua accessors.
+struct MockHost {
+    kind: &'static str,
+}
+
+impl ModuleHost for MockHost {
+    fn kind(&self) -> &'static str {
+        self.kind
+    }
+    fn role(&self) -> &'static str {
+        "mock"
+    }
+    fn register_accessor(&self, _lua: &Lua) -> LuaResult<Option<AnyUserData>> {
+        Ok(None)
+    }
+    fn ocpp_accessor(&self, _lua: &Lua) -> LuaResult<Option<AnyUserData>> {
+        Ok(None)
+    }
+}
+
+/// The module commands a [`MockView`] advertises, so a help test can assert the active view's list
+/// is merged in.
+pub(super) const MOCK_COMMAND: &str = "mockcmd";
+const MOCK_CMDS: &[CommandDescriptor] = &[CommandDescriptor {
+    name: MOCK_COMMAND,
+    description: "mock module command",
+}];
+
+/// Handles a test keeps after moving a [`MockView`] into a `Tab`, to observe the calls `App` made
+/// to it. All fields are `Arc`-shared with the live view.
+#[derive(Clone)]
+pub(super) struct MockHandle {
+    refreshes: Arc<AtomicUsize>,
+    commands: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockHandle {
+    /// How many times `App` called `refresh` on this view.
+    pub(super) fn refreshes(&self) -> usize {
+        self.refreshes.load(Ordering::Relaxed)
+    }
+
+    /// Every command string `App` forwarded to this view, in order.
+    pub(super) fn commands(&self) -> Vec<String> {
+        self.commands.lock().unwrap().clone()
+    }
+}
+
+/// A `ModuleView` test double: renders nothing, records `refresh`/`handle_command`, and can be
+/// pre-loaded with a session spec, a one-shot replacement, and a module host.
+pub(super) struct MockView {
+    name: String,
+    log: SharedLog,
+    focused: bool,
+    overlay_active: bool,
+    session_spec: Option<serde_json::Value>,
+    replacement: Option<Box<dyn ModuleView>>,
+    host_kind: Option<&'static str>,
+    refreshes: Arc<AtomicUsize>,
+    commands: Arc<Mutex<Vec<String>>>,
+}
+
+impl MockView {
+    /// A view plus the handle to observe it. `name` is the module/tab identity. Not `new` because
+    /// it returns the observation handle alongside the view, not `Self`; chain builder methods on
+    /// the returned view and `.boxed()` it for [`build_app`].
+    pub(super) fn pair(name: &str) -> (MockView, MockHandle) {
+        let refreshes = Arc::new(AtomicUsize::new(0));
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let handle = MockHandle {
+            refreshes: refreshes.clone(),
+            commands: commands.clone(),
+        };
+        let view = MockView {
+            name: name.to_string(),
+            log: Arc::new(tokio::sync::RwLock::new(LogRing::init())),
+            focused: false,
+            overlay_active: false,
+            session_spec: None,
+            replacement: None,
+            host_kind: None,
+            refreshes,
+            commands,
+        };
+        (view, handle)
+    }
+
+    /// Give this view a session spec so `:write` serializes something for its tab.
+    pub(super) fn with_session_spec(mut self, spec: serde_json::Value) -> Self {
+        self.session_spec = Some(spec);
+        self
+    }
+
+    /// Pre-load the view returned by the next `take_replacement` poll (one-shot).
+    pub(super) fn with_replacement(mut self, replacement: Box<dyn ModuleView>) -> Self {
+        self.replacement = Some(replacement);
+        self
+    }
+
+    /// Make this view participate in the session-module registry under the given kind.
+    pub(super) fn with_host(mut self, kind: &'static str) -> Self {
+        self.host_kind = Some(kind);
+        self
+    }
+
+    /// Re-box after a builder chain that started from an already-boxed `new`.
+    pub(super) fn boxed(self) -> Box<dyn ModuleView> {
+        Box::new(self)
+    }
+}
+
+impl SetFocus for MockView {
+    fn set_focused(&mut self, focus: bool) {
+        self.focused = focus;
+    }
+}
+
+impl IsFocus for MockView {
+    fn is_focused(&self) -> bool {
+        self.focused
+    }
+}
+
+impl ModuleView for MockView {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn render(&mut self, _frame: &mut Frame, _area: Rect) {}
+
+    fn render_overlay(&mut self, _frame: &mut Frame, _area: Rect) {}
+
+    fn handle_events(&mut self, modifiers: KeyModifiers, code: KeyCode) -> EventResult {
+        EventResult::Unhandled(modifiers, code)
+    }
+
+    fn refresh<'a>(&'a mut self) -> RefreshFuture<'a> {
+        let refreshes = self.refreshes.clone();
+        Box::pin(async move {
+            refreshes.fetch_add(1, Ordering::Relaxed);
+        })
+    }
+
+    fn is_overlay_active(&self) -> bool {
+        self.overlay_active
+    }
+
+    fn handle_command<'a>(&'a mut self, cmd: &'a str) -> CommandFuture<'a> {
+        let commands = self.commands.clone();
+        let cmd = cmd.to_string();
+        Box::pin(async move {
+            commands.lock().unwrap().push(cmd);
+            CommandResult::Handled(None)
+        })
+    }
+
+    fn commands(&self) -> &[CommandDescriptor] {
+        MOCK_CMDS
+    }
+
+    fn log(&self) -> SharedLog {
+        self.log.clone()
+    }
+
+    fn session_spec(&self) -> Option<serde_json::Value> {
+        self.session_spec.clone()
+    }
+
+    fn take_replacement(&mut self) -> Option<Box<dyn ModuleView>> {
+        self.replacement.take()
+    }
+
+    fn scripts(&self) -> Option<&[ScriptDef]> {
+        None
+    }
+
+    fn module_host(&self) -> Option<Arc<dyn ModuleHost>> {
+        self.host_kind
+            .map(|kind| Arc::new(MockHost { kind }) as Arc<dyn ModuleHost>)
+    }
+}
+
+/// Build an `App` on a [`MockScreen`] from a list of pre-boxed views, one tab each. The tab names
+/// come from each view's `name()`. A one-second session interval keeps the sim quiet.
+pub(super) fn build_app(views: Vec<Box<dyn ModuleView>>) -> App<MockScreen> {
+    let tabs = views
+        .into_iter()
+        .map(|view| super::Tab::new_from_view(view.name(), view))
+        .collect();
+    App::with_screen(
+        MockScreen::new(),
+        tabs,
+        vec![],
+        std::time::Duration::from_secs(1),
+    )
+    .unwrap()
+}


### PR DESCRIPTION
## Background

Coverage work under #98 stopped at the TUI app shell: `App::new()` builds an
`AlternateScreen` whose constructor calls `enable_raw_mode()`, which errors with no
controlling terminal, so `App` could not be constructed under `cargo test`. #110 landed
the `DrawSurface` seam that lets a mock screen replace the terminal; this PR uses that
seam to construct and drive `App` headlessly and backfills citing tests for the shell's
navigation, command, quit, tick and `:write` requirements. Closes #108.

## How it was resolved

- **Shared test kit** (`ferrowl/src/app/testkit.rs`, `#[cfg(test)]`): a `MockView`
  `ModuleView` double that records `refresh`/`handle_command` and can be pre-loaded with a
  session spec, a one-shot replacement, and a module host; the `MockScreen` `DrawSurface`
  (moved here from `mod.rs`) now exposes its cell buffer so layout/help tests can assert on
  what was painted; a `build_app` helper.
- **One behaviour-neutral refactor**: `should_act_on(kind)` extracted from the run loop so
  the press-only key filter (UI-R-007) is testable without a real event source. Also
  `#[derive(Debug)]` on the internal `Focus` enum for `assert_eq!`.
- **16 citing tests** across `mod.rs`, `keys.rs`, `commands.rs`, each doc comment citing its
  requirement ID.

## Requirements covered

Existing requirements, none changed — pure test backfill:

- **Nav / focus**: UI-R-003, UI-R-006, UI-R-007, UI-R-009, UI-R-010, UI-R-012
- **Command / quit / help**: UI-R-015, UI-R-019, UI-R-020
- **Layout / tick**: UI-R-002, UI-R-040, UI-R-041, UI-R-042
- **`:write`**: CS-R-030, CS-R-031, CS-R-032

UI-R-001 (raw-mode entry + terminal restore on normal/error/panic exit) is added to the
`docs/specs/README.md` exempt list: its restore path calls the real terminal, which panics
under `cargo test` with no tty — the very reason the `DrawSurface` seam exists. The seam is
exercised headlessly; the terminal control itself is a platform fact no `shall` test observes.

## Known weak pins

- UI-R-040 asserts every tab is polled; the concurrency (`join_all`) is structural, not
  barrier-tested.
- UI-R-041 pins `REDRAW_INTERVAL == 100 ms` plus draw-per-tick; the loop's idle-timeout
  trigger is not driven (the run loop owns its own event thread).

## Verification

- `cargo test --workspace` — 0 failed (ferrowl bin 755 passed, +16 new)
- `cargo clippy --workspace` — clean
- `cargo fmt --check` — clean
