### PR TITLE
Harden swallowed error paths and tighten dead-code hygiene

### DIFF
--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -427,6 +427,7 @@ abort the task if it has not finished within the grace period; a stopped instanc
 shall be restartable.
 
 **MB-R-098** — When a Modbus module view stops its running instance as part of a
-`:restart` or `:reload` command, a failure of that stop shall be reported in the
+`:restart` or `:reload` command, a failure of that stop — other than the instance
+not currently being running, which is the expected no-op — shall be reported in the
 module message log at Error level rather than silently discarded. A failed start on
 `:restart` is already surfaced.

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -425,3 +425,8 @@ is not running, shall fail with an error rather than being silently dropped.
 **MB-R-094** — Stopping a client shall first request graceful termination and only
 abort the task if it has not finished within the grace period; a stopped instance
 shall be restartable.
+
+**MB-R-098** — When a Modbus module view stops its running instance as part of a
+`:restart` or `:reload` command, a failure of that stop shall be reported in the
+module message log at Error level rather than silently discarded. A failed start on
+`:restart` is already surfaced.

--- a/docs/specs/ocpp/requirements.md
+++ b/docs/specs/ocpp/requirements.md
@@ -430,6 +430,11 @@ from the in-memory buffer does not cause a message to be logged twice or skipped
 shall never discard an encode failure silently: the failure shall be logged to the
 module's error channel before the payload degrades to JSON `null`.
 
+**OC-R-102** — When an OCPP module view stops or (re)starts its backend as part of a
+settings change, version switch, or a `stop`/`restart` command, a failure of that
+stop or start shall be reported in the module message log at Error level rather than
+silently discarded.
+
 ---
 
 ## Send dialogs

--- a/ferrowl-lua/src/builder.rs
+++ b/ferrowl-lua/src/builder.rs
@@ -22,12 +22,13 @@ where
     }
 }
 
-#[allow(dead_code)]
 impl<K> ContextBuilder<K>
 where
     K: Hash + Eq + Default,
 {
-    /// Create context builder from context result
+    /// Create context builder from context result. Test-only: production builders start from
+    /// [`ContextBuilder::default`] and chain `with_*`.
+    #[cfg(test)]
     fn from(context: Result<Context<K>>) -> Self {
         Self { context }
     }

--- a/ferrowl-lua/src/context.rs
+++ b/ferrowl-lua/src/context.rs
@@ -14,7 +14,6 @@ where
     scripts: HashMap<K, Script>,
 }
 
-#[allow(dead_code)]
 impl<K> Context<K>
 where
     K: Hash + Eq + Default,

--- a/ferrowl-lua/src/script_state.rs
+++ b/ferrowl-lua/src/script_state.rs
@@ -1,20 +1,17 @@
 use crate::Error;
 
 /// ScriptState of a lua execution
-#[allow(dead_code)]
 enum ExecState {
     Err(Error),
     Ok,
 }
 
 /// Meta state of a lua execution
-#[allow(dead_code)]
 pub struct ScriptState {
     state: ExecState,
     time_since: std::time::Instant,
 }
 
-#[allow(dead_code)]
 impl ScriptState {
     /// Create a new error state
     pub fn err(err: Error) -> Self {

--- a/ferrowl-util/src/tokio.rs
+++ b/ferrowl-util/src/tokio.rs
@@ -127,7 +127,6 @@ pub async fn spawn_detach_with_context<F: Send + IntoFuture + Future + 'static>(
 ///     join_all().await;
 /// }
 /// ```
-#[allow(dead_code)]
 pub async fn join_all() {
     loop {
         let mut context = CONTEXT.lock().await;
@@ -175,7 +174,6 @@ pub async fn join_all() {
 ///     join_all_of_context("Local").await;
 /// }
 /// ```
-#[allow(dead_code)]
 pub async fn join_all_of_context(ctx: &'static str) {
     loop {
         let mut context = CONTEXT.lock().await;

--- a/ferrowl/src/instance/error.rs
+++ b/ferrowl/src/instance/error.rs
@@ -26,3 +26,12 @@ pub enum Error {
     #[error("Instance error: {0}")]
     Instance(#[from] InstanceError),
 }
+
+impl Error {
+    /// True when this is the benign "instance was not running" outcome — a stop of an
+    /// already-stopped instance, which `:restart`/`:reload` treat as a no-op rather than a
+    /// reportable failure.
+    pub fn is_not_running(&self) -> bool {
+        matches!(self, Error::Instance(InstanceError::NotRunning))
+    }
+}

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -171,8 +171,8 @@ impl<T: KeyParams> Instance<T> {
                     h.handle.await
                 }
             }
-            _ => {
-                unreachable!("case is unreachable");
+            None => {
+                unreachable!("stop() early-returns when handle is None");
             }
         };
 

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -566,12 +566,23 @@ impl ModuleView for ModbusModuleView {
             return Box::pin(async move {
                 let role = self.spec.role.to_string();
                 let endpoint = self.spec.endpoint.to_string();
-                let _ = self.module.stop().await;
+                let stop_err = self
+                    .module
+                    .stop()
+                    .await
+                    .err()
+                    .filter(|e| !e.is_not_running());
                 match self.module.start().await {
-                    Ok(()) => CommandResult::Handled(Some((
-                        Level::Info,
-                        format!("Restarted {role} on {endpoint}"),
-                    ))),
+                    Ok(()) => match stop_err {
+                        None => CommandResult::Handled(Some((
+                            Level::Info,
+                            format!("Restarted {role} on {endpoint}"),
+                        ))),
+                        Some(e) => CommandResult::Handled(Some((
+                            Level::Error,
+                            format!("Restarted {role} on {endpoint}, but stop of previous instance failed: {e}"),
+                        ))),
+                    },
                     Err(e) => CommandResult::Handled(Some((
                         Level::Error,
                         format!("Restart {role} failed: {e}"),
@@ -598,7 +609,12 @@ impl ModuleView for ModbusModuleView {
                         )));
                     }
                 };
-                let _ = self.module.stop().await;
+                let stop_err = self
+                    .module
+                    .stop()
+                    .await
+                    .err()
+                    .filter(|e| !e.is_not_running());
                 let new_module = ModbusModule::new(&self.spec, &device);
                 self.module = new_module;
                 self.device = device;
@@ -616,7 +632,16 @@ impl ModuleView for ModbusModuleView {
                         format!(":reload start error: {e}"),
                     )));
                 }
-                CommandResult::Handled(Some((Level::Info, format!(":reload done — '{path}'"))))
+                match stop_err {
+                    None => CommandResult::Handled(Some((
+                        Level::Info,
+                        format!(":reload done — '{path}'"),
+                    ))),
+                    Some(e) => CommandResult::Handled(Some((
+                        Level::Error,
+                        format!(":reload done — '{path}', but stop of previous instance failed: {e}"),
+                    ))),
+                }
             });
         }
 
@@ -931,10 +956,11 @@ mod tests {
         ModbusModuleView, ModbusViewOverlay, PendingAction, decode_definition, parse_set_args,
         raw_hex,
     };
+    use crate::app::Level;
     use crate::config::{DeviceConfig, Endpoint, ModuleSpec, Role};
     use crate::module::modbus::setup_dialog::SetupValues;
     use crate::module::modbus::table::Definition;
-    use crate::module::view::ModuleView;
+    use crate::module::view::{CommandResult, ModuleView};
     use crossterm::event::{KeyCode, KeyModifiers};
     use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder, Value};
@@ -1523,5 +1549,34 @@ mod tests {
         };
         view.apply_setup(values).await;
         assert_eq!(view.device.reconnect, Some(false));
+    }
+
+    #[tokio::test]
+    /// MB-R-098 — stopping an already-stopped instance during `:restart` is the expected
+    /// no-op, not a reportable stop failure, so the restart is surfaced as Info.
+    async fn ut_restart_from_stopped_does_not_report_stop_failure() {
+        let mut view = new_view();
+        // Bind ephemerally so the restart's start() is deterministic.
+        view.spec.endpoint = Endpoint::Tcp {
+            ip: "127.0.0.1".into(),
+            port: 0,
+        };
+        // The module is not running: stop() yields NotRunning, which must be swallowed.
+        let result = view.handle_command("restart").await;
+        match result {
+            CommandResult::Handled(Some((level, msg))) => {
+                assert!(
+                    matches!(level, Level::Info),
+                    "benign not-running stop must not surface as Error: {msg}"
+                );
+                assert!(
+                    !msg.contains("stop of previous instance failed"),
+                    "unexpected stop-failure text: {msg}"
+                );
+            }
+            _ => panic!("restart should be handled with a log line"),
+        }
+        // Tear down the server task spawned by the restart.
+        let _ = view.handle_command("stop").await;
     }
 }

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -580,7 +580,9 @@ impl ModuleView for ModbusModuleView {
                         ))),
                         Some(e) => CommandResult::Handled(Some((
                             Level::Error,
-                            format!("Restarted {role} on {endpoint}, but stop of previous instance failed: {e}"),
+                            format!(
+                                "Restarted {role} on {endpoint}, but stop of previous instance failed: {e}"
+                            ),
                         ))),
                     },
                     Err(e) => CommandResult::Handled(Some((
@@ -639,7 +641,9 @@ impl ModuleView for ModbusModuleView {
                     ))),
                     Some(e) => CommandResult::Handled(Some((
                         Level::Error,
-                        format!(":reload done — '{path}', but stop of previous instance failed: {e}"),
+                        format!(
+                            ":reload done — '{path}', but stop of previous instance failed: {e}"
+                        ),
                     ))),
                 }
             });

--- a/ferrowl/src/module/ocpp/client/view/backend.rs
+++ b/ferrowl/src/module/ocpp/client/view/backend.rs
@@ -194,12 +194,22 @@ impl<V: ClientVersion> ClientView<V> {
                 device.connectors = self.device.connectors.clone();
                 device.config = self.device.config.clone();
                 if spec.role == OcppRole::Server {
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log
+                            .write()
+                            .await
+                            .write(Level::Error, &format!("Stop before role switch failed: {e}"));
+                    }
                     self.deferred.replacement = Some(build_server_view(spec, path, device));
                     return;
                 }
                 if spec.version != self.spec.version {
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log.write().await.write(
+                            Level::Error,
+                            &format!("Stop before version switch failed: {e}"),
+                        );
+                    }
                     if !device.scripts.is_empty() {
                         self.log.write().await.write(
                             Level::Warning,
@@ -210,7 +220,12 @@ impl<V: ClientVersion> ClientView<V> {
                     return;
                 } else {
                     let was_online = self.backend.is_online();
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log.write().await.write(
+                            Level::Error,
+                            &format!("Stop for settings update failed: {e}"),
+                        );
+                    }
                     self.spec = spec;
                     self.device = device;
                     self.device_path = path;
@@ -220,7 +235,12 @@ impl<V: ClientVersion> ClientView<V> {
                         .write(Level::Info, "Settings updated");
                     if was_online {
                         let handler = self.make_handler();
-                        let _ = self.backend.start(&self.spec, handler).await;
+                        if let Err(e) = self.backend.start(&self.spec, handler).await {
+                            self.log.write().await.write(
+                                Level::Error,
+                                &format!("Restart after settings update failed: {e}"),
+                            );
+                        }
                     }
                 }
             }
@@ -376,7 +396,12 @@ impl<V: ClientVersion> ClientView<V> {
                 }
             }),
             "restart" => Box::pin(async move {
-                let _ = self.backend.stop().await;
+                if let Err(e) = self.backend.stop().await {
+                    self.log
+                        .write()
+                        .await
+                        .write(Level::Error, &format!("Reconnect: stop failed: {e}"));
+                }
                 let handler = self.make_handler();
                 match self.backend.start(&self.spec, handler).await {
                     Ok(()) => CommandResult::Handled(Some((Level::Info, "Reconnecting".into()))),

--- a/ferrowl/src/module/ocpp/client/view/backend.rs
+++ b/ferrowl/src/module/ocpp/client/view/backend.rs
@@ -195,10 +195,10 @@ impl<V: ClientVersion> ClientView<V> {
                 device.config = self.device.config.clone();
                 if spec.role == OcppRole::Server {
                     if let Err(e) = self.backend.stop().await {
-                        self.log
-                            .write()
-                            .await
-                            .write(Level::Error, &format!("Stop before role switch failed: {e}"));
+                        self.log.write().await.write(
+                            Level::Error,
+                            &format!("Stop before role switch failed: {e}"),
+                        );
                     }
                     self.deferred.replacement = Some(build_server_view(spec, path, device));
                     return;

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -1009,4 +1009,20 @@ mod tests {
             "the version switch must warn about version-specific actions"
         );
     }
+
+    #[tokio::test]
+    /// OC-R-102 — a failed backend (re)start from the client view is reported at Error level.
+    async fn ut_restart_reports_backend_start_failure() {
+        let mut v = client_view::<V2_0_1>(OcppVersion::V2_0_1);
+        // Point at a closed port so the reconnect's start() fails fast.
+        v.spec.port = 1;
+        let result = v.handle_command_impl("restart").await;
+        match result {
+            crate::module::view::CommandResult::Handled(Some((level, msg))) => {
+                assert!(matches!(level, crate::app::Level::Error), "{msg}");
+                assert!(msg.contains("Reconnect failed"), "{msg}");
+            }
+            _ => panic!("restart should be handled with a log line"),
+        }
+    }
 }

--- a/ferrowl/src/module/ocpp/server/view/backend.rs
+++ b/ferrowl/src/module/ocpp/server/view/backend.rs
@@ -538,7 +538,12 @@ where
                 if spec.role == OcppRole::Client {
                     // Stop the listener first: dropping `Server<V>` only detaches its accept task,
                     // leaving the port bound, so the swapped-in view could never rebind.
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log
+                            .write()
+                            .await
+                            .write(Level::Error, &format!("Stop before role switch failed: {e}"));
+                    }
                     self.deferred.replacement = Some(build_client_view(spec, path, device));
                     return;
                 }
@@ -546,14 +551,24 @@ where
                     // A version change must swap the whole view: `ServerView<V>`/`OcppServer<V>` are
                     // generic over the *old* version and would rebind with the old subprotocol,
                     // rejecting the (now-different-version) client handshake with a 400.
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log.write().await.write(
+                            Level::Error,
+                            &format!("Stop before version switch failed: {e}"),
+                        );
+                    }
                     self.deferred.replacement = Some(build_server_view(spec, path, device));
                     return;
                 }
                 // Rebind on the (possibly changed) endpoint: the backend builds its listener
                 // config from the spec passed into `start`, so updating `self.spec` is all an
                 // edit needs.
-                let _ = self.backend.stop().await;
+                if let Err(e) = self.backend.stop().await {
+                    self.log
+                        .write()
+                        .await
+                        .write(Level::Error, &format!("Stop for settings update failed: {e}"));
+                }
                 self.spec = spec;
                 self.device = device;
                 self.device_path = path;
@@ -643,15 +658,28 @@ where
                 }
                 "stop" => {
                     self.want_running = false;
-                    let _ = self.backend.stop().await;
+                    let stop_result = self.backend.stop().await;
                     self.entries.clear();
                     self.conn_identity.clear();
                     self.cs_configs.clear();
                     self.clear_lua_states();
-                    CommandResult::Handled(Some((Level::Info, "CSMS server stopped".into())))
+                    match stop_result {
+                        Ok(()) => {
+                            CommandResult::Handled(Some((Level::Info, "CSMS server stopped".into())))
+                        }
+                        Err(e) => CommandResult::Handled(Some((
+                            Level::Error,
+                            format!("CSMS server stop failed: {e}"),
+                        ))),
+                    }
                 }
                 "restart" => {
-                    let _ = self.backend.stop().await;
+                    if let Err(e) = self.backend.stop().await {
+                        self.log
+                            .write()
+                            .await
+                            .write(Level::Error, &format!("Restart: stop failed: {e}"));
+                    }
                     self.entries.clear();
                     self.conn_identity.clear();
                     self.cs_configs.clear();

--- a/ferrowl/src/module/ocpp/server/view/backend.rs
+++ b/ferrowl/src/module/ocpp/server/view/backend.rs
@@ -539,10 +539,10 @@ where
                     // Stop the listener first: dropping `Server<V>` only detaches its accept task,
                     // leaving the port bound, so the swapped-in view could never rebind.
                     if let Err(e) = self.backend.stop().await {
-                        self.log
-                            .write()
-                            .await
-                            .write(Level::Error, &format!("Stop before role switch failed: {e}"));
+                        self.log.write().await.write(
+                            Level::Error,
+                            &format!("Stop before role switch failed: {e}"),
+                        );
                     }
                     self.deferred.replacement = Some(build_client_view(spec, path, device));
                     return;
@@ -564,10 +564,10 @@ where
                 // config from the spec passed into `start`, so updating `self.spec` is all an
                 // edit needs.
                 if let Err(e) = self.backend.stop().await {
-                    self.log
-                        .write()
-                        .await
-                        .write(Level::Error, &format!("Stop for settings update failed: {e}"));
+                    self.log.write().await.write(
+                        Level::Error,
+                        &format!("Stop for settings update failed: {e}"),
+                    );
                 }
                 self.spec = spec;
                 self.device = device;
@@ -664,9 +664,10 @@ where
                     self.cs_configs.clear();
                     self.clear_lua_states();
                     match stop_result {
-                        Ok(()) => {
-                            CommandResult::Handled(Some((Level::Info, "CSMS server stopped".into())))
-                        }
+                        Ok(()) => CommandResult::Handled(Some((
+                            Level::Info,
+                            "CSMS server stopped".into(),
+                        ))),
                         Err(e) => CommandResult::Handled(Some((
                             Level::Error,
                             format!("CSMS server stop failed: {e}"),


### PR DESCRIPTION
## Background

An implementation audit (issue #117) surfaced three small robustness/hygiene clusters:
non-exhaustive matching on an async shutdown path, backend `start`/`stop` failures
discarded in the module views, and over-broad `#[allow(dead_code)]` masking which items
are actually unused.

## How it's resolved

- **Exhaustive `Handle` match (C1).** `Instance::stop` matched `Option<Handle>` with a
  `_ => unreachable!()` that swallowed both `None` (already ruled out) and any future
  `Handle` variant. Replaced with an explicit `None =>`, so adding a variant now fails to
  compile instead of panicking at runtime.
- **Surface swallowed start/stop failures (C2, OC-R-102 / MB-R-098).** The OCPP client
  and server views and the Modbus views dropped `let _ = backend.stop()/start().await` on
  settings changes, version switches, and `:restart`/`:reload`/`stop`. They now report the
  failure in the module message log at Error level. Modbus adds `Error::is_not_running()`
  so an already-stopped instance stays a benign no-op rather than a spurious Error line
  (OCPP's `stop()` already no-ops when idle).
- **Narrow dead-code allows (C3).** Dropped `#[allow(dead_code)]` from the public
  `ferrowl-util` tracked-task helpers and the `ferrowl-lua` `ScriptState`/`ContextBuilder`/
  `Context` impls — they were spurious (public API) — and gated the genuinely test-only
  `ContextBuilder::from` behind `#[cfg(test)]`. `clippy -D warnings` confirms nothing was
  actually dead.

## Spec

Two new requirements (C2 is observable; C1/C3 are non-normative):
- **OC-R-102** — an OCPP view stop/(re)start failure shall be reported at Error, not discarded.
- **MB-R-098** — a Modbus view `:restart`/`:reload` stop failure shall be reported at Error,
  other than the benign instance-not-running no-op.

## Verification

- `cargo test --workspace` — green, incl. new `ut_restart_reports_backend_start_failure`
  (OCPP, OC-R-102) and `ut_restart_from_stopped_does_not_report_stop_failure` (Modbus, MB-R-098).
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` — clean.
- C1 compile-time proof: adding a throwaway `Handle` variant makes `Instance::stop` fail to
  compile (E0004), then reverted.

Closes #117
