### PR TITLE
Pin the toolchain and CI action refs, and align the local clippy hook with CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Update nightly tag
-        uses: EndBug/latest-tag@latest
+        uses: EndBug/latest-tag@v1.6.3
         if: github.ref == 'refs/heads/main'
         with:
           ref: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         target: [x86_64-pc-windows-gnu, x86_64-unknown-linux-musl]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7
       - name: Compile and release
         uses: rust-build/rust-build.action@v1.4.5
         env:

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -11,7 +11,7 @@ pre-commit:
  
     clippy:
       glob: "*.rs"
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --workspace -- -D warnings
 
       fail_text: |
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Background

Three reproducibility gaps between contributor machines and CI:

1. `rust-toolchain.toml` pinned only `channel = "stable"` — no exact version, no components. A floating stable lets rustfmt/clippy output drift between machines and CI.
2. `.github/workflows/release.yml` used `actions/checkout@master` (a mutable ref) while `nightly.yml` pinned `@v7`, and `nightly.yml` still carried one mutable ref of its own (`EndBug/latest-tag@latest`).
3. The lefthook pre-commit hook ran `cargo clippy` without `--workspace`, while CI runs `cargo clippy --workspace -- -D warnings` — a workspace-wide warning in an untouched crate passed locally and failed in CI.

## How this was resolved

- **`rust-toolchain.toml`** — pinned the exact current stable, `channel = "1.95.0"` (what the local toolchain and the `rust:latest` CI image resolve to today), and added `components = ["rustfmt", "clippy"]` so the formatter and linter are always present and versioned with the toolchain.
- **`release.yml`** — `actions/checkout@master` → `@v7`, matching `nightly.yml`.
- **`nightly.yml`** — `EndBug/latest-tag@latest` → `@v1.6.3`, pinning the last mutable action ref.
- **`.lefthook.yml`** — clippy hook now runs `cargo clippy --workspace -- -D warnings`, identical to the CI invocation.

## Scope notes

Left deliberately untouched, outside the issue's stated scope: Woodpecker's `rust:latest` images (a separate floating-toolchain surface) and `dtolnay/rust-toolchain@nightly` in `codeql.yml` (a toolchain-channel selector, not a version pin).

## Verification

`rustup show active-toolchain` resolves to `1.95.0` via the new pin; `rustfmt` and `clippy` components are installed; all three edited YAML files parse; the hook line now reads `cargo clippy --workspace -- -D warnings`. Config-only — no product code, tests, or lints affected.

Closes #118
