### PR TITLE
Fix ARCHITECTURE.md's Lua-bridge and OCPP crate boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,8 +24,8 @@ published independently.
 | `ferrowl-codec` | Register descriptions (slave id, function code, address, access, format) and the codec between raw `u16` words and typed values. |
 | `ferrowl-store` | In-memory model of a Modbus register space — access-checked value cells, shared as `Arc<RwLock<Memory>>`. |
 | `ferrowl-modbus` | Modbus client and server tasks over TCP and RTU, on [tokio-modbus](https://github.com/slowtec/tokio-modbus). |
-| `ferrowl-ocpp` | Version-generic OCPP engine (a `Version` trait over 1.6 / 2.0.1 / 2.1), Charging Station and CSMS roles, over JSON-on-WebSocket, wrapping [rust-ocpp](https://github.com/codelabsab/rust-ocpp). |
-| `ferrowl-lua` | Embedded Lua 5.4 runtime ([mlua](https://github.com/mlua-rs/mlua)) exposing the `C_*` bridge modules to simulation scripts, in a restricted sandbox. |
+| `ferrowl-ocpp` | OCPP transport and engine core: JSON-on-WebSocket framing, connection and correlation, and the version-generic Charging Station / CSMS engine cores (a `Version` trait over 1.6 / 2.0.1 / 2.1), wrapping [rust-ocpp](https://github.com/codelabsab/rust-ocpp). The per-version actions, spec tables, and device state machines live in the `ferrowl` binary. |
+| `ferrowl-lua` | Embedded Lua 5.4 runtime ([mlua](https://github.com/mlua-rs/mlua)) and the `C_*` module framework — the restricted sandbox and the trait shells scripts call. It has no dependency on the Modbus or OCPP crates; the concrete `C_Register` / `C_OCPP` wiring to `ferrowl-store::Memory` and the OCPP state lives in the `ferrowl` binary. |
 | `ferrowl-syntax` | Syntax highlighting for the in-TUI code editor (Lua and JSON). |
 | `ferrowl-ring` | Fixed-capacity ring buffer generic over the element type; backs each module's log pane. |
 | `ferrowl-util` | Shared helpers: config (de)serialization, tracked tokio task spawning, small macros and traits. |
@@ -82,8 +82,8 @@ their observable contracts are specified where they are used:
 | Area | Crates | Spec |
 |---|---|---|
 | Modbus | `ferrowl-codec`, `ferrowl-store`, `ferrowl-modbus` | [`docs/specs/modbus/`](./docs/specs/modbus/) |
-| OCPP | `ferrowl-ocpp` | [`docs/specs/ocpp/`](./docs/specs/ocpp/) |
-| Scripting | `ferrowl-lua`, `ferrowl-lua-derive` | [`docs/specs/scripting/`](./docs/specs/scripting/) |
+| OCPP | `ferrowl-ocpp` (transport + engine core), most of the OCPP behavior in `ferrowl` | [`docs/specs/ocpp/`](./docs/specs/ocpp/) |
+| Scripting | `ferrowl-lua`, `ferrowl-lua-derive`, the `C_*` wiring in `ferrowl` | [`docs/specs/scripting/`](./docs/specs/scripting/) |
 | TUI | `ferrowl-ui`, `ferrowl-ui-derive`, `ferrowl-syntax` | [`docs/specs/tui/`](./docs/specs/tui/) |
 | Config & session | `ferrowl-util`, parts of `ferrowl` | [`docs/specs/config-session/`](./docs/specs/config-session/) |
 | CLI & headless | parts of `ferrowl` | [`docs/specs/cli-headless/`](./docs/specs/cli-headless/) |


### PR DESCRIPTION
## Background

Two boundary descriptions in `ARCHITECTURE.md` no longer matched the code, misrouting agents and contributors to crates that do not implement the behavior:

1. The `ferrowl-lua` entry read as though the crate exposed the concrete `C_*` bridge. In reality `ferrowl-lua` depends only on `mlua` and `ferrowl-lua-derive` — it has **no** dependency on `ferrowl-store`, `ferrowl-codec`, or `ferrowl-ocpp`, and defines only the sandbox and the `C_*` trait shells.
2. The spec map routed all OCPP work to `ferrowl-ocpp`, but that crate holds only transport and the engine core (~3.6k lines); the per-version actions, spec tables, and device state machines (~22.8k lines) live in the `ferrowl` binary.

## How this was resolved

Docs-only change to `ARCHITECTURE.md`:

- **Crate table** — rewrote the `ferrowl-ocpp` entry to say it owns transport + the version-generic CS/CSMS engine core, with the actions/spec/state machines noted as living in the binary. Rewrote the `ferrowl-lua` entry to state it has no Modbus/OCPP dependency and that the concrete `C_Register` / `C_OCPP` wiring lives in the `ferrowl` binary.
- **Spec map** — the OCPP and Scripting rows now name `ferrowl` alongside `ferrowl-ocpp` / `ferrowl-lua` as where the behavior is implemented.

## Verification

Claims checked against the tree before editing: `ferrowl-lua/Cargo.toml` lists only `mlua` + `ferrowl-lua-derive`; OCPP source is 22,791 lines under `ferrowl/src/module/ocpp/` vs 3,645 in `ferrowl-ocpp/src/`. Docs-only — no code, tests, or lints affected.

Closes #116
