### PR TITLE
Pin rust-ocpp to an explicit commit and drop a stale cargo-deny ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "rust-ocpp"
 version = "3.0.4"
-source = "git+https://github.com/TumbleOwlee/rust-ocpp?branch=main#d9d8364e7d802dacfd8a4bfc479ce89a3210dece"
+source = "git+https://github.com/TumbleOwlee/rust-ocpp?rev=d9d8364e7d802dacfd8a4bfc479ce89a3210dece#d9d8364e7d802dacfd8a4bfc479ce89a3210dece"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ ratatui = { version = "0.30.0", features = [
     "unstable-widget-ref",
 ] }
 rcgen = "0.14.8"
-rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", branch = "main", default-features = false }
+# Pinned by rev, not branch: `cargo update` must not silently move us to whatever the fork's
+# `main` points at. Bump the rev deliberately when pulling in upstream changes.
+rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "d9d8364e7d802dacfd8a4bfc479ce89a3210dece", default-features = false }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",

--- a/deny.toml
+++ b/deny.toml
@@ -18,13 +18,7 @@ all-features = true
 version = 2
 # Every entry here needs a comment saying why it is accepted and what would let us drop it.
 # An unexplained ignore is indistinguishable from an unnoticed vulnerability.
-ignore = [
-    # proc-macro-error2 is unmaintained. Transitive and not ours to fix: it arrives via
-    # validator_derive <- validator, which both ferrowl-ocpp and rust-ocpp depend on. It is a
-    # compile-time-only proc-macro crate, so it ships no code in the binary and the
-    # unmaintained status carries no runtime exposure. Drop this once validator moves off it.
-    "RUSTSEC-2026-0173",
-]
+ignore = []
 
 [licenses]
 version = 2
@@ -65,5 +59,6 @@ allow-wildcard-paths = true
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-# rust-ocpp is consumed from a fork (see ferrowl-ocpp/Cargo.toml) rather than crates.io.
+# rust-ocpp is consumed from a fork (pinned by rev in the workspace Cargo.toml) rather than
+# crates.io.
 allow-git = ["https://github.com/TumbleOwlee/rust-ocpp"]


### PR DESCRIPTION
## Why

Two dependency-hygiene findings from a repo inspection:

- `rust-ocpp` was consumed with `branch = "main"`. The lockfile pinned commit
  `d9d8364`, so builds were reproducible, but any `cargo update` would have
  silently moved the workspace to whatever the fork's `main` pointed at.
- `cargo deny check` warned that the ignored advisory RUSTSEC-2026-0173
  (proc-macro-error2 unmaintained) no longer matches any crate in the graph —
  a dead ignore entry.

## Changes

- `rust-ocpp` is now pinned by `rev = "d9d8364…"` — the exact commit the
  lockfile already resolved to, so no dependency code changes. A comment states
  that bumping the rev is the deliberate way to pull in upstream changes.
- Removed the stale RUSTSEC-2026-0173 ignore from `deny.toml`.
- Fixed the `[sources]` comment in `deny.toml` to point at the workspace
  `Cargo.toml`, where the git dependency actually lives.

No behavior change; no spec impact.

## Verification

- `cargo deny check` clean with no warnings.
- `cargo test --workspace` all green, `cargo clippy --workspace --all-targets
  -- -D warnings` clean, `cargo fmt --check` clean.
- `Cargo.lock` diff confirms the same commit resolves before and after.