### PR TITLE
Fix flaky sim test that bound a fixed port instead of an ephemeral one

### DIFF
--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -855,7 +855,9 @@ mod tests {
         use super::ModbusModule;
 
         let device = device_with_script(vec![script(r#"C_Register:Set("marker", 7)"#, true)]);
-        let mut module = ModbusModule::new(&test_spec("sim6", 15207), &device);
+        // Port 0: this is the one sim test that actually calls `start()`, so a fixed port
+        // would fail whenever something else occupies it.
+        let mut module = ModbusModule::new(&test_spec("sim6", 0), &device);
         assert!(module.lua_running());
 
         module.start().await.expect("start");


### PR DESCRIPTION
## Why

Same defect class as #128: `ut_network_stop_leaves_sim_running` (pinning
SC-R-026) is the only Modbus sim test that actually calls `start()`, and it
bound fixed port 127.0.0.1:15207. Anything occupying that port fails the test
with "Address already in use". The other sim tests (ports 15201–15208) never
start the network instance, so their ports are inert labels.

## Fix

Test-only change, no behavior or spec change: the test now passes port 0 so
the server binds ephemerally, with a comment noting why this test alone needs
it.

## Verification

- Reproduced deterministically: with a listener held on 127.0.0.1:15207 the
  test fails before the fix and passes after.
- `cargo test --workspace` all green, `cargo clippy --workspace --all-targets
  -- -D warnings` clean, `cargo fmt --check` clean.