### PR TITLE
Document that tests must bind ephemeral ports only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,14 @@ Dev loop: `cargo run --release -- --demo` (built-in demo tabs, no config needed)
   function names prefixed `ut_`. For integration tests, the function names are 
   prefixed with `it_`  (notably in `ferrowl-ui` and much of `ferrowl`). Integration
   tests belong in each crate's `tests/`.
+- **Tests bind ephemeral ports only.** Any test that starts a network listener (Modbus
+  TCP, OCPP WebSocket, a raw occupier socket) binds port 0 and reads the assigned port
+  back — never a fixed port number. A fixed port makes the test fail whenever anything
+  else on the machine holds it (a running `ferrowl --demo`, a parallel checkout's tests);
+  ephemeral binding removes the collision class entirely. Fixed ports in specs that are
+  never `start()`ed are inert, but prefer port 0 there too so the intent stays obvious.
+  Deliberately *occupying* a port to test bind-failure handling still binds the occupier
+  ephemerally first, then points the server at that port (see `tcp_loopback.rs`).
 - All 13 workspace crates are versioned in lockstep. Don't bump one independently.
 - Config files are TOML or JSON only (extension-driven), never YAML.
 - Rust edition 2024, stable toolchain (`rust-toolchain.toml`).


### PR DESCRIPTION
## Why

Two flaky tests (#128, #130) bound fixed ports and failed whenever anything on
the machine held them — a running `ferrowl --demo`, a parallel checkout's test
run. The fix pattern was the same both times (bind port 0), but nothing wrote
the rule down.

## Change

Docs only: a new convention in `AGENTS.md` under Conventions —

- any test that starts a network listener binds port 0 and reads the assigned
  port back, never a fixed port;
- fixed ports in specs that are never `start()`ed are inert, but port 0 is
  preferred there too so intent stays obvious;
- bind-conflict tests occupy an ephemeral port first, then point the server at
  it (the existing `tcp_loopback.rs` pattern).

## Verification

Docs-only change — no code, no spec impact, nothing to run.