### PR TITLE
Fix flaky restart test that bound a fixed port instead of an ephemeral one

### DIFF
--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -1559,12 +1559,17 @@ mod tests {
     /// MB-R-098 — stopping an already-stopped instance during `:restart` is the expected
     /// no-op, not a reportable stop failure, so the restart is surfaced as Info.
     async fn ut_restart_from_stopped_does_not_report_stop_failure() {
-        let mut view = new_view();
-        // Bind ephemerally so the restart's start() is deterministic.
-        view.spec.endpoint = Endpoint::Tcp {
+        // Bind ephemerally so the restart's start() is deterministic. The endpoint must be
+        // ephemeral *before* module construction: `ModbusModule::new` snapshots the spec, so
+        // mutating `view.spec` afterwards would leave the module bound to the fixture port.
+        let device = empty_device();
+        let mut spec = tcp_server_spec();
+        spec.endpoint = Endpoint::Tcp {
             ip: "127.0.0.1".into(),
             port: 0,
         };
+        let module = super::super::ModbusModule::new(&spec, &device);
+        let mut view = ModbusModuleView::new(module, spec, device);
         // The module is not running: stop() yields NotRunning, which must be swallowed.
         let result = view.handle_command("restart").await;
         match result {


### PR DESCRIPTION
## Why

`ut_restart_from_stopped_does_not_report_stop_failure` (pinning MB-R-098) intended
to bind ephemerally, but set `view.spec.endpoint` to port 0 only *after*
`ModbusModule::new` had snapshotted the spec into the instance's net config. The
restart therefore always bound the fixture port 127.0.0.1:5020, and the test failed
with "Address already in use" whenever anything occupied that port — e.g. a running
`ferrowl --demo`, whose default Modbus endpoint is the same port.

## Fix

Test-only change, no behavior or spec change. The test now builds its spec with
port 0 before constructing the module, so the restart genuinely binds an ephemeral
port. A comment notes why the endpoint must be set pre-construction.

## Verification

- Reproduced deterministically: with a listener held on 127.0.0.1:5020 the test
  fails before the fix and passes after.
- `cargo test --workspace` (757 passed), `cargo clippy --workspace --all-targets
  -- -D warnings`, `cargo fmt --check` all clean.