### PR TITLE
Make GitHub the sole nightly artifact builder and mirror the quality gate to GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+# Mirrors the Woodpecker quality gate (.woodpecker/check.yml) so its result is a
+# GitHub-visible status check, usable by branch protection and PR gating. The
+# toolchain (channel + rustfmt/clippy components) is resolved from
+# rust-toolchain.toml by rustup, so no explicit component installs are needed.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo clippy --workspace -- -D warnings
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo check --workspace
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo test --workspace
+
+  # Advisories, licenses, and banned/duplicate crates. Policy lives in deny.toml.
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: cargo install cargo-deny --locked
+      - run: cargo deny check

--- a/.woodpecker/nightly.yml
+++ b/.woodpecker/nightly.yml
@@ -1,18 +1,14 @@
+# Nightly release orchestration.
+#
+# Single source of truth for the `nightly` GitHub Release *object*: this pipeline
+# refreshes the release and its notes. It deliberately does NOT build or attach
+# binaries — creating the release fires `.github/workflows/release.yml`, which is
+# the sole builder of release artifacts (nightly and tagged versions alike).
+#
+# The `nightly` tag itself is moved by `.github/workflows/nightly.yml` on push to
+# main; that tag push is what triggers the steps below.
 steps:
-  build:
-    image: rust:latest
-    commands:
-      - apt-get update && apt-get install -y mingw-w64 zip
-      - rustup target add x86_64-pc-windows-gnu
-      - cargo check
-      - cargo test
-      - cargo build --release
-      - cargo build --release --target x86_64-pc-windows-gnu
-    when:
-      - event: tag
-        ref: refs/tags/nightly
-
-  delete-nightly:
+  release:
     image: alpine
     environment:
       GITHUB_TOKEN:
@@ -36,6 +32,8 @@ steps:
         [ -n "$GENERATED" ] && printf '%s\n\n' "$GENERATED" >> release-notes.md
         printf 'Built from commit **%s** on **%s**.\n\n' \
           "$CI_COMMIT_SHA" "$(date -u +%Y-%m-%d)" >> release-notes.md
+        # Delete the previous nightly release so the notes and assets are rebuilt
+        # cleanly. The `nightly` git tag is left in place (owned by GitHub Actions).
         RELEASE_ID=$(curl -sf \
           -H "Authorization: token $GITHUB_TOKEN" \
           https://api.github.com/repos/$REPO/releases/tags/nightly \
@@ -44,21 +42,15 @@ steps:
           -H "Authorization: token $GITHUB_TOKEN" \
           https://api.github.com/repos/$REPO/releases/$RELEASE_ID \
           && echo "Deleted release $RELEASE_ID" || echo "No existing release to delete"
-    when:
-      - event: tag
-        ref: refs/tags/nightly
-
-  upload:
-    image: woodpeckerci/plugin-release
-    settings:
-      api_key:
-        from_secret: github_token
-      title: 'Nightly'
-      prerelease: true
-      note: release-notes.md
-      checksum:
-        - sha256
-        - md5
+        # Recreate the release shell as a prerelease. Publishing it (draft:false)
+        # emits the `release: created` event that release.yml builds artifacts on.
+        curl -sf -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          https://api.github.com/repos/$REPO/releases \
+          -d "$(jq -n --arg tag nightly --arg sha "$CI_COMMIT_SHA" \
+            --rawfile body release-notes.md \
+            '{tag_name:$tag, target_commitish:$sha, name:"Nightly", body:$body, prerelease:true, draft:false}')"
     when:
       - event: tag
         ref: refs/tags/nightly


### PR DESCRIPTION
## Background

Two CI systems ran in parallel with overlapping nightly responsibility:

- **Woodpecker** `nightly.yml` reacted to the `nightly` tag, built linux+windows binaries, deleted the old release, and uploaded a new one.
- **GitHub Actions** `release.yml` reacts to `release: created` and also builds+attaches artifacts.

So when Woodpecker created the nightly release, `release.yml` fired and attached a *second* set of artifacts to the same release — a race and double-publish. Separately, the quality gate (test, clippy, cargo-deny) ran only on Woodpecker, invisible to GitHub branch protection and PR status checks (#113).

## How it's resolved

- **One artifact builder.** Woodpecker `nightly.yml` no longer builds or uploads binaries. It only refreshes the nightly GitHub Release *object*: regenerate notes, delete the old release, recreate it as a published prerelease. Publishing fires `release.yml`, which is now the single builder of release artifacts for nightly and tagged versions alike.
- **Gate visible on GitHub.** New `.github/workflows/ci.yml` mirrors the Woodpecker gate (`fmt`, `clippy -D warnings`, `check`, `test`, `cargo-deny`) on push + PR, so the result is a GitHub status check usable for branch protection. Toolchain and rustfmt/clippy components resolve from `rust-toolchain.toml`, so no explicit component installs.
- **Tag movement unchanged.** `.github/workflows/nightly.yml` still moves the `nightly` tag on push to main; that tag push is what triggers Woodpecker.

Event chain, no loop: push to main → GH moves `nightly` tag (+ gate runs on GH and Woodpecker) → tag push → Woodpecker recreates the release → `release: created` → `release.yml` builds and attaches assets.

## Note

Nightly drops the old `sha256`/`md5` checksum files that `plugin-release` produced; artifacts now come from `release.yml`, matching how tagged version releases already publish. Parity, not a new gap.

## Verification

YAML validated (all five workflow files parse); jq `--rawfile` confirmed available on alpine jq 1.7. CI-only change with no local runtime — full confirmation is the first post-merge nightly cycle.

Closes #113
