### PR TITLE
Unify each view's command dispatch with its help list, fixing the unhandled :write-device

### DIFF
--- a/docs/specs/tui/edge-cases.md
+++ b/docs/specs/tui/edge-cases.md
@@ -131,3 +131,10 @@ The command-help popup shown while typing `:` lists a fixed set of generic
 commands plus the active view's advertised list. Generic aliases beyond those
 shown (e.g. `:q!`, `:save`, `:write`) are still accepted by the parser even
 though the popup shows only one representative spelling.
+
+### 6.8 Module commands match on the exact first token
+
+A forwarded module command is recognized by its exact first whitespace-delimited
+token: `:setfoo` is an unknown command, not a malformed `:set`. Argument
+validation applies only after the token matches (`:set` alone still reports the
+usage warning).

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -20,7 +20,8 @@ use crate::module::modbus::dialog::{EditInputDialog, EditSelectionDialog};
 use crate::module::modbus::setup_dialog::SetupDialog;
 use crate::module::modbus::table::{Definition, TableView, cmp_definitions};
 use crate::module::view::{
-    CommandDescriptor, CommandFuture, CommandResult, ModuleView, RefreshFuture, SharedLog,
+    CommandDescriptor, CommandFuture, CommandResult, CommandSpec, ModuleView, RefreshFuture,
+    SharedLog, parse_command,
 };
 
 use super::ModbusModule;
@@ -528,10 +529,12 @@ impl ModuleView for ModbusModuleView {
     }
 
     fn handle_command<'a>(&'a mut self, cmd: &'a str) -> CommandFuture<'a> {
-        let trimmed = cmd.trim();
+        let Some(parsed) = parse_command(&MODBUS_COMMAND_SPECS, cmd) else {
+            return Box::pin(std::future::ready(CommandResult::Unhandled));
+        };
 
-        if trimmed == "start" {
-            return Box::pin(async move {
+        match parsed {
+            ModbusCmd::Start => Box::pin(async move {
                 let role = self.spec.role.to_string();
                 let endpoint = self.spec.endpoint.to_string();
                 match self.module.start().await {
@@ -544,11 +547,9 @@ impl ModuleView for ModbusModuleView {
                         format!("Start {role} failed: {e}"),
                     ))),
                 }
-            });
-        }
+            }),
 
-        if trimmed == "stop" {
-            return Box::pin(async move {
+            ModbusCmd::Stop => Box::pin(async move {
                 let role = self.spec.role.to_string();
                 match self.module.stop().await {
                     Ok(()) => {
@@ -559,11 +560,9 @@ impl ModuleView for ModbusModuleView {
                         format!("Stop {role} failed: {e}"),
                     ))),
                 }
-            });
-        }
+            }),
 
-        if trimmed == "restart" {
-            return Box::pin(async move {
+            ModbusCmd::Restart => Box::pin(async move {
                 let role = self.spec.role.to_string();
                 let endpoint = self.spec.endpoint.to_string();
                 let stop_err = self
@@ -590,11 +589,9 @@ impl ModuleView for ModbusModuleView {
                         format!("Restart {role} failed: {e}"),
                     ))),
                 }
-            });
-        }
+            }),
 
-        if trimmed == "reload" {
-            return Box::pin(async move {
+            ModbusCmd::Reload => Box::pin(async move {
                 if self.spec.device.is_empty() {
                     return CommandResult::Handled(Some((
                         Level::Warning,
@@ -646,64 +643,65 @@ impl ModuleView for ModbusModuleView {
                         ),
                     ))),
                 }
-            });
-        }
+            }),
 
-        if trimmed == "edit" || trimmed == "e" {
-            let timing = ModbusModule::resolve_timing(&self.device);
-            let dialog = SetupDialog::edit(
-                &self.spec.name,
-                &self.spec.device,
-                self.spec.role,
-                &self.spec.endpoint,
-                timing,
-                &self.device.read_ranges,
-            );
-            self.overlay = ModbusViewOverlay::Setup(Box::new(dialog));
-            return Box::pin(std::future::ready(CommandResult::Handled(None)));
-        }
-
-        if trimmed == "add" || trimmed == "a" {
-            self.overlay =
-                ModbusViewOverlay::Register(Box::new(ModbusOverlay::Add(EditInputDialog::new())));
-            return Box::pin(std::future::ready(CommandResult::Handled(None)));
-        }
-
-        if trimmed == "script" {
-            self.overlay = ModbusViewOverlay::Scripts(Box::new(ScriptDialog::new(
-                &self.device.scripts,
-                self.device.script_interval_duration(),
-                ScriptContext::Modbus,
-            )));
-            return Box::pin(std::future::ready(CommandResult::Handled(None)));
-        }
-
-        if trimmed == "compact" {
-            self.table.set_compact(!self.table.compact);
-            return Box::pin(std::future::ready(CommandResult::Handled(None)));
-        }
-
-        if trimmed == "wd" {
-            if self.spec.device.is_empty() {
-                return Box::pin(std::future::ready(CommandResult::Handled(Some((
-                    Level::Warning,
-                    "No configuration file path configured.".into(),
-                )))));
+            ModbusCmd::Edit => {
+                let timing = ModbusModule::resolve_timing(&self.device);
+                let dialog = SetupDialog::edit(
+                    &self.spec.name,
+                    &self.spec.device,
+                    self.spec.role,
+                    &self.spec.endpoint,
+                    timing,
+                    &self.device.read_ranges,
+                );
+                self.overlay = ModbusViewOverlay::Setup(Box::new(dialog));
+                Box::pin(std::future::ready(CommandResult::Handled(None)))
             }
-            let path = self.spec.device.clone();
-            let result = self.save_device_to(&path);
-            return Box::pin(std::future::ready(result));
-        }
 
-        if let Some(path) = trimmed.strip_prefix("wd ") {
-            let path = path.trim().to_string();
-            let result = self.save_device_to(&path);
-            return Box::pin(std::future::ready(result));
-        }
+            ModbusCmd::Add => {
+                self.overlay = ModbusViewOverlay::Register(Box::new(ModbusOverlay::Add(
+                    EditInputDialog::new(),
+                )));
+                Box::pin(std::future::ready(CommandResult::Handled(None)))
+            }
 
-        if let Some(file) = trimmed.strip_prefix("log ") {
-            let file = file.trim().to_string();
-            return Box::pin(async move {
+            ModbusCmd::Script => {
+                self.overlay = ModbusViewOverlay::Scripts(Box::new(ScriptDialog::new(
+                    &self.device.scripts,
+                    self.device.script_interval_duration(),
+                    ScriptContext::Modbus,
+                )));
+                Box::pin(std::future::ready(CommandResult::Handled(None)))
+            }
+
+            ModbusCmd::Compact => {
+                self.table.set_compact(!self.table.compact);
+                Box::pin(std::future::ready(CommandResult::Handled(None)))
+            }
+
+            ModbusCmd::WriteDevice(None) => {
+                if self.spec.device.is_empty() {
+                    return Box::pin(std::future::ready(CommandResult::Handled(Some((
+                        Level::Warning,
+                        "No configuration file path configured.".into(),
+                    )))));
+                }
+                let path = self.spec.device.clone();
+                let result = self.save_device_to(&path);
+                Box::pin(std::future::ready(result))
+            }
+
+            ModbusCmd::WriteDevice(Some(path)) => {
+                let result = self.save_device_to(&path);
+                Box::pin(std::future::ready(result))
+            }
+
+            // Bare `:log` is not a Modbus command (the spec gives Modbus only `:log <file>`);
+            // it stays unknown, matching the pre-table behavior.
+            ModbusCmd::Log(None) => Box::pin(std::future::ready(CommandResult::Unhandled)),
+
+            ModbusCmd::Log(Some(file)) => Box::pin(async move {
                 self.device.log_file = Some(file.clone());
                 match self.module.set_log_base(Some(&file)) {
                     Ok(()) => CommandResult::Handled(Some((
@@ -715,17 +713,10 @@ impl ModuleView for ModbusModuleView {
                         format!("Failed to open log file {file}: {e}"),
                     ))),
                 }
-            });
-        }
+            }),
 
-        if trimmed.starts_with("set") {
-            return Box::pin(async move {
-                let rest = cmd
-                    .trim_start()
-                    .split_once(char::is_whitespace)
-                    .map(|(_, r)| r.trim_start())
-                    .unwrap_or("");
-                let (register, value) = parse_set_args(rest);
+            ModbusCmd::Set(rest) => Box::pin(async move {
+                let (register, value) = parse_set_args(rest.as_deref().unwrap_or(""));
                 if register.is_empty() || value.is_empty() {
                     return CommandResult::Handled(Some((
                         Level::Warning,
@@ -733,32 +724,37 @@ impl ModuleView for ModbusModuleView {
                     )));
                 }
                 self.set_register_value(&register, &value).await
-            });
-        }
+            }),
 
-        // Sync commands routed via App (order) — delegate to the sync inner handler.
-        let parts: Vec<&str> = trimmed.split_whitespace().collect();
-        let sync_result = match parts.as_slice() {
-            ["order"] => {
-                let original = self
-                    .module
-                    .registers()
-                    .iter()
-                    .map(|(n, d, r, v)| Definition::new(n.clone(), d.clone(), r.clone(), v.clone()))
-                    .collect();
-                self.sort = None;
-                self.table.set_definitions(original);
-                CommandResult::Handled(Some((Level::Info, "Order cleared".to_string())))
+            ModbusCmd::Order(rest) => {
+                let parts: Vec<&str> = rest.as_deref().unwrap_or("").split_whitespace().collect();
+                let sync_result = match parts.as_slice() {
+                    [] => {
+                        let original = self
+                            .module
+                            .registers()
+                            .iter()
+                            .map(|(n, d, r, v)| {
+                                Definition::new(n.clone(), d.clone(), r.clone(), v.clone())
+                            })
+                            .collect();
+                        self.sort = None;
+                        self.table.set_definitions(original);
+                        CommandResult::Handled(Some((Level::Info, "Order cleared".to_string())))
+                    }
+                    [col] | [col, "asc"] => self.apply_order(col, false),
+                    [col, "desc"] => self.apply_order(col, true),
+                    _ => CommandResult::Unhandled,
+                };
+                Box::pin(std::future::ready(sync_result))
             }
-            ["order", col] | ["order", col, "asc"] => self.apply_order(col, false),
-            ["order", col, "desc"] => self.apply_order(col, true),
-            _ => CommandResult::Unhandled,
-        };
-        Box::pin(std::future::ready(sync_result))
+        }
     }
 
     fn commands(&self) -> &[CommandDescriptor] {
-        &MODBUS_COMMANDS
+        static DESCRIPTORS: std::sync::OnceLock<Vec<CommandDescriptor>> =
+            std::sync::OnceLock::new();
+        DESCRIPTORS.get_or_init(|| MODBUS_COMMAND_SPECS.iter().map(|s| s.descriptor).collect())
     }
 
     fn keybinds(&self) -> &[CommandDescriptor] {
@@ -829,54 +825,121 @@ static MODBUS_KEYBINDS: [CommandDescriptor; 5] = [
     },
 ];
 
-static MODBUS_COMMANDS: [CommandDescriptor; 12] = [
-    CommandDescriptor {
-        name: ":e | :edit",
-        description: "edit module setup",
+/// The parsed form of every command this view accepts; produced by [`parse_command`] over
+/// [`MODBUS_COMMAND_SPECS`]. The exhaustive `match` in `handle_command` is what guarantees a
+/// table entry cannot exist without a handler.
+enum ModbusCmd {
+    Start,
+    Stop,
+    Restart,
+    Reload,
+    Edit,
+    Add,
+    Script,
+    Compact,
+    WriteDevice(Option<String>),
+    Log(Option<String>),
+    Set(Option<String>),
+    Order(Option<String>),
+}
+
+/// Single source for this view's commands: aliases, help row, and parse target per entry.
+static MODBUS_COMMAND_SPECS: [CommandSpec<ModbusCmd>; 12] = [
+    CommandSpec {
+        aliases: &["e", "edit"],
+        descriptor: CommandDescriptor {
+            name: ":e | :edit",
+            description: "edit module setup",
+        },
+        build: |_| ModbusCmd::Edit,
     },
-    CommandDescriptor {
-        name: ":a | :add",
-        description: "add register to device",
+    CommandSpec {
+        aliases: &["a", "add"],
+        descriptor: CommandDescriptor {
+            name: ":a | :add",
+            description: "add register to device",
+        },
+        build: |_| ModbusCmd::Add,
     },
-    CommandDescriptor {
-        name: ":start",
-        description: "start module",
+    CommandSpec {
+        aliases: &["start"],
+        descriptor: CommandDescriptor {
+            name: ":start",
+            description: "start module",
+        },
+        build: |_| ModbusCmd::Start,
     },
-    CommandDescriptor {
-        name: ":stop",
-        description: "stop module",
+    CommandSpec {
+        aliases: &["stop"],
+        descriptor: CommandDescriptor {
+            name: ":stop",
+            description: "stop module",
+        },
+        build: |_| ModbusCmd::Stop,
     },
-    CommandDescriptor {
-        name: ":restart",
-        description: "restart module",
+    CommandSpec {
+        aliases: &["restart"],
+        descriptor: CommandDescriptor {
+            name: ":restart",
+            description: "restart module",
+        },
+        build: |_| ModbusCmd::Restart,
     },
-    CommandDescriptor {
-        name: ":reload",
-        description: "reload device config",
+    CommandSpec {
+        aliases: &["reload"],
+        descriptor: CommandDescriptor {
+            name: ":reload",
+            description: "reload device config",
+        },
+        build: |_| ModbusCmd::Reload,
     },
-    CommandDescriptor {
-        name: ":compact",
-        description: "toggle compact mode",
+    CommandSpec {
+        aliases: &["compact"],
+        descriptor: CommandDescriptor {
+            name: ":compact",
+            description: "toggle compact mode",
+        },
+        build: |_| ModbusCmd::Compact,
     },
-    CommandDescriptor {
-        name: ":set <reg> <val>",
-        description: "write register value",
+    CommandSpec {
+        aliases: &["set"],
+        descriptor: CommandDescriptor {
+            name: ":set <reg> <val>",
+            description: "write register value",
+        },
+        build: |rest| ModbusCmd::Set(rest.map(str::to_string)),
     },
-    CommandDescriptor {
-        name: ":wd | :write-device [path]",
-        description: "save device config",
+    CommandSpec {
+        aliases: &["wd", "write-device"],
+        descriptor: CommandDescriptor {
+            name: ":wd | :write-device [path]",
+            description: "save device config",
+        },
+        build: |rest| ModbusCmd::WriteDevice(rest.map(str::to_string)),
     },
-    CommandDescriptor {
-        name: ":log <file>",
-        description: "set log file",
+    CommandSpec {
+        aliases: &["log"],
+        descriptor: CommandDescriptor {
+            name: ":log <file>",
+            description: "set log file",
+        },
+        build: |rest| ModbusCmd::Log(rest.map(str::to_string)),
     },
-    CommandDescriptor {
-        name: ":script",
-        description: "manage lua scripts",
+    CommandSpec {
+        aliases: &["script"],
+        descriptor: CommandDescriptor {
+            name: ":script",
+            description: "manage lua scripts",
+        },
+        build: |_| ModbusCmd::Script,
     },
-    CommandDescriptor {
-        name: ":order [col] [asc|desc]",
-        description: "sort table by column",
+    CommandSpec {
+        aliases: &["order"],
+        descriptor: CommandDescriptor {
+            name: ":order [col] [asc|desc]",
+            description: "sort table by column",
+        },
+        build: |rest| ModbusCmd::Order(rest.map(str::to_string)),
     },
 ];
 
@@ -1587,5 +1650,42 @@ mod tests {
         }
         // Tear down the server task spawned by the restart.
         let _ = view.handle_command("stop").await;
+    }
+
+    #[tokio::test]
+    /// tui/api-contract §2.1 — `:write-device [path]` is the long spelling of `:wd` and saves
+    /// the device config the same way.
+    async fn ut_write_device_alias_saves_like_wd() {
+        let mut view = new_view();
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("ferrowl-write-device-{}.toml", std::process::id()));
+        let p = path.to_str().expect("temp path is valid UTF-8").to_string();
+        let result = view.handle_command(&format!("write-device {p}")).await;
+        match result {
+            CommandResult::Handled(Some((_, msg))) => {
+                assert!(msg.contains("Saved device config"), "unexpected: {msg}");
+            }
+            _ => panic!(":write-device should be handled with a save message"),
+        }
+        assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    /// TUI edge case 6.8 — commands match on the exact first token: `:setfoo` is unknown, not a
+    /// malformed `:set`; bare `:set` still reports the usage warning.
+    async fn ut_set_prefix_typo_is_unknown_bare_set_warns() {
+        let mut view = new_view();
+        assert!(matches!(
+            view.handle_command("setfoo 1 2").await,
+            CommandResult::Unhandled
+        ));
+        match view.handle_command("set").await {
+            CommandResult::Handled(Some((level, msg))) => {
+                assert!(matches!(level, Level::Warning));
+                assert!(msg.contains(":set requires"), "unexpected: {msg}");
+            }
+            _ => panic!("bare :set should warn about usage"),
+        }
     }
 }

--- a/ferrowl/src/module/ocpp/client/view/backend.rs
+++ b/ferrowl/src/module/ocpp/client/view/backend.rs
@@ -13,9 +13,12 @@ use crate::module::ocpp::config::session::OcppRole;
 use crate::module::ocpp::lock::{HasState, with_state, with_state_mut};
 use crate::module::ocpp::scope::Scope;
 use crate::module::ocpp::server::build_server_view;
-use crate::module::view::{CommandFuture, CommandResult, RefreshFuture};
+use crate::module::view::{CommandFuture, CommandResult, RefreshFuture, parse_command};
 
-use super::{ClientState, ClientVersion, ClientView, config_rows, conn_rows, msg_row, nv_rows};
+use super::{
+    ClientState, ClientVersion, ClientView, OCPP_CLIENT_COMMAND_SPECS, OcppClientCmd, config_rows,
+    conn_rows, msg_row, nv_rows,
+};
 
 impl<V: ClientVersion> ClientView<V> {
     pub(super) fn start_sim(&mut self) {
@@ -373,8 +376,11 @@ impl<V: ClientVersion> ClientView<V> {
     }
 
     pub(super) fn handle_command_impl<'a>(&'a mut self, cmd: &'a str) -> CommandFuture<'a> {
-        match cmd.trim() {
-            "start" => Box::pin(async move {
+        let Some(parsed) = parse_command(&OCPP_CLIENT_COMMAND_SPECS, cmd) else {
+            return Box::pin(std::future::ready(CommandResult::Unhandled));
+        };
+        match parsed {
+            OcppClientCmd::Start => Box::pin(async move {
                 let handler = self.make_handler();
                 match self.backend.start(&self.spec, handler).await {
                     Ok(()) => CommandResult::Handled(Some((
@@ -386,7 +392,7 @@ impl<V: ClientVersion> ClientView<V> {
                     }
                 }
             }),
-            "stop" => Box::pin(async move {
+            OcppClientCmd::Stop => Box::pin(async move {
                 match self.backend.stop().await {
                     Ok(()) => CommandResult::Handled(Some((Level::Info, "Disconnected".into()))),
                     Err(e) => CommandResult::Handled(Some((
@@ -395,7 +401,7 @@ impl<V: ClientVersion> ClientView<V> {
                     ))),
                 }
             }),
-            "restart" => Box::pin(async move {
+            OcppClientCmd::Restart => Box::pin(async move {
                 if let Err(e) = self.backend.stop().await {
                     self.log
                         .write()
@@ -411,7 +417,7 @@ impl<V: ClientVersion> ClientView<V> {
                     ))),
                 }
             }),
-            "edit" | "e" => {
+            OcppClientCmd::Edit => {
                 self.overlay = super::ClientOverlay::Setup(Box::new(
                     crate::module::ocpp::setup_dialog::OcppSetupDialog::edit(
                         &self.spec,
@@ -420,11 +426,11 @@ impl<V: ClientVersion> ClientView<V> {
                 ));
                 Box::pin(std::future::ready(CommandResult::Handled(None)))
             }
-            "compact" => {
+            OcppClientCmd::Compact => {
                 self.set_compact(!self.compact);
                 Box::pin(std::future::ready(CommandResult::Handled(None)))
             }
-            "wd" => {
+            OcppClientCmd::WriteDevice(None) => {
                 let result = if self.device_path.is_empty() {
                     CommandResult::Handled(Some((
                         Level::Warning,
@@ -435,33 +441,26 @@ impl<V: ClientVersion> ClientView<V> {
                 };
                 Box::pin(std::future::ready(result))
             }
-            cmd if cmd.starts_with("wd ") => {
-                let path = cmd["wd ".len()..].trim().to_string();
+            OcppClientCmd::WriteDevice(Some(path)) => {
                 let result = self.save_device_to(&path);
                 Box::pin(std::future::ready(result))
             }
-            "log" => {
-                self.device.log_file = None;
-                Box::pin(std::future::ready(CommandResult::Handled(Some((
-                    Level::Info,
-                    "File logging disabled".into(),
-                )))))
-            }
-            cmd if cmd.starts_with("log ") => {
-                let path = cmd["log ".len()..].trim().to_string();
-                let msg = if path.is_empty() {
-                    self.device.log_file = None;
-                    "File logging disabled".to_string()
-                } else {
-                    self.device.log_file = Some(path.clone());
-                    format!("Logging to {path}")
+            OcppClientCmd::Log(file) => {
+                let msg = match file {
+                    None => {
+                        self.device.log_file = None;
+                        "File logging disabled".to_string()
+                    }
+                    Some(path) => {
+                        self.device.log_file = Some(path.clone());
+                        format!("Logging to {path}")
+                    }
                 };
                 Box::pin(std::future::ready(CommandResult::Handled(Some((
                     Level::Info,
                     msg,
                 )))))
             }
-            _ => Box::pin(std::future::ready(CommandResult::Unhandled)),
         }
     }
 }

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -52,7 +52,7 @@ use crate::module::ocpp::config::session::OcppSpec;
 use crate::module::ocpp::lock::{HasState, with_state, with_state_mut};
 use crate::module::ocpp::scope::Scope;
 use crate::module::ocpp::setup_dialog::OcppSetupDialog;
-use crate::module::view::{CommandDescriptor, ModuleView, SharedLog};
+use crate::module::view::{CommandDescriptor, CommandSpec, ModuleView, SharedLog};
 
 pub use render::{choice, number, text_input};
 
@@ -596,7 +596,14 @@ impl<V: ClientVersion> ModuleView for ClientView<V> {
     }
 
     fn commands(&self) -> &[CommandDescriptor] {
-        &OCPP_CLIENT_COMMANDS
+        static DESCRIPTORS: std::sync::OnceLock<Vec<CommandDescriptor>> =
+            std::sync::OnceLock::new();
+        DESCRIPTORS.get_or_init(|| {
+            OCPP_CLIENT_COMMAND_SPECS
+                .iter()
+                .map(|s| s.descriptor)
+                .collect()
+        })
     }
 
     fn keybinds(&self) -> &[CommandDescriptor] {
@@ -658,34 +665,76 @@ static OCPP_CLIENT_KEYBINDS: [CommandDescriptor; 4] = [
     },
 ];
 
-static OCPP_CLIENT_COMMANDS: [CommandDescriptor; 7] = [
-    CommandDescriptor {
-        name: ":e | :edit",
-        description: "edit module setup",
+/// The parsed form of every command the CS client view accepts; produced by [`parse_command`]
+/// over [`OCPP_CLIENT_COMMAND_SPECS`]. The exhaustive `match` in `handle_command_impl` is what
+/// guarantees a table entry cannot exist without a handler.
+pub(super) enum OcppClientCmd {
+    Start,
+    Stop,
+    Restart,
+    Edit,
+    Compact,
+    WriteDevice(Option<String>),
+    Log(Option<String>),
+}
+
+/// Single source for this view's commands: aliases, help row, and parse target per entry.
+pub(super) static OCPP_CLIENT_COMMAND_SPECS: [CommandSpec<OcppClientCmd>; 7] = [
+    CommandSpec {
+        aliases: &["e", "edit"],
+        descriptor: CommandDescriptor {
+            name: ":e | :edit",
+            description: "edit module setup",
+        },
+        build: |_| OcppClientCmd::Edit,
     },
-    CommandDescriptor {
-        name: ":start",
-        description: "connect to the CSMS",
+    CommandSpec {
+        aliases: &["start"],
+        descriptor: CommandDescriptor {
+            name: ":start",
+            description: "connect to the CSMS",
+        },
+        build: |_| OcppClientCmd::Start,
     },
-    CommandDescriptor {
-        name: ":stop",
-        description: "disconnect",
+    CommandSpec {
+        aliases: &["stop"],
+        descriptor: CommandDescriptor {
+            name: ":stop",
+            description: "disconnect",
+        },
+        build: |_| OcppClientCmd::Stop,
     },
-    CommandDescriptor {
-        name: ":restart",
-        description: "reconnect",
+    CommandSpec {
+        aliases: &["restart"],
+        descriptor: CommandDescriptor {
+            name: ":restart",
+            description: "reconnect",
+        },
+        build: |_| OcppClientCmd::Restart,
     },
-    CommandDescriptor {
-        name: ":compact",
-        description: "toggle compact rows",
+    CommandSpec {
+        aliases: &["compact"],
+        descriptor: CommandDescriptor {
+            name: ":compact",
+            description: "toggle compact rows",
+        },
+        build: |_| OcppClientCmd::Compact,
     },
-    CommandDescriptor {
-        name: ":wd | :write-device [path]",
-        description: "save device config",
+    CommandSpec {
+        aliases: &["wd", "write-device"],
+        descriptor: CommandDescriptor {
+            name: ":wd | :write-device [path]",
+            description: "save device config",
+        },
+        build: |rest| OcppClientCmd::WriteDevice(rest.map(str::to_string)),
     },
-    CommandDescriptor {
-        name: ":log [file]",
-        description: "set/clear log file",
+    CommandSpec {
+        aliases: &["log"],
+        descriptor: CommandDescriptor {
+            name: ":log [file]",
+            description: "set/clear log file",
+        },
+        build: |rest| OcppClientCmd::Log(rest.map(str::to_string)),
     },
 ];
 
@@ -1024,5 +1073,26 @@ mod tests {
             }
             _ => panic!("restart should be handled with a log line"),
         }
+    }
+
+    #[tokio::test]
+    /// ocpp/api-contract CS command table — `:write-device [path]` is the long spelling of
+    /// `:wd` and saves the device config the same way.
+    async fn write_device_alias_saves_like_wd() {
+        use crate::module::view::CommandResult;
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-ocpp-client-write-device-{}.toml",
+            std::process::id()
+        ));
+        let p = path.to_str().expect("temp path is valid UTF-8").to_string();
+        let CommandResult::Handled(Some((_, msg))) =
+            v.handle_command_impl(&format!("write-device {p}")).await
+        else {
+            panic!(":write-device must be handled with a message");
+        };
+        assert!(msg.contains("Saved device config"), "unexpected: {msg}");
+        assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/ferrowl/src/module/ocpp/server/view/backend.rs
+++ b/ferrowl/src/module/ocpp/server/view/backend.rs
@@ -20,10 +20,11 @@ use crate::module::ocpp::server::backend::{
 };
 use crate::module::ocpp::server::build_server_view;
 use crate::module::ocpp::server::lua::{run_server_script_once, run_server_sim};
-use crate::module::view::{CommandFuture, CommandResult, RefreshFuture};
+use crate::module::view::{CommandFuture, CommandResult, RefreshFuture, parse_command};
 
 use super::{
-    Entry, EntryState, EntryStateT, ServerOverlay, ServerVersion, ServerView, fill_device_rfids,
+    Entry, EntryState, EntryStateT, OCPP_SERVER_COMMAND_SPECS, OcppServerCmd, ServerOverlay,
+    ServerVersion, ServerView, fill_device_rfids,
 };
 
 /// The start/restart log line, built from the TLS mode the backend reports it actually bound
@@ -641,8 +642,11 @@ where
 
     pub(super) fn handle_command_impl<'a>(&'a mut self, cmd: &'a str) -> CommandFuture<'a> {
         Box::pin(async move {
-            match cmd.trim() {
-                "start" => {
+            let Some(parsed) = parse_command(&OCPP_SERVER_COMMAND_SPECS, cmd) else {
+                return CommandResult::Unhandled;
+            };
+            match parsed {
+                OcppServerCmd::Start => {
                     self.want_running = true;
                     let handler = V::handler(self.events_tx.clone(), self.rfids.clone());
                     match self.backend.start(&self.spec, handler).await {
@@ -656,7 +660,7 @@ where
                         ))),
                     }
                 }
-                "stop" => {
+                OcppServerCmd::Stop => {
                     self.want_running = false;
                     let stop_result = self.backend.stop().await;
                     self.entries.clear();
@@ -674,7 +678,7 @@ where
                         ))),
                     }
                 }
-                "restart" => {
+                OcppServerCmd::Restart => {
                     if let Err(e) = self.backend.stop().await {
                         self.log
                             .write()
@@ -698,7 +702,7 @@ where
                         ))),
                     }
                 }
-                "edit" | "e" => {
+                OcppServerCmd::Edit => {
                     self.overlay = ServerOverlay::Setup(Box::new(
                         crate::module::ocpp::setup_dialog::OcppSetupDialog::edit(
                             &self.spec,
@@ -707,7 +711,7 @@ where
                     ));
                     CommandResult::Handled(None)
                 }
-                "wd" => {
+                OcppServerCmd::WriteDevice(None) => {
                     if self.device_path.is_empty() {
                         CommandResult::Handled(Some((
                             Level::Warning,
@@ -717,79 +721,75 @@ where
                         self.save_device_to(&self.device_path.clone())
                     }
                 }
-                cmd if cmd.starts_with("wd ") => {
-                    let path = cmd["wd ".len()..].trim().to_string();
-                    self.save_device_to(&path)
-                }
-                "compact" => {
+                OcppServerCmd::WriteDevice(Some(path)) => self.save_device_to(&path),
+                OcppServerCmd::Compact => {
                     self.set_compact(!self.compact);
                     CommandResult::Handled(None)
                 }
-                "log" => {
+                OcppServerCmd::Log(None) => {
                     self.device.log_file = None;
                     CommandResult::Handled(Some((Level::Info, "File logging disabled".into())))
                 }
-                cmd if cmd.starts_with("log ") => {
-                    let path = cmd["log ".len()..].trim().to_string();
-                    if path.is_empty() {
-                        self.device.log_file = None;
-                        CommandResult::Handled(Some((Level::Info, "File logging disabled".into())))
-                    } else {
-                        self.device.log_file = Some(path.clone());
-                        CommandResult::Handled(Some((Level::Info, format!("Logging to {path}"))))
-                    }
+                OcppServerCmd::Log(Some(path)) => {
+                    self.device.log_file = Some(path.clone());
+                    CommandResult::Handled(Some((Level::Info, format!("Logging to {path}"))))
                 }
-                "rfid" => {
-                    let msg = with_rfids(&self.rfids, |s| {
-                        if s.cs.is_empty() {
-                            "CS RFID accept-list empty (all tags accepted)".to_string()
-                        } else {
-                            format!("Accepted CS RFIDs: {}", s.cs.join(", "))
-                        }
-                    });
-                    CommandResult::Handled(Some((Level::Info, msg)))
-                }
-                "rfid clear" => {
-                    with_rfids_mut(&self.rfids, |s| s.cs.clear());
-                    CommandResult::Handled(Some((
-                        Level::Info,
-                        "CS RFID accept-list cleared (all accepted)".into(),
-                    )))
-                }
-                cmd if cmd.starts_with("rfid add ") => {
-                    let tag = cmd["rfid add ".len()..].trim().to_string();
-                    if tag.is_empty() {
-                        return CommandResult::Handled(Some((
-                            Level::Warning,
-                            "Usage: :rfid add <tag>".into(),
-                        )));
-                    }
-                    if with_rfids_mut(&self.rfids, |s| s.add(Scope::CS, tag.clone())) {
-                        CommandResult::Handled(Some((Level::Info, format!("Added CS RFID {tag}"))))
-                    } else {
-                        CommandResult::Handled(Some((
-                            Level::Warning,
-                            format!("{tag} already in accept-list"),
-                        )))
-                    }
-                }
-                cmd if cmd.starts_with("rfid del ") => {
-                    let tag = cmd["rfid del ".len()..].trim().to_string();
-                    if with_rfids_mut(&self.rfids, |s| s.remove(Scope::CS, &tag)) {
-                        CommandResult::Handled(Some((
-                            Level::Info,
-                            format!("Removed CS RFID {tag}"),
-                        )))
-                    } else {
-                        CommandResult::Handled(Some((
-                            Level::Warning,
-                            format!("{tag} not in accept-list"),
-                        )))
-                    }
-                }
-                _ => CommandResult::Unhandled,
+                OcppServerCmd::Rfid(sub) => self.handle_rfid(sub.as_deref()),
             }
         })
+    }
+
+    /// The `:rfid` subcommands: bare lists the accept-list, `clear` empties it, `add <tag>` /
+    /// `del <tag>` mutate it. Anything else stays unhandled (an unknown command).
+    fn handle_rfid(&mut self, sub: Option<&str>) -> CommandResult {
+        match sub {
+            None => {
+                let msg = with_rfids(&self.rfids, |s| {
+                    if s.cs.is_empty() {
+                        "CS RFID accept-list empty (all tags accepted)".to_string()
+                    } else {
+                        format!("Accepted CS RFIDs: {}", s.cs.join(", "))
+                    }
+                });
+                CommandResult::Handled(Some((Level::Info, msg)))
+            }
+            Some("clear") => {
+                with_rfids_mut(&self.rfids, |s| s.cs.clear());
+                CommandResult::Handled(Some((
+                    Level::Info,
+                    "CS RFID accept-list cleared (all accepted)".into(),
+                )))
+            }
+            Some(rest) if rest.starts_with("add ") => {
+                let tag = rest["add ".len()..].trim().to_string();
+                if tag.is_empty() {
+                    return CommandResult::Handled(Some((
+                        Level::Warning,
+                        "Usage: :rfid add <tag>".into(),
+                    )));
+                }
+                if with_rfids_mut(&self.rfids, |s| s.add(Scope::CS, tag.clone())) {
+                    CommandResult::Handled(Some((Level::Info, format!("Added CS RFID {tag}"))))
+                } else {
+                    CommandResult::Handled(Some((
+                        Level::Warning,
+                        format!("{tag} already in accept-list"),
+                    )))
+                }
+            }
+            Some(rest) if rest.starts_with("del ") => {
+                let tag = rest["del ".len()..].trim().to_string();
+                if with_rfids_mut(&self.rfids, |s| s.remove(Scope::CS, &tag)) {
+                    CommandResult::Handled(Some((Level::Info, format!("Removed CS RFID {tag}"))))
+                } else {
+                    CommandResult::Handled(Some((
+                        Level::Warning,
+                        format!("{tag} not in accept-list"),
+                    )))
+                }
+            }
+            Some(_) => CommandResult::Unhandled,
+        }
     }
 }
 

--- a/ferrowl/src/module/ocpp/server/view/mod.rs
+++ b/ferrowl/src/module/ocpp/server/view/mod.rs
@@ -49,7 +49,7 @@ use crate::module::ocpp::server::backend::{
 use crate::module::ocpp::server::detail::DetailOverlay;
 use crate::module::ocpp::server::lua::{ServerActionQueue, ServerStates, SharedServerStates};
 use crate::module::ocpp::setup_dialog::OcppSetupDialog;
-use crate::module::view::{CommandDescriptor, ModuleView, SharedLog};
+use crate::module::view::{CommandDescriptor, CommandSpec, ModuleView, SharedLog};
 
 /// Build the runtime RFID store from a persisted device config (CS list + per-connector lists).
 fn rfid_store_from_device(device: &OcppDeviceConfig) -> RfidStore {
@@ -462,7 +462,15 @@ where
     }
 
     fn commands(&self) -> &[CommandDescriptor] {
-        &OCPP_SERVER_COMMANDS
+        static DESCRIPTORS: std::sync::OnceLock<Vec<CommandDescriptor>> =
+            std::sync::OnceLock::new();
+        DESCRIPTORS.get_or_init(|| {
+            OCPP_SERVER_COMMAND_SPECS
+                .iter()
+                .map(|s| s.descriptor)
+                .chain(OCPP_SERVER_EXTRA_HELP.iter().copied())
+                .collect()
+        })
     }
 
     fn keybinds(&self) -> &[CommandDescriptor] {
@@ -517,35 +525,90 @@ static OCPP_SERVER_KEYBINDS: [CommandDescriptor; 3] = [
     },
 ];
 
-static OCPP_SERVER_COMMANDS: [CommandDescriptor; 9] = [
-    CommandDescriptor {
-        name: ":start | :stop",
-        description: "bind / unbind the CSMS listener",
+/// The parsed form of every command the CSMS server view accepts; produced by [`parse_command`]
+/// over [`OCPP_SERVER_COMMAND_SPECS`]. The exhaustive `match` in `handle_command_impl` is what
+/// guarantees a table entry cannot exist without a handler.
+pub(super) enum OcppServerCmd {
+    Start,
+    Stop,
+    Restart,
+    Edit,
+    Compact,
+    WriteDevice(Option<String>),
+    Log(Option<String>),
+    Rfid(Option<String>),
+}
+
+/// Single source for this view's commands: aliases, help row, and parse target per entry.
+pub(super) static OCPP_SERVER_COMMAND_SPECS: [CommandSpec<OcppServerCmd>; 8] = [
+    CommandSpec {
+        aliases: &["start"],
+        descriptor: CommandDescriptor {
+            name: ":start",
+            description: "bind the CSMS listener",
+        },
+        build: |_| OcppServerCmd::Start,
     },
-    CommandDescriptor {
-        name: ":restart",
-        description: "rebind the listener (clears entries)",
+    CommandSpec {
+        aliases: &["stop"],
+        descriptor: CommandDescriptor {
+            name: ":stop",
+            description: "unbind the CSMS listener",
+        },
+        build: |_| OcppServerCmd::Stop,
     },
-    CommandDescriptor {
-        name: ":e | :edit",
-        description: "edit module setup",
+    CommandSpec {
+        aliases: &["restart"],
+        descriptor: CommandDescriptor {
+            name: ":restart",
+            description: "rebind the listener (clears entries)",
+        },
+        build: |_| OcppServerCmd::Restart,
     },
-    CommandDescriptor {
-        name: ":wd | :write-device [path]",
-        description: "save device config",
+    CommandSpec {
+        aliases: &["e", "edit"],
+        descriptor: CommandDescriptor {
+            name: ":e | :edit",
+            description: "edit module setup",
+        },
+        build: |_| OcppServerCmd::Edit,
     },
-    CommandDescriptor {
-        name: ":compact",
-        description: "toggle compact rows",
+    CommandSpec {
+        aliases: &["wd", "write-device"],
+        descriptor: CommandDescriptor {
+            name: ":wd | :write-device [path]",
+            description: "save device config",
+        },
+        build: |rest| OcppServerCmd::WriteDevice(rest.map(str::to_string)),
     },
-    CommandDescriptor {
-        name: ":log [file]",
-        description: "set/clear log file",
+    CommandSpec {
+        aliases: &["compact"],
+        descriptor: CommandDescriptor {
+            name: ":compact",
+            description: "toggle compact rows",
+        },
+        build: |_| OcppServerCmd::Compact,
     },
-    CommandDescriptor {
-        name: ":rfid [add|del <tag> | clear]",
-        description: "CSMS RFID accept-list",
+    CommandSpec {
+        aliases: &["log"],
+        descriptor: CommandDescriptor {
+            name: ":log [file]",
+            description: "set/clear log file",
+        },
+        build: |rest| OcppServerCmd::Log(rest.map(str::to_string)),
     },
+    CommandSpec {
+        aliases: &["rfid"],
+        descriptor: CommandDescriptor {
+            name: ":rfid [add|del <tag> | clear]",
+            description: "CSMS RFID accept-list",
+        },
+        build: |rest| OcppServerCmd::Rfid(rest.map(str::to_string)),
+    },
+];
+
+/// Display-only help rows appended after the command rows (keys, not `:` commands).
+static OCPP_SERVER_EXTRA_HELP: [CommandDescriptor; 2] = [
     CommandDescriptor {
         name: "d",
         description: "delete the selected charging station / connector",
@@ -900,6 +963,27 @@ mod tests {
     }
 
     // --- Module lifecycle: listener rebuild / restart ---------------------------------------
+
+    #[tokio::test]
+    /// ocpp/api-contract CSMS command table — `:write-device [path]` is the long spelling of
+    /// `:wd` and saves the device config the same way.
+    async fn write_device_alias_saves_like_wd() {
+        use crate::module::view::CommandResult;
+        let mut v = server_view();
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-ocpp-server-write-device-{}.toml",
+            std::process::id()
+        ));
+        let p = path.to_str().expect("temp path is valid UTF-8").to_string();
+        let CommandResult::Handled(Some((_, msg))) =
+            v.handle_command_impl(&format!("write-device {p}")).await
+        else {
+            panic!(":write-device must be handled with a message");
+        };
+        assert!(msg.contains("Saved device config"), "unexpected: {msg}");
+        assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[tokio::test]
     /// OC-R-082 — the listener configuration is rebuilt from the current module spec on every

--- a/ferrowl/src/module/view.rs
+++ b/ferrowl/src/module/view.rs
@@ -21,9 +21,42 @@ pub enum CommandResult {
 }
 
 /// One entry in a module's command help list.
+#[derive(Clone, Copy)]
 pub struct CommandDescriptor {
     pub name: &'static str,
     pub description: &'static str,
+}
+
+/// One command in a view's dispatch table: the accepted aliases, the help row advertising it,
+/// and the constructor for the view's parsed-command value. Alias list, help text, and parse
+/// target live in this one entry so the advertised list and the handled set cannot drift apart;
+/// the exhaustive `match` on the parsed enum is what guarantees every entry has a handler.
+pub struct CommandSpec<C> {
+    /// First-token spellings that select this command (e.g. `&["wd", "write-device"]`).
+    pub aliases: &'static [&'static str],
+    /// The help row shown for this command.
+    pub descriptor: CommandDescriptor,
+    /// Build the parsed command from the argument remainder: `None` for a bare token,
+    /// `Some(rest)` (trimmed, non-empty) when arguments followed it.
+    pub build: fn(rest: Option<&str>) -> C,
+}
+
+/// Match `input` against `specs` by its exact first whitespace-delimited token (edge case
+/// TUI 6.8: `setfoo` never matches `set`). The remainder after the token — trimmed, `None`
+/// when empty — is passed to the matching entry's `build`. Returns `None` for an unknown
+/// token; argument validation is the handler's job, applied only after the token matched.
+pub fn parse_command<C>(specs: &[CommandSpec<C>], input: &str) -> Option<C> {
+    let trimmed = input.trim();
+    let (token, rest) = match trimmed.split_once(char::is_whitespace) {
+        Some((token, rest)) => (token, rest.trim()),
+        None => (trimmed, ""),
+    };
+    let spec = specs.iter().find(|s| s.aliases.contains(&token))?;
+    Some((spec.build)(if rest.is_empty() {
+        None
+    } else {
+        Some(rest)
+    }))
 }
 
 /// Object-safe async return type for [`ModuleView::handle_command`].
@@ -131,5 +164,66 @@ impl IsFocus for Box<dyn ModuleView> {
 impl HandleEvents for Box<dyn ModuleView> {
     fn handle_events(&mut self, modifiers: KeyModifiers, code: KeyCode) -> EventResult {
         (**self).handle_events(modifiers, code)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    enum Cmd {
+        Start,
+        Save(Option<String>),
+    }
+
+    fn specs() -> [CommandSpec<Cmd>; 2] {
+        [
+            CommandSpec {
+                aliases: &["start"],
+                descriptor: CommandDescriptor {
+                    name: ":start",
+                    description: "start",
+                },
+                build: |_| Cmd::Start,
+            },
+            CommandSpec {
+                aliases: &["wd", "write-device"],
+                descriptor: CommandDescriptor {
+                    name: ":wd | :write-device [path]",
+                    description: "save",
+                },
+                build: |rest| Cmd::Save(rest.map(str::to_string)),
+            },
+        ]
+    }
+
+    #[test]
+    /// Every alias of a table entry selects the same command.
+    fn ut_parse_command_matches_every_alias() {
+        let specs = specs();
+        assert_eq!(parse_command(&specs, "wd"), Some(Cmd::Save(None)));
+        assert_eq!(parse_command(&specs, "write-device"), Some(Cmd::Save(None)));
+        assert_eq!(parse_command(&specs, "start"), Some(Cmd::Start));
+    }
+
+    #[test]
+    /// The remainder after the first token is trimmed and passed to `build`; empty becomes `None`.
+    fn ut_parse_command_passes_trimmed_remainder() {
+        let specs = specs();
+        assert_eq!(
+            parse_command(&specs, "  wd   a b.toml  "),
+            Some(Cmd::Save(Some("a b.toml".into())))
+        );
+        assert_eq!(parse_command(&specs, " wd  "), Some(Cmd::Save(None)));
+    }
+
+    #[test]
+    /// TUI edge case 6.8 — commands match on the exact first token, so a prefix typo is unknown.
+    fn ut_parse_command_exact_first_token_only() {
+        let specs = specs();
+        assert_eq!(parse_command(&specs, "startx"), None);
+        assert_eq!(parse_command(&specs, "wdx path"), None);
+        assert_eq!(parse_command(&specs, ""), None);
     }
 }


### PR DESCRIPTION
## Why

Each module view's `handle_command` was a hand-written string-match chain, kept
manually in sync with a separate static `CommandDescriptor` array that renders
the help popup. The two lists drifted: `:write-device` — specified in the TUI
and OCPP api-contracts and advertised in the help of all three views — was
handled by none of them and answered with "Unknown command". The Modbus `:set`
arm also matched on `starts_with("set")`, so typos like `:setfoo` were captured
as malformed `:set` instead of reported unknown.

Closes #132

## How

New shared plumbing in `module/view.rs`: a `CommandSpec` entry bundles a
command's aliases, its help row, and the constructor of the view's parsed-command
value; `parse_command` matches the exact first whitespace-delimited token
against the aliases and hands the trimmed remainder to the matching entry.

Each view (Modbus, OCPP server, OCPP client) now declares one static
`CommandSpec` table plus a parsed-command enum, and `handle_command` becomes
parse → exhaustive `match`, with the old handler bodies moved over unchanged
(sub-argument parsing for `:set`, `:order`, `:rfid` stays inside the arms). The
drift class is now unrepresentable: alias list, help row, and parse target live
in one table entry; a table entry without a handler arm fails to compile; and
`commands()` serves the help rows mapped from the same table, so the old
parallel descriptor statics are deleted. Display-only help rows (the CSMS
view's `d` / `Enter` hints) are appended after the table-derived rows.

Behavior changes:
- `:write-device` now works everywhere `:wd` does (spec was already right).
- Prefix typos (`:setfoo`) are unknown commands — pinned as new TUI edge case
  6.8 in `docs/specs/tui/edge-cases.md`.
- Cosmetic: the CSMS help lists `:start` and `:stop` as separate rows (was one
  combined row), matching the other views.

## Verification

- New tests: parse infra (`module/view.rs`, 3), `:write-device` alias saves on
  all three views, `:setfoo` unknown / bare `:set` still warns (TUI 6.8).
- Full `cargo test --workspace`, `clippy -D warnings`, `fmt --check` clean.
- Manual in the demo TUI (tmux): `:write-device` saves on Modbus/CSMS/CS tabs,
  `:wd` unchanged, `:setfoo` and `:rfidfoo` report unknown, `:order name desc`
  and `:rfid add/clear` unchanged.