### PR TITLE
Stop OCPP wire-log encoding from swallowing encode errors

### DIFF
--- a/docs/specs/ocpp/requirements.md
+++ b/docs/specs/ocpp/requirements.md
@@ -426,6 +426,10 @@ module's log file at most once, tracked by its sequence number, so that eviction
 from the in-memory buffer does not cause a message to be logged twice or skipped
 (see [`edge-cases.md`](./edge-cases.md) §6.11 for the burst bound).
 
+**OC-R-101** — Encoding an OCPP action or response to JSON for the message log
+shall never discard an encode failure silently: the failure shall be logged to the
+module's error channel before the payload degrades to JSON `null`.
+
 ---
 
 ## Send dialogs

--- a/ferrowl/src/module/ocpp/client/backend.rs
+++ b/ferrowl/src/module/ocpp/client/backend.rs
@@ -17,6 +17,7 @@ use ferrowl_ocpp::{Error, Version};
 
 use crate::module::ocpp::config::session::OcppSpec;
 use crate::module::ocpp::scope::Scope;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// Number of `refresh` ticks per second (the UI ticks at ~100ms), used to convert second-based
 /// cadences (heartbeat interval, MeterValues period) into tick counts.
@@ -298,7 +299,7 @@ impl<V: Version> OcppSender<V> {
     /// never blocks the UI loop because the caller spawns it.
     pub async fn send_scoped(self, action: V::Action, scope: Scope) -> Result<Value, Error> {
         let name = V::action_name(&action).to_string();
-        let request = V::encode_action(&action).unwrap_or(Value::Null);
+        let request = encode_action_or_log::<V>(&action);
         record(
             &self.messages,
             scope,
@@ -316,7 +317,7 @@ impl<V: Version> OcppSender<V> {
         };
         match result {
             Ok(response) => {
-                let payload = V::encode_response(&response).unwrap_or(Value::Null);
+                let payload = encode_response_or_log::<V>(&response);
                 record(
                     &self.messages,
                     scope,

--- a/ferrowl/src/module/ocpp/client/v1_6/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/handler.rs
@@ -23,9 +23,9 @@ use ferrowl_ocpp::{Action16, CallError, CallErrorCode, Response16, V1_6, Version
 
 use crate::module::ocpp::client::backend::{Dir, Messages, OcppMessage, push_capped};
 use crate::module::ocpp::client::v1_6::state::CsState;
-use crate::module::ocpp::client::v2_common::{encode_action_or_log, encode_response_or_log};
 use crate::module::ocpp::lock::HasState;
 use crate::module::ocpp::scope::Scope;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// Scope an inbound CSMS→CS Call belongs to, for the message log: a top-level `connectorId` targets
 /// that connector, otherwise it is CS-level.

--- a/ferrowl/src/module/ocpp/client/v2_0_1/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v2_0_1/handler.rs
@@ -28,10 +28,9 @@ use ferrowl_ocpp::{Action201, CallError, CallErrorCode, Response201, V2_0_1, Ver
 use crate::module::ocpp::client::backend::{Dir, Messages, OcppMessage, push_capped};
 use crate::module::ocpp::client::config::ConfigKey;
 use crate::module::ocpp::client::v2_0_1::state::CsState;
-use crate::module::ocpp::client::v2_common::{
-    clear_limit_by_purpose, encode_action_or_log, inbound_scope, unknown_evse,
-};
+use crate::module::ocpp::client::v2_common::{clear_limit_by_purpose, inbound_scope, unknown_evse};
 use crate::module::ocpp::lock::HasState;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// Inbound handler for an OCPP 2.0.1 charging station, backed by shared [`CsState`].
 pub struct CsStateHandler {
@@ -418,7 +417,7 @@ impl CsActionHandler<V2_0_1> for CsStateHandler {
         action: Action201,
     ) -> impl Future<Output = Result<Response201, CallError>> + Send {
         let name = V2_0_1::action_name(&action).to_string();
-        let request = V2_0_1::encode_action(&action).unwrap_or(serde_json::Value::Null);
+        let request = encode_action_or_log::<V2_0_1>(&action);
         // Reject Calls targeting an EVSE this station does not have. `with_state` drops the read
         // guard before `respond()` runs (which takes its own write lock) — holding both deadlocks.
         let unknown = self.with_state(|s| unknown_evse(&request, s));
@@ -433,7 +432,7 @@ impl CsActionHandler<V2_0_1> for CsStateHandler {
             None => self.respond(&action),
         };
         let reply_payload = match &result {
-            Ok(resp) => V2_0_1::encode_response(resp).unwrap_or(serde_json::Value::Null),
+            Ok(resp) => encode_response_or_log::<V2_0_1>(resp),
             Err(_) => serde_json::Value::Null,
         };
         let ok = result.is_ok();

--- a/ferrowl/src/module/ocpp/client/v2_1/handler.rs
+++ b/ferrowl/src/module/ocpp/client/v2_1/handler.rs
@@ -25,10 +25,9 @@ use ferrowl_ocpp::{Action21, CallError, CallErrorCode, Response21, V2_1, Version
 use crate::module::ocpp::client::backend::{Dir, Messages, OcppMessage, push_capped};
 use crate::module::ocpp::client::config::ConfigKey;
 use crate::module::ocpp::client::v2_0_1::state::CsState;
-use crate::module::ocpp::client::v2_common::{
-    clear_limit_by_purpose, encode_action_or_log, inbound_scope, unknown_evse,
-};
+use crate::module::ocpp::client::v2_common::{clear_limit_by_purpose, inbound_scope, unknown_evse};
 use crate::module::ocpp::lock::HasState;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// Inbound handler for an OCPP 2.1 charging station, backed by shared [`CsState`].
 pub struct CsStateHandler {
@@ -415,7 +414,7 @@ impl CsActionHandler<V2_1> for CsStateHandler {
         action: Action21,
     ) -> impl Future<Output = Result<Response21, CallError>> + Send {
         let name = V2_1::action_name(&action).to_string();
-        let request = V2_1::encode_action(&action).unwrap_or(serde_json::Value::Null);
+        let request = encode_action_or_log::<V2_1>(&action);
         // Reject Calls targeting an EVSE this station does not have. `with_state` drops the read
         // guard before `respond()` runs (which takes its own write lock) — holding both deadlocks.
         let unknown = self.with_state(|s| unknown_evse(&request, s));
@@ -430,7 +429,7 @@ impl CsActionHandler<V2_1> for CsStateHandler {
             None => self.respond(&action),
         };
         let reply_payload = match &result {
-            Ok(resp) => V2_1::encode_response(resp).unwrap_or(serde_json::Value::Null),
+            Ok(resp) => encode_response_or_log::<V2_1>(resp),
             Err(_) => serde_json::Value::Null,
         };
         let ok = result.is_ok();

--- a/ferrowl/src/module/ocpp/client/v2_common.rs
+++ b/ferrowl/src/module/ocpp/client/v2_common.rs
@@ -23,27 +23,6 @@ use crate::module::ocpp::client::view::{
 use crate::module::ocpp::config::device::ConnectorRef;
 use crate::module::ocpp::scope::{Scope, evse_id};
 use ferrowl_lua::module::ValueType;
-use ferrowl_ocpp::Version;
-
-/// Encodes an inbound `action` to JSON for `respond()`'s decision logic (e.g. reading fields out of
-/// a `SetChargingProfile`). An encode failure here would otherwise silently degrade to an empty
-/// payload with no trace; this logs it to stderr (the crate's existing error-reporting channel, see
-/// `main.rs`/`headless.rs`) before falling back to `Value::Null` so callers keep their existing
-/// "missing field" behavior.
-pub(crate) fn encode_action_or_log<V: Version>(action: &V::Action) -> serde_json::Value {
-    V::encode_action(action).unwrap_or_else(|e| {
-        eprintln!("ocpp: failed to encode action to JSON: {e}");
-        serde_json::Value::Null
-    })
-}
-
-/// [`encode_action_or_log`]'s twin for responses.
-pub(crate) fn encode_response_or_log<V: Version>(response: &V::Response) -> serde_json::Value {
-    V::encode_response(response).unwrap_or_else(|e| {
-        eprintln!("ocpp: failed to encode response to JSON: {e}");
-        serde_json::Value::Null
-    })
-}
 
 /// Clear the per-purpose charge limit a ClearChargingProfile targets: the field matching `purpose`,
 /// or every per-purpose limit when no purpose criterion is given. An unknown purpose clears nothing.
@@ -459,70 +438,6 @@ pub(crate) fn active_meter_scopes(s: &CsState) -> Vec<Scope> {
 mod tests {
     use super::*;
     use crate::module::ocpp::client::v2_0_1::state::ConnectorState;
-    use ferrowl_ocpp::{ConnectorScope, OcppError, ValidationError};
-
-    /// Minimal [`Version`] mock whose `encode_action` always fails, to exercise
-    /// `encode_action_or_log`'s fallback path without depending on a real action type ever failing
-    /// to serialize.
-    struct FailingVersion;
-
-    impl Version for FailingVersion {
-        type Action = ();
-        type Response = ();
-
-        fn action_name(_action: &()) -> &'static str {
-            "Failing"
-        }
-        fn action_names() -> &'static [&'static str] {
-            &[]
-        }
-        fn cs_actions() -> &'static [&'static str] {
-            &[]
-        }
-        fn csms_actions() -> &'static [(&'static str, ConnectorScope)] {
-            &[]
-        }
-        fn default_action(_name: &str) -> Option<()> {
-            None
-        }
-        fn default_response(_name: &str) -> Option<()> {
-            None
-        }
-        fn subprotocol() -> &'static str {
-            "failing"
-        }
-        fn decode_call(_action_name: &str, _payload: serde_json::Value) -> Result<(), OcppError> {
-            unimplemented!("not exercised by this test")
-        }
-        fn validate(_action: &()) -> Result<(), ValidationError> {
-            Ok(())
-        }
-        fn encode_response(_response: &()) -> Result<serde_json::Value, OcppError> {
-            Err(OcppError::UnknownAction("Failing".to_string()))
-        }
-        fn encode_action(_action: &()) -> Result<serde_json::Value, OcppError> {
-            Err(OcppError::UnknownAction("Failing".to_string()))
-        }
-        fn decode_result(_action: &(), _payload: serde_json::Value) -> Result<(), OcppError> {
-            unimplemented!("not exercised by this test")
-        }
-    }
-
-    #[test]
-    fn ut_encode_action_or_log_returns_null_on_encode_failure() {
-        assert_eq!(
-            encode_action_or_log::<FailingVersion>(&()),
-            serde_json::Value::Null
-        );
-    }
-
-    #[test]
-    fn ut_encode_response_or_log_returns_null_on_encode_failure() {
-        assert_eq!(
-            encode_response_or_log::<FailingVersion>(&()),
-            serde_json::Value::Null
-        );
-    }
 
     /// A CS with the given EVSE ids seeded via `add_connector` at connector ids 1..=n.
     fn state_with(evses: &[i64]) -> CsState {

--- a/ferrowl/src/module/ocpp/mod.rs
+++ b/ferrowl/src/module/ocpp/mod.rs
@@ -14,3 +14,4 @@ pub mod setup;
 pub mod setup_dialog;
 pub mod spec;
 mod widgets;
+pub(crate) mod wire_log;

--- a/ferrowl/src/module/ocpp/server/backend.rs
+++ b/ferrowl/src/module/ocpp/server/backend.rs
@@ -20,6 +20,7 @@ use crate::module::ocpp::client::backend::{Dir, OcppMessage};
 use crate::module::ocpp::config::session::OcppSpec;
 use crate::module::ocpp::lock::{with_state, with_state_mut};
 pub use crate::module::ocpp::scope::Scope;
+use crate::module::ocpp::wire_log::encode_response_or_log;
 
 /// A lifecycle/message event delivered from the CSMS server tasks to the view. Version-agnostic:
 /// action payloads are carried as JSON so the (version-specific) view extracts connector ids and
@@ -267,7 +268,7 @@ impl<V: Version> OcppServerSender<V> {
             .await
             .map_err(|_| Error::ChannelClosed)?;
         match reply_rx.await {
-            Ok(Ok(response)) => Ok(V::encode_response(&response).unwrap_or(Value::Null)),
+            Ok(Ok(response)) => Ok(encode_response_or_log::<V>(&response)),
             Ok(Err(call_err)) => Err(Error::Call(call_err)),
             Err(_) => Err(Error::ChannelClosed),
         }

--- a/ferrowl/src/module/ocpp/server/v1_6/handler.rs
+++ b/ferrowl/src/module/ocpp/server/v1_6/handler.rs
@@ -20,6 +20,7 @@ use crate::module::ocpp::scope::Scope;
 use crate::module::ocpp::server::backend::{
     EventTx, RfidLists, ServerEvent, cs_authorized, scope_authorized,
 };
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// CSMS inbound handler for OCPP 1.6.
 pub struct CsmsHandler16 {
@@ -102,10 +103,10 @@ impl CsmsActionHandler<V1_6> for CsmsHandler16 {
         action: Action16,
     ) -> impl Future<Output = Result<Response16, CallError>> + Send {
         let name = V1_6::action_name(&action).to_string();
-        let request = V1_6::encode_action(&action).unwrap_or(Value::Null);
+        let request = encode_action_or_log::<V1_6>(&action);
         let result = self.respond(&name, &action, &request);
         let response = match &result {
-            Ok(resp) => V1_6::encode_response(resp).unwrap_or(Value::Null),
+            Ok(resp) => encode_response_or_log::<V1_6>(resp),
             Err(_) => Value::Null,
         };
         let _ = self.tx.send(ServerEvent::Inbound {

--- a/ferrowl/src/module/ocpp/server/v2_0_1/handler.rs
+++ b/ferrowl/src/module/ocpp/server/v2_0_1/handler.rs
@@ -13,6 +13,7 @@ use ferrowl_ocpp::{Action201, CallError, CallErrorCode, Response201, V2_0_1, Ver
 
 use crate::module::ocpp::server::backend::{EventTx, RfidLists, ServerEvent};
 use crate::module::ocpp::server::v2_common::craft_response;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// CSMS inbound handler for OCPP 2.0.1.
 pub struct CsmsHandler {
@@ -51,10 +52,10 @@ impl CsmsActionHandler<V2_0_1> for CsmsHandler {
         action: Action201,
     ) -> impl Future<Output = Result<Response201, CallError>> + Send {
         let name = V2_0_1::action_name(&action).to_string();
-        let request = V2_0_1::encode_action(&action).unwrap_or(Value::Null);
+        let request = encode_action_or_log::<V2_0_1>(&action);
         let result = self.respond(&name, &action, &request);
         let response = match &result {
-            Ok(resp) => V2_0_1::encode_response(resp).unwrap_or(Value::Null),
+            Ok(resp) => encode_response_or_log::<V2_0_1>(resp),
             Err(_) => Value::Null,
         };
         let _ = self.tx.send(ServerEvent::Inbound {

--- a/ferrowl/src/module/ocpp/server/v2_1/handler.rs
+++ b/ferrowl/src/module/ocpp/server/v2_1/handler.rs
@@ -12,6 +12,7 @@ use ferrowl_ocpp::{Action21, CallError, CallErrorCode, Response21, V2_1, Version
 
 use crate::module::ocpp::server::backend::{EventTx, RfidLists, ServerEvent};
 use crate::module::ocpp::server::v2_common::craft_response;
+use crate::module::ocpp::wire_log::{encode_action_or_log, encode_response_or_log};
 
 /// CSMS inbound handler for OCPP 2.1.
 pub struct CsmsHandler {
@@ -50,10 +51,10 @@ impl CsmsActionHandler<V2_1> for CsmsHandler {
         action: Action21,
     ) -> impl Future<Output = Result<Response21, CallError>> + Send {
         let name = V2_1::action_name(&action).to_string();
-        let request = V2_1::encode_action(&action).unwrap_or(Value::Null);
+        let request = encode_action_or_log::<V2_1>(&action);
         let result = self.respond(&name, &action, &request);
         let response = match &result {
-            Ok(resp) => V2_1::encode_response(resp).unwrap_or(Value::Null),
+            Ok(resp) => encode_response_or_log::<V2_1>(resp),
             Err(_) => Value::Null,
         };
         let _ = self.tx.send(ServerEvent::Inbound {

--- a/ferrowl/src/module/ocpp/wire_log.rs
+++ b/ferrowl/src/module/ocpp/wire_log.rs
@@ -1,0 +1,98 @@
+//! Shared helpers for rendering an OCPP action or response to JSON for the message log.
+//!
+//! Both the client and the server encode payloads for the in-memory message log (and the outbound
+//! command replies that become log entries). An encode failure there would otherwise silently
+//! degrade to `Value::Null` with no trace; these helpers log the failure to stderr — the crate's
+//! existing error-reporting channel (see `main.rs`/`headless.rs`) — before falling back to `Null`,
+//! so callers keep their "empty payload" degradation while the failure is no longer invisible
+//! (OC-R-101). They live here, outside either role's module, so both sides can reach them without
+//! one depending on the other's internals.
+
+use ferrowl_ocpp::Version;
+
+/// Encode an `action` to JSON for the message log, logging any encode failure before degrading to
+/// `Value::Null`.
+pub(crate) fn encode_action_or_log<V: Version>(action: &V::Action) -> serde_json::Value {
+    V::encode_action(action).unwrap_or_else(|e| {
+        eprintln!("ocpp: failed to encode action to JSON: {e}");
+        serde_json::Value::Null
+    })
+}
+
+/// [`encode_action_or_log`]'s twin for responses.
+pub(crate) fn encode_response_or_log<V: Version>(response: &V::Response) -> serde_json::Value {
+    V::encode_response(response).unwrap_or_else(|e| {
+        eprintln!("ocpp: failed to encode response to JSON: {e}");
+        serde_json::Value::Null
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferrowl_ocpp::{ConnectorScope, OcppError, ValidationError};
+
+    /// Minimal [`Version`] mock whose `encode_action`/`encode_response` always fail, to exercise the
+    /// helpers' fallback path without depending on a real action type ever failing to serialize.
+    struct FailingVersion;
+
+    impl Version for FailingVersion {
+        type Action = ();
+        type Response = ();
+
+        fn action_name(_action: &()) -> &'static str {
+            "Failing"
+        }
+        fn action_names() -> &'static [&'static str] {
+            &[]
+        }
+        fn cs_actions() -> &'static [&'static str] {
+            &[]
+        }
+        fn csms_actions() -> &'static [(&'static str, ConnectorScope)] {
+            &[]
+        }
+        fn default_action(_name: &str) -> Option<()> {
+            None
+        }
+        fn default_response(_name: &str) -> Option<()> {
+            None
+        }
+        fn subprotocol() -> &'static str {
+            "failing"
+        }
+        fn decode_call(_action_name: &str, _payload: serde_json::Value) -> Result<(), OcppError> {
+            unimplemented!("not exercised by this test")
+        }
+        fn validate(_action: &()) -> Result<(), ValidationError> {
+            Ok(())
+        }
+        fn encode_response(_response: &()) -> Result<serde_json::Value, OcppError> {
+            Err(OcppError::UnknownAction("Failing".to_string()))
+        }
+        fn encode_action(_action: &()) -> Result<serde_json::Value, OcppError> {
+            Err(OcppError::UnknownAction("Failing".to_string()))
+        }
+        fn decode_result(_action: &(), _payload: serde_json::Value) -> Result<(), OcppError> {
+            unimplemented!("not exercised by this test")
+        }
+    }
+
+    #[test]
+    /// OC-R-101 — an action that fails to encode degrades to `null` instead of vanishing untraced.
+    fn ut_encode_action_or_log_returns_null_on_encode_failure() {
+        assert_eq!(
+            encode_action_or_log::<FailingVersion>(&()),
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    /// OC-R-101 — a response that fails to encode degrades to `null` instead of vanishing untraced.
+    fn ut_encode_response_or_log_returns_null_on_encode_failure() {
+        assert_eq!(
+            encode_response_or_log::<FailingVersion>(&()),
+            serde_json::Value::Null
+        );
+    }
+}


### PR DESCRIPTION
## Background

The OCPP handlers encoded wire payloads for the UI message log with `encode_action(...).unwrap_or(Value::Null)` / `encode_response(...).unwrap_or(Value::Null)`, discarding any encode error and logging `null` with no trace. Error-logging helpers (`encode_action_or_log` / `encode_response_or_log`) already existed, but ~13 call sites across the v1.6/v2.0.1/v2.1 server handlers, the v2.0.1/v2.1 client handlers, and both backends bypassed them.

## Requirement

**OC-R-101** — Encoding an OCPP action or response to JSON for the message log shall never discard an encode failure silently: the failure shall be logged to the module's error channel before the payload degrades to JSON `null`.

## How this was resolved

1. **Relocated the helpers.** `encode_action_or_log` / `encode_response_or_log` lived in `client/v2_common.rs`; the server could not reach them without depending on a *client* module. Moved both (plus their unit tests and the `FailingVersion` mock) to a new neutral `ocpp/wire_log.rs` (`pub(crate)`) so both roles use one copy without cross-role coupling. This is a coupling-cut move, not a size split.
2. **Routed every bypass site** through the helpers — server handlers (v1.6/2.0.1/2.1), client handlers (2.0.1/2.1), and both backends. The v1.6 client handler already used them. The `Err(_) => Value::Null` arms are untouched: those are error *results*, not encode failures.

## Verification

- `cargo test --workspace` passes, including the two OC-R-101 tests (`ut_encode_action_or_log_returns_null_on_encode_failure`, `ut_encode_response_or_log_returns_null_on_encode_failure`).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check` are clean.
- Audit grep for any remaining `encode_*(...).unwrap_or(...Value::Null)` wire-log site returns empty.
- Not driven in the demo TUI: a real action always encodes, so the failure branch is unreachable at runtime — tests plus the audit are the exercise.

Closes #114
