### PR TITLE
Close the spec-to-test traceability gap for 21 untested requirements

### DIFF
--- a/ferrowl-lua/src/module/time.rs
+++ b/ferrowl-lua/src/module/time.rs
@@ -38,3 +38,32 @@ impl Time {
             .as_millis())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Time;
+
+    #[test]
+    /// SC-R-017 — C_Time is measured from the moment its context is built, and building a fresh
+    /// context (a fresh module) resets the origin to zero.
+    fn ut_time_measured_from_construction_and_resets_on_rebuild() {
+        let lua = mlua::Lua::new();
+        let t1 = Time::default();
+        // Freshly built: elapsed is ~0.
+        assert!(Time::get_ms(&lua, &t1, ()).unwrap() < 40);
+
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        let elapsed = Time::get_ms(&lua, &t1, ()).unwrap();
+        assert!(
+            elapsed >= 40,
+            "elapsed should have advanced, got {elapsed}ms"
+        );
+
+        // Rebuilding the context builds a new Time whose origin is reset to now.
+        let t2 = Time::default();
+        assert!(
+            Time::get_ms(&lua, &t2, ()).unwrap() < elapsed,
+            "a rebuilt clock must start from zero, not inherit the old origin"
+        );
+    }
+}

--- a/ferrowl-lua/src/module/value_type.rs
+++ b/ferrowl-lua/src/module/value_type.rs
@@ -38,3 +38,65 @@ impl mlua::FromLua for ValueType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ValueType;
+    use mlua::{FromLua, IntoLua, Lua};
+
+    #[test]
+    /// SC-R-009 — the five boundary types (integer, float, string, boolean, nil) each cross from
+    /// Lua into a host `ValueType`.
+    fn ut_from_lua_accepts_the_five_boundary_types() {
+        let lua = Lua::new();
+        let cases = [
+            ("42", "Int"),
+            ("1.5", "Float"),
+            ("'hi'", "String"),
+            ("true", "Bool"),
+            ("nil", "Nil"),
+        ];
+        for (expr, want) in cases {
+            let value = lua.load(expr).eval::<mlua::Value>().unwrap();
+            let got = ValueType::from_lua(value, &lua).unwrap();
+            let variant = match got {
+                ValueType::Int(_) => "Int",
+                ValueType::Float(_) => "Float",
+                ValueType::String(_) => "String",
+                ValueType::Bool(_) => "Bool",
+                ValueType::Nil => "Nil",
+            };
+            assert_eq!(variant, want, "for Lua expression `{expr}`");
+        }
+    }
+
+    #[test]
+    /// SC-R-009 — any other Lua value (table, function) fails conversion with an error rather than
+    /// being coerced or silently dropped.
+    fn ut_from_lua_rejects_non_scalar_values() {
+        let lua = Lua::new();
+        for expr in ["{}", "function() end"] {
+            let value = lua.load(expr).eval::<mlua::Value>().unwrap();
+            assert!(
+                ValueType::from_lua(value, &lua).is_err(),
+                "`{expr}` must fail conversion, not coerce"
+            );
+        }
+    }
+
+    #[test]
+    /// SC-R-009 — each of the five host types converts back into its matching Lua value.
+    fn ut_into_lua_round_trips_the_five_types() {
+        let lua = Lua::new();
+        assert!(ValueType::Int(7).into_lua(&lua).unwrap().is_integer());
+        assert!(ValueType::Float(1.5).into_lua(&lua).unwrap().is_number());
+        assert!(
+            ValueType::String("x".into())
+                .into_lua(&lua)
+                .unwrap()
+                .is_string()
+        );
+        assert!(ValueType::Bool(true).into_lua(&lua).unwrap().is_boolean());
+        assert!(ValueType::Nil.into_lua(&lua).unwrap().is_nil());
+    }
+}

--- a/ferrowl-lua/tests/modules.rs
+++ b/ferrowl-lua/tests/modules.rs
@@ -190,3 +190,110 @@ fn ut_builder_propagates_script_error() {
         .build();
     assert!(result.is_err());
 }
+
+#[test]
+/// SC-R-001 — scripts run on a real, compiled-in Lua 5.4 VM.
+fn ut_runtime_is_lua_5_4() {
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_script("ver".to_string(), r#"assert(_VERSION == "Lua 5.4")"#)
+        .build()
+        .unwrap();
+    ctx.call(&"ver".to_string()).unwrap();
+}
+
+#[test]
+/// SC-R-002 — a C_* call is synchronous and blocking: it completes and yields its value before the
+/// calling script's next statement runs.
+fn ut_host_call_is_synchronous() {
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_module(TimeModule::default())
+        // The second statement uses the value the first call returned: the call must have
+        // completed before control returned to the script.
+        .with_script(
+            "sync".to_string(),
+            r#"
+            local a = C_Time:GetMs()
+            assert(type(a) == "number")
+            local b = C_Time:GetMs()
+            assert(b >= a)
+        "#,
+        )
+        .build()
+        .unwrap();
+    ctx.call(&"sync".to_string()).unwrap();
+}
+
+#[test]
+/// SC-R-004 — every script in one context shares that context's single global environment: a
+/// global set by one script is visible to another.
+fn ut_scripts_share_one_global_environment() {
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_script("setter".to_string(), "shared = 123")
+        .with_script("getter".to_string(), "assert(shared == 123)")
+        .build()
+        .unwrap();
+    // The setter runs first; the getter then observes the global it left behind.
+    ctx.call(&"setter".to_string()).unwrap();
+    ctx.call(&"getter".to_string()).unwrap();
+}
+
+#[test]
+/// SC-R-008 — the only host-injected globals are the C_* modules registered for the context plus
+/// `print`; no other bespoke host global is injected.
+fn ut_only_registered_host_globals_are_present() {
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_stdlib()
+        .with_module(TimeModule::default())
+        .with_print_sink(VecSink::default())
+        .with_script(
+            "globals".to_string(),
+            r#"
+            -- Registered for this context:
+            assert(C_Time ~= nil)
+            assert(print ~= nil)
+            -- Not registered here, and no other bespoke host global exists:
+            assert(C_Register == nil)
+            assert(C_OCPP == nil)
+            assert(C_Module == nil)
+            assert(C_Anything == nil)
+        "#,
+        )
+        .build()
+        .unwrap();
+    ctx.call(&"globals".to_string()).unwrap();
+}
+
+#[test]
+/// SC-R-015 — scripts in a context run sequentially within a cycle: each runs to completion, so a
+/// shared global mutated by both reflects both runs regardless of their (unspecified) order.
+fn ut_scripts_in_a_cycle_run_sequentially() {
+    let mut ctx = ContextBuilder::<String>::default()
+        // Order-agnostic: whichever runs first initialises `acc`, the other increments it. If the
+        // two could interleave, the read-modify-write would race; sequential execution makes the
+        // final value deterministic.
+        .with_script("a".to_string(), "acc = (acc or 0) + 1")
+        .with_script("b".to_string(), "acc = (acc or 0) + 1")
+        .with_script("check".to_string(), "assert(acc == 2)")
+        .build()
+        .unwrap();
+    ctx.call(&"a".to_string()).unwrap();
+    ctx.call(&"b".to_string()).unwrap();
+    ctx.call(&"check".to_string()).unwrap();
+}
+
+#[test]
+/// SC-R-019 — a module not registered in the context is a nil global, so naming it fails at run
+/// time with an "attempt to index a nil value" error rather than silently no-opping.
+fn ut_unregistered_module_indexes_nil_and_errors() {
+    // A Modbus-shaped context gets C_Register, never C_OCPP; indexing the absent module errors.
+    let mut ctx = ContextBuilder::<String>::default()
+        .with_module(RegisterModule::init(Handle))
+        .with_script("bad".to_string(), r#"C_OCPP:Get("x")"#)
+        .build()
+        .unwrap();
+    let err = ctx.call(&"bad".to_string()).unwrap_err();
+    assert!(
+        err.to_string().contains("nil value"),
+        "expected a nil-index error, got: {err}"
+    );
+}

--- a/ferrowl/src/app/keys.rs
+++ b/ferrowl/src/app/keys.rs
@@ -315,6 +315,32 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-005 — an open modal layer consumes the keys its lower layers would otherwise receive:
+    /// while the keybind-help dialog is open, a `:` that would open the command line at the content
+    /// layer is swallowed, leaving help open and the command line unopened.
+    fn ut_open_help_layer_consumes_lower_layer_keys() {
+        let mut app = app_with(&["a"]);
+        assert!(!app.help_open);
+
+        // Open the topmost (help) layer.
+        app.handle_nav_key(KeyModifiers::empty(), KeyCode::Char('?'));
+        assert!(app.help_open, "`?` opens the keybind-help layer");
+
+        // `:` would open the command line at the content layer; the open help layer eats it.
+        app.handle_nav_key(KeyModifiers::empty(), KeyCode::Char(':'));
+        assert!(app.help_open, "help stays open");
+        assert_eq!(
+            app.focus,
+            Focus::Content,
+            "the command line must not have opened beneath the modal help layer"
+        );
+
+        // Esc dismisses help, restoring the lower layers.
+        app.handle_nav_key(KeyModifiers::empty(), KeyCode::Esc);
+        assert!(!app.help_open, "Esc closes the help layer");
+    }
+
+    #[test]
     /// UI-R-009 — the `Ctrl+w` chord toggles focus between the active tab's content view and its
     /// log pane.
     fn ut_ctrl_w_chord_toggles_content_and_log_focus() {

--- a/ferrowl/src/app/mod.rs
+++ b/ferrowl/src/app/mod.rs
@@ -625,6 +625,33 @@ mod tests {
     }
 
     #[test]
+    /// UI-R-043 — a tab owns a bounded ring log of timestamped, severity-tagged lines
+    /// (Info/Warning/Error), retaining only its most recent capacity.
+    fn ut_log_ring_is_bounded_and_severity_tagged() {
+        let mut ring = LogRing::init();
+        ring.write(Level::Info, "info line");
+        ring.write(Level::Warning, "warn line");
+        ring.write(Level::Error, "error line");
+
+        let recent = ring.peek_n(3);
+        // Each entry keeps its severity and a timestamp alongside the message.
+        assert_eq!(
+            recent.iter().map(|(_, lvl, _)| *lvl).collect::<Vec<_>>(),
+            vec![Level::Info, Level::Warning, Level::Error]
+        );
+        assert!(
+            recent.iter().all(|(ts, _, _)| *ts > 0),
+            "lines are timestamped"
+        );
+
+        // The ring is bounded: writing past capacity retains only the most recent LOG_SIZE lines.
+        for i in 0..(LOG_SIZE + 20) {
+            ring.write(Level::Info, &format!("l{i}"));
+        }
+        assert_eq!(ring.peek_n(LOG_SIZE + 100).len(), LOG_SIZE);
+    }
+
+    #[test]
     /// UI-R-044 — a long line is truncated to the per-line cap, and the total-written counter is
     /// monotonic across ring eviction.
     fn ut_log_truncates_long_lines_and_counts_monotonically() {

--- a/ferrowl/src/app/overlay.rs
+++ b/ferrowl/src/app/overlay.rs
@@ -135,3 +135,56 @@ impl<S: DrawSurface> App<S> {
         self.close_overlay();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::testkit::{MockSetup, MockView, build_app};
+
+    fn app_with(names: &[&str]) -> App<crate::app::testkit::MockScreen> {
+        build_app(names.iter().map(|n| MockView::pair(n).0.boxed()).collect())
+    }
+
+    async fn active_log_lines(app: &App<crate::app::testkit::MockScreen>) -> Vec<String> {
+        app.tabs[app.active]
+            .log
+            .read()
+            .await
+            .peek_n(crate::app::LOG_SIZE)
+            .into_iter()
+            .map(|(_, _, line)| line)
+            .collect()
+    }
+
+    #[tokio::test]
+    /// UI-R-025 — confirming a creation dialog whose name collides with an existing tab is refused
+    /// with a warning in the active tab's log and leaves the dialog open, never overwriting or
+    /// duplicating the name; a non-colliding name creates the tab and closes the dialog.
+    async fn ut_creating_a_colliding_tab_name_is_refused_with_the_dialog_left_open() {
+        let mut app = app_with(&["a"]);
+
+        // Confirm a creation dialog that resolves to the already-used name "a".
+        app.overlay = Some(Overlay::Creation(Box::new(MockSetup::new("a"))));
+        app.focus = Focus::Dialog;
+        app.confirm_overlay().await;
+
+        assert_eq!(app.tabs.len(), 1, "a colliding name must not add a tab");
+        assert!(
+            app.overlay.is_some(),
+            "the setup dialog stays open on refusal"
+        );
+        assert!(
+            active_log_lines(&app)
+                .await
+                .iter()
+                .any(|l| l.contains("already in use")),
+            "a warning must be logged into the active tab"
+        );
+
+        // A distinct name is accepted: the tab is created and the dialog closes.
+        app.overlay = Some(Overlay::Creation(Box::new(MockSetup::new("b"))));
+        app.confirm_overlay().await;
+        assert_eq!(app.tabs.len(), 2, "a unique name creates the tab");
+        assert!(app.overlay.is_none(), "the dialog closes after creation");
+    }
+}

--- a/ferrowl/src/app/testkit.rs
+++ b/ferrowl/src/app/testkit.rs
@@ -31,6 +31,7 @@ use ratatui::layout::Rect;
 
 use super::{App, LogRing};
 use crate::config::script::ScriptDef;
+use crate::module::type_descriptor::{ModuleViewFactory, SetupView};
 use crate::module::view::{
     CommandDescriptor, CommandFuture, CommandResult, ModuleView, RefreshFuture, SharedLog,
 };
@@ -255,6 +256,37 @@ impl ModuleView for MockView {
     fn module_host(&self) -> Option<Arc<dyn ModuleHost>> {
         self.host_kind
             .map(|kind| Arc::new(MockHost { kind }) as Arc<dyn ModuleHost>)
+    }
+}
+
+/// A [`SetupView`] test double whose `confirm` always validates to a fixed tab name backed by a
+/// fresh [`MockView`]. Lets a creation-flow test drive `confirm_overlay` to either the create or
+/// the name-collision branch without a real module setup dialog.
+pub(super) struct MockSetup {
+    name: String,
+}
+
+impl MockSetup {
+    pub(super) fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+        }
+    }
+}
+
+impl SetupView for MockSetup {
+    fn render(&mut self, _area: Rect, _buf: &mut Buffer) {}
+    fn handle_events(&mut self, modifiers: KeyModifiers, code: KeyCode) -> EventResult {
+        EventResult::Unhandled(modifiers, code)
+    }
+    fn focus_next(&mut self) {}
+    fn focus_previous(&mut self) {}
+    fn confirm(&self) -> Option<(String, ModuleViewFactory)> {
+        let name = self.name.clone();
+        Some((
+            self.name.clone(),
+            Box::new(move || MockView::pair(&name).0.boxed()),
+        ))
     }
 }
 

--- a/ferrowl/src/cli/headless.rs
+++ b/ferrowl/src/cli/headless.rs
@@ -405,6 +405,8 @@ mod tests {
 
     #[tokio::test]
     /// CL-R-031 — a `[sim]` line flags exit-code 2 only when --exit-on-error is set.
+    /// CL-R-034 — a Lua sim error (a `[sim]` line) does not by itself fail a headless run: with
+    /// --exit-on-error off it surfaces without flagging the exit code.
     async fn ut_drain_log_flags_sim_error_prefix_only_when_requested() {
         let log = new_log();
         log.write().await.write(Level::Error, "[sim] boom");

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -715,4 +715,158 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("cannot Set nil value"));
     }
+
+    // --- Execution model: dedicated thread, stop control, responsive sleep, shared locking ---
+
+    /// A log sink that records the OS thread on which Lua logging (and thus execution) occurred.
+    #[derive(Clone)]
+    struct ThreadIdSink(Arc<std::sync::Mutex<Option<std::thread::ThreadId>>>);
+    impl LogSink for ThreadIdSink {
+        fn log(&self, _level: LogLevel, _line: &str) {
+            *self.0.lock().unwrap() = Some(std::thread::current().id());
+        }
+    }
+
+    #[test]
+    /// SC-R-010 — a sim owner runs its Lua context on a dedicated OS thread, building and executing
+    /// the context there rather than on the caller (UI/async) thread.
+    fn ut_sim_runs_lua_on_a_dedicated_thread() {
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let sink = ThreadIdSink(seen.clone());
+        let caller = std::thread::current().id();
+
+        // Mirror run_sim's model: the context is built and run inside its own thread (mlua::Lua is
+        // !Send, so it cannot be built on one thread and moved to another).
+        std::thread::spawn(move || {
+            let mut ctx = ContextBuilder::<String>::default()
+                .with_stdlib()
+                .with_print_sink(sink)
+                .with_script("t".to_string(), r#"print("ran")"#)
+                .build()
+                .unwrap();
+            let _ = ctx.call_all();
+        })
+        .join()
+        .unwrap();
+
+        let ran_on = seen.lock().unwrap().expect("the script must have executed");
+        assert_ne!(
+            ran_on, caller,
+            "Lua must execute on a dedicated thread, not the caller"
+        );
+    }
+
+    #[test]
+    /// SC-R-012 — setting the stop flag and joining stops the sim; the sim handle's destruction
+    /// (Drop) also stops and joins its thread.
+    fn ut_sim_stops_on_flag_and_on_drop() {
+        let noop = || vec![("noop".to_string(), "local x = 1".to_string())];
+
+        // Explicit stop(): once it returns, the thread has been joined and logged its exit.
+        let log = script_log();
+        let mut handle = run_sim(
+            evse_memory(),
+            vstore(),
+            evse_registers(),
+            noop(),
+            Duration::from_millis(20),
+            log.clone(),
+            no_sink(),
+        )
+        .expect("a non-empty script set spawns a sim thread");
+        handle.stop();
+        assert!(
+            log_lines(&log)
+                .iter()
+                .any(|l| l.contains("[sim] stopped completely"))
+        );
+
+        // Drop path: dropping the handle stops and joins without an explicit stop().
+        let log2 = script_log();
+        {
+            let _h = run_sim(
+                evse_memory(),
+                vstore(),
+                evse_registers(),
+                noop(),
+                Duration::from_millis(20),
+                log2.clone(),
+                no_sink(),
+            )
+            .expect("a non-empty script set spawns a sim thread");
+        }
+        assert!(
+            log_lines(&log2)
+                .iter()
+                .any(|l| l.contains("[sim] stopped completely"))
+        );
+    }
+
+    #[test]
+    /// SC-R-013 — the cycle sleep is chunked and re-checks the stop flag, so a stop set during the
+    /// idle portion of a cycle is observed promptly instead of after the full interval.
+    fn ut_sleep_responsive_observes_stop_promptly() {
+        // Already-requested stop: the chunked sleep must bail out well before the 10s interval.
+        let stopped = AtomicBool::new(true);
+        let start = std::time::Instant::now();
+        sleep_responsive(Duration::from_secs(10), &stopped);
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "a stopped sim must not sleep the full cycle interval"
+        );
+
+        // Without a stop, it does sleep roughly the (short) interval.
+        let running = AtomicBool::new(false);
+        let start = std::time::Instant::now();
+        sleep_responsive(Duration::from_millis(80), &running);
+        assert!(start.elapsed() >= Duration::from_millis(60));
+    }
+
+    #[test]
+    /// SC-R-029 — host state reached from Lua is guarded by the same lock the network task uses: a
+    /// bridge write blocks while that lock is held elsewhere and completes once it is released.
+    fn ut_bridge_write_contends_on_the_host_lock() {
+        let memory = evse_memory();
+        let bridge = RegisterBridge::new(memory.clone(), vstore(), Arc::new(evse_registers()));
+        let done = Arc::new(AtomicBool::new(false));
+
+        // Hold the module memory's write lock, exactly as the network task would while updating.
+        let guard = memory.write();
+
+        let done_writer = done.clone();
+        let writer = std::thread::spawn(move || {
+            // Takes the same lock, so it cannot make progress until the guard above is released.
+            bridge
+                .write("setpoint".to_string(), ValueType::Int(5))
+                .expect("write");
+            done_writer.store(true, Ordering::Relaxed);
+        });
+
+        // While we hold the lock, the Lua-side write is blocked on it.
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !done.load(Ordering::Relaxed),
+            "the write proceeded without acquiring the shared host lock"
+        );
+
+        drop(guard); // release: the contended write now completes
+        assert!(wait_for(Duration::from_secs(2), || done.load(Ordering::Relaxed)));
+        writer.join().unwrap();
+
+        // The value the Lua write applied is the one now in shared host memory.
+        let setpoint = memory
+            .read()
+            .read(
+                Key {
+                    id: SlaveKey {
+                        slave_id: 1,
+                        kind: Kind::HoldingRegister,
+                    },
+                },
+                &CellType::Register,
+                &Range::new(0, 1),
+            )
+            .expect("read setpoint");
+        assert_eq!(setpoint, vec![5]);
+    }
 }

--- a/ferrowl/src/migrate.rs
+++ b/ferrowl/src/migrate.rs
@@ -650,6 +650,59 @@ mod tests {
     }
 
     #[test]
+    /// CS-R-043 — migration stamps the output device config with the current build version.
+    fn ut_migrate_stamps_current_version() {
+        let (device, _) = convert(legacy_sample());
+        assert_eq!(device.version.as_deref(), Some(crate::config::VERSION));
+    }
+
+    #[test]
+    /// CS-R-042 — legacy fields with no current equivalent are dropped with a warning per field,
+    /// never silently, and the register carrying a dropped field still migrates.
+    fn ut_migrate_drops_legacy_fields_with_warning() {
+        let mut legacy = legacy_sample();
+        legacy.history_length = Some(50);
+        legacy.definitions.clear();
+        legacy.definitions.insert(
+            "reversed".into(),
+            LegacyRegisterDef {
+                slave_id: 1,
+                read_code: 3,
+                address: Some(LegacyAddress::Int(1)),
+                length: 1,
+                access: "ReadOnly".into(),
+                value_type: "U16".into(),
+                reverse: true, // legacy per-register field with no current equivalent
+                resolution: 1.0,
+                is_virtual: false,
+                description: String::new(),
+                on_update: None,
+                values: vec![],
+                default: None,
+            },
+        );
+        // A contiguous range with a non-zero slave_id: another dropped legacy field.
+        legacy.contiguous_memory = vec![LegacyMemoryRange {
+            slave_id: 7,
+            read_code: 3,
+            range: LegacyRange {
+                start: LegacyAddress::Int(0),
+                end: LegacyAddress::Int(1),
+            },
+        }];
+
+        let (device, warnings) = convert(legacy);
+
+        // A warning is emitted for each dropped legacy field, not swallowed.
+        assert!(warnings.iter().any(|w| w.contains("history_length")));
+        assert!(warnings.iter().any(|w| w.contains("reverse")));
+        assert!(warnings.iter().any(|w| w.contains("slave_id")));
+
+        // The register survives the dropped `reverse` field — the drop is non-fatal.
+        assert!(device.definitions.contains_key("reversed"));
+    }
+
+    #[test]
     /// CS-R-041 — a full legacy sample migrates through the transformation contract.
     fn ut_convert_full_sample() {
         let (device, warnings) = convert(legacy_sample());

--- a/ferrowl/tests/cli.rs
+++ b/ferrowl/tests/cli.rs
@@ -92,6 +92,86 @@ fn it_migrate_exit_codes() {
 }
 
 #[test]
+/// CS-R-040 — the migrate subcommand converts a pre-rewrite config file into a device-config file.
+/// CS-R-043 — input and output encodings are each chosen independently from their own extension,
+/// so a JSON source migrates to a TOML destination (and vice-versa), version-stamped either way.
+/// CS-R-045 — migration produces a device config only, never a session file.
+fn it_migrate_cross_encoding_produces_device_config() {
+    let dir = std::env::temp_dir();
+
+    // A minimal pre-rewrite config with one holding register and a contiguous range.
+    let legacy_json = r#"{
+        "contiguous_memory": [{ "read_code": 3, "range": { "start": 0, "end": 4 } }],
+        "definitions": {
+            "rpm": { "read_code": 3, "address": 16, "type": "U16" }
+        }
+    }"#;
+
+    // JSON source → TOML destination: the two encodings are chosen independently.
+    let input = dir.join("ferrowl_migrate_cross_in.json");
+    std::fs::write(&input, legacy_json).unwrap();
+    let output = dir.join("ferrowl_migrate_cross_out.toml");
+    let ok = bin()
+        .args([
+            "migrate",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run migrate");
+    assert_eq!(
+        ok.status.code(),
+        Some(0),
+        "a JSON→TOML migration must exit 0; stderr: {}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+
+    let toml_out = std::fs::read_to_string(&output).unwrap();
+    // Version-stamped (CS-R-043) and shaped as a device config, not a session (CS-R-045):
+    // device configs carry `read_ranges`/`definitions`; a session would carry `[[modules]]`.
+    assert!(
+        toml_out.contains("version"),
+        "output must be version-stamped"
+    );
+    assert!(
+        toml_out.contains("[definitions.") || toml_out.contains("[read_ranges]"),
+        "output must be a device config, got:\n{toml_out}"
+    );
+    assert!(
+        !toml_out.contains("[[modules]]"),
+        "migration must not produce a session file"
+    );
+
+    // TOML source → JSON destination: the reverse direction is equally independent.
+    let input2 = dir.join("ferrowl_migrate_cross_in.toml");
+    std::fs::write(&input2, "").unwrap();
+    let output2 = dir.join("ferrowl_migrate_cross_out.json");
+    let ok2 = bin()
+        .args([
+            "migrate",
+            "-i",
+            input2.to_str().unwrap(),
+            "-o",
+            output2.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run migrate");
+    assert_eq!(
+        ok2.status.code(),
+        Some(0),
+        "a TOML→JSON migration must exit 0; stderr: {}",
+        String::from_utf8_lossy(&ok2.stderr)
+    );
+    let json_out = std::fs::read_to_string(&output2).unwrap();
+    assert!(
+        json_out.contains("\"version\""),
+        "JSON output must be version-stamped, got:\n{json_out}"
+    );
+}
+
+#[test]
 /// CL-R-042 — setup/fatal diagnostics go to stderr, keeping stdout as the drained-log stream.
 fn it_fatal_diagnostics_go_to_stderr() {
     let module =


### PR DESCRIPTION
## Background

`docs/specs/README.md` guarantees that every requirement not on its "intentionally not unit-tested" list carries a test whose doc comment cites the requirement ID. An audit found 21 IDs that were neither cited by a test nor on that list, breaking the guarantee. This restores it.

## Scope

The 21 IDs, by area:

- **config-session:** CS-R-040, 042, 043, 045 (the `migrate` envelope)
- **scripting:** SC-R-001, 002, 004, 008, 009, 010, 012, 013, 015, 017, 019, 029
- **tui:** UI-R-005, 025, 043
- **cli-headless:** CL-R-034

UI-R-001 appeared in the issue but is already on the README exclusion list (raw-mode/terminal fact); the issue's list was stale for it, so no action was taken.

## How it was resolved

Every gap was closed by adding a citing test — no new exclusions, so the README needs no edit. Where a test already exercised the behavior but cited only a neighbouring ID (CL-R-034, next to CL-R-031), the missing ID was added to that test's doc comment.

- **Migrate:** unit tests for version stamping (CS-R-043) and legacy-field dropping (CS-R-042); a subprocess end-to-end test proving independent input/output encodings JSON↔TOML (CS-R-043), conversion of a pre-rewrite file (CS-R-040), and device-config-only output (CS-R-045).
- **Scripting:** tests spread across `modules.rs`, `value_type.rs`, `time.rs`, and `lua.rs` covering the Lua 5.4 runtime, synchronous host calls, shared globals, the host-global allowlist, the five boundary types, the dedicated sim thread, stop/drop control, chunked responsive sleep, sequential cycle execution, `C_Time` origin/reset, and unregistered-module nil-index errors. SC-R-029 got a deterministic mutual-exclusion test: a bridge write blocks while the host memory lock is held elsewhere and completes on release.
- **TUI/CLI:** modal layer key-consumption (UI-R-005), tab-name collision refusal (UI-R-025), the bounded/timestamped/severity-tagged log ring (UI-R-043), and "a Lua sim error does not by itself fail a headless run" (CL-R-034).

A single `#[cfg(test)]` helper was added — `MockSetup` in `app/testkit.rs`, a `SetupView` double that lets the tab-creation flow be driven without a real module setup dialog.

## Verification

`cargo test --workspace`, `cargo fmt --check`, and `cargo clippy --workspace --tests` all clean. Tests-only change: no product behavior changed, so there is no spec/normative diff.

## Closes

Closes #112.
