### PR TITLE
Add configurable register order for multi-register Modbus types

### DIFF
--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -197,6 +197,7 @@ reversed entries are skipped silently.
 | `access` | enum | `ReadWrite` | `ReadOnly`, `WriteOnly`, `ReadWrite` |
 | `type` | enum | — (required) | `U8`, `U16`, `U32`, `U64`, `U128`, `I8`, `I16`, `I32`, `I64`, `I128`, `F32`, `F64`, `Ascii` |
 | `endian` | enum | `Big` | `Big`, `Little` |
+| `word_order` | enum | `Normal` | `Normal`, `Reversed` (register order, numeric types only) |
 | `resolution` | f64 | `1.0` | display scale (`displayed = raw × resolution`) |
 | `bitmask` | optional string | unset ⇒ full mask | `0x`-prefixed hex or decimal; integer types only |
 | `length` | usize | `1` | ASCII width in registers (ignored for numeric types) |

--- a/docs/specs/modbus/data-contract.md
+++ b/docs/specs/modbus/data-contract.md
@@ -69,6 +69,31 @@ whole byte stream across its registers.
 So for a `U32` whose two words on the wire are `0xAABB 0xCCDD`: `Big` decodes
 `0xAABBCCDD`, `Little` decodes `0xDDCCBBAA`.
 
+### 2.2a Register order
+
+Independent of byte order, every integer and float format also carries a **register
+order** of `Normal` or `Reversed`. It reorders the format's 16-bit *words*: `Normal`
+leaves them in natural order; `Reversed` reverses the whole word sequence (for a
+`U64`'s four words `[w0,w1,w2,w3]` → `[w3,w2,w1,w0]`).
+
+Register order composes with byte order as a separate axis: on decode the word
+sequence is reordered **first**, then the byte-order rule of §2.2 is applied; on
+encode the byte-order rule runs first and the words are reordered last. The two stay
+exact inverses. The default `Normal` reproduces the byte-order rule applied alone.
+
+The two axes give the four layouts for a `U32` whose wire words are `0xAABB 0xCCDD`:
+
+| Byte order | Register order | Decodes to |
+|---|---|---|
+| `Big` | `Normal` | `0xAABBCCDD` |
+| `Little` | `Normal` | `0xDDCCBBAA` |
+| `Big` | `Reversed` | `0xCCDDAABB` |
+| `Little` | `Reversed` | `0xBBAADDCC` |
+
+For a single-register format (`U8`/`I8`/`U16`/`I16`) register order is a no-op —
+reversing a one-word sequence changes nothing. `Ascii` has no register order, just as
+it has no byte order.
+
 ### 2.3 Floats
 
 `F32` and `F64` are the raw IEEE 754 bit pattern, subject to the same byte-order

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -22,6 +22,8 @@ mistaken for an oversight and silently "fixed".
 | `Ascii` with `length = 0` | zero-width: encodes to no words, decodes to the empty string |
 | A `bitmask` string in the device config that does not parse | silently falls back to the full (no-op) mask — no error, no warning |
 | A malformed or reversed entry in a `read_ranges` string | silently skipped — no error, no warning |
+| `word_order = Reversed` on a single-register format (`U8`/`I8`/`U16`/`I16`) | inert no-op: reversing a one-word sequence changes nothing |
+| `word_order` on an `Ascii` format | ignored — ASCII carries no register order, as it carries no byte order |
 
 ---
 

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -70,6 +70,18 @@ sit in the low byte for big-endian and the high byte for little-endian.
 `Big` or `Little`. Big-endian shall interpret the register words' byte stream in
 wire order; little-endian shall interpret it fully reversed.
 
+**MB-R-099** — Every integer and float format shall additionally carry a register
+order of `Normal` or `Reversed`, independent of its byte order (MB-R-013). The
+register order shall act on the sequence of the format's 16-bit words: `Normal`
+leaves them in natural order; `Reversed` reverses the whole word sequence. It shall
+be applied to the words **before** the byte-order rule on decode and **after** it on
+encode, so decode and encode remain exact inverses. It shall default to `Normal`,
+under which behavior is identical to the byte-order rule applied alone.
+
+**MB-R-100** — For a single-register format (width 1: `U8`, `I8`, `U16`, `I16`),
+register order shall be a no-op, since reversing a one-word sequence yields the same
+sequence.
+
 **MB-R-014** — Every integer format shall carry a bit-field mask; the field shift
 shall be *derived* from the mask as its trailing-zero count and shall never be
 configured independently.

--- a/ferrowl-codec/src/codec.rs
+++ b/ferrowl-codec/src/codec.rs
@@ -1,7 +1,7 @@
 //! Decode register words into [`Value`]s and encode string input back into words.
 
 use crate::error::CodecError;
-use crate::format::{Alignment, Endian, Format};
+use crate::format::{Alignment, Endian, Format, WordOrder};
 use crate::traits::{IntoVec, ParseFromU8};
 use crate::value::Value;
 
@@ -15,9 +15,14 @@ pub fn decode(format: &Format, bytes: &[u16]) -> Result<Value, CodecError> {
     if bytes.len() < width {
         Err(CodecError::TooFewBytes(format.clone()))
     } else {
-        let bytes = bytes
+        // Register order acts on the word sequence *before* the byte-order rule
+        // (MB-R-099): reverse the words first, then flatten to a byte stream.
+        let mut words: Vec<u16> = bytes.iter().take(width).copied().collect();
+        if format.word_order() == WordOrder::Reversed {
+            words.reverse();
+        }
+        let bytes = words
             .iter()
-            .take(width)
             .flat_map(|v| [(v >> 8) as u8, (v & 0xFF) as u8]);
 
         // Big-endian parses the byte stream as-is; little-endian reverses it
@@ -52,54 +57,54 @@ pub fn decode(format: &Format, bytes: &[u16]) -> Result<Value, CodecError> {
             };
         }
         match format {
-            Format::U8((e, r, bf)) => {
+            Format::U8((e, _, r, bf)) => {
                 check_width!(bf, 8);
                 decode_byte!(U8, u8, e, r, bf)
             }
-            Format::I8((e, r, bf)) => {
+            Format::I8((e, _, r, bf)) => {
                 check_width!(bf, 8);
                 decode_byte!(I8, i8, e, r, bf)
             }
-            Format::U16((e, r, bf)) => {
+            Format::U16((e, _, r, bf)) => {
                 check_width!(bf, 16);
                 decode_int!(U16, u16, u16, e, r, bf)
             }
-            Format::U32((e, r, bf)) => {
+            Format::U32((e, _, r, bf)) => {
                 check_width!(bf, 32);
                 decode_int!(U32, u32, u32, e, r, bf)
             }
-            Format::U64((e, r, bf)) => {
+            Format::U64((e, _, r, bf)) => {
                 check_width!(bf, 64);
                 decode_int!(U64, u64, u64, e, r, bf)
             }
-            Format::U128((e, r, bf)) => {
+            Format::U128((e, _, r, bf)) => {
                 check_width!(bf, 128);
                 decode_int!(U128, u128, u128, e, r, bf)
             }
-            Format::I16((e, r, bf)) => {
+            Format::I16((e, _, r, bf)) => {
                 check_width!(bf, 16);
                 decode_int!(I16, u16, i16, e, r, bf)
             }
-            Format::I32((e, r, bf)) => {
+            Format::I32((e, _, r, bf)) => {
                 check_width!(bf, 32);
                 decode_int!(I32, u32, i32, e, r, bf)
             }
-            Format::I64((e, r, bf)) => {
+            Format::I64((e, _, r, bf)) => {
                 check_width!(bf, 64);
                 decode_int!(I64, u64, i64, e, r, bf)
             }
-            Format::I128((e, r, bf)) => {
+            Format::I128((e, _, r, bf)) => {
                 check_width!(bf, 128);
                 decode_int!(I128, u128, i128, e, r, bf)
             }
-            Format::F32((e, r)) => {
+            Format::F32((e, _, r)) => {
                 let u: u32 = match e {
                     Endian::Big => bytes.parse(),
                     Endian::Little => bytes.rev().parse(),
                 };
                 Ok(Value::F32((f32::from_bits(u), r.clone())))
             }
-            Format::F64((e, r)) => {
+            Format::F64((e, _, r)) => {
                 let u: u64 = match e {
                     Endian::Big => bytes.parse(),
                     Endian::Little => bytes.rev().parse(),
@@ -148,7 +153,7 @@ fn parse_value(format: &Format, s: &str) -> Result<Value, CodecError> {
         }};
     }
     match format {
-        Format::F32((_, r)) => {
+        Format::F32((_, _, r)) => {
             let val: f32 = if let Some(s) = s.strip_prefix("0x") {
                 u32::from_str_radix(s, 16).map(f32::from_bits)?
             } else {
@@ -156,7 +161,7 @@ fn parse_value(format: &Format, s: &str) -> Result<Value, CodecError> {
             };
             Ok(Value::F32((val, r.clone())))
         }
-        Format::F64((_, r)) => {
+        Format::F64((_, _, r)) => {
             let val: f64 = if let Some(s) = s.strip_prefix("0x") {
                 u64::from_str_radix(s, 16).map(f64::from_bits)?
             } else {
@@ -165,7 +170,7 @@ fn parse_value(format: &Format, s: &str) -> Result<Value, CodecError> {
             Ok(Value::F64((val, r.clone())))
         }
         Format::Ascii(_) => Ok(Value::Ascii(s.to_string())),
-        Format::U8((_, r, bf)) => {
+        Format::U8((_, _, r, bf)) => {
             if !bf.fits(8) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
@@ -176,31 +181,31 @@ fn parse_value(format: &Format, s: &str) -> Result<Value, CodecError> {
             };
             Ok(Value::U8((val, r.clone())))
         }
-        Format::U16((_, r, bf)) => {
+        Format::U16((_, _, r, bf)) => {
             if !bf.fits(16) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_uint!(U16, u16, r, s)
         }
-        Format::U32((_, r, bf)) => {
+        Format::U32((_, _, r, bf)) => {
             if !bf.fits(32) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_uint!(U32, u32, r, s)
         }
-        Format::U64((_, r, bf)) => {
+        Format::U64((_, _, r, bf)) => {
             if !bf.fits(64) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_uint!(U64, u64, r, s)
         }
-        Format::U128((_, r, bf)) => {
+        Format::U128((_, _, r, bf)) => {
             if !bf.fits(128) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_uint!(U128, u128, r, s)
         }
-        Format::I8((_, r, bf)) => {
+        Format::I8((_, _, r, bf)) => {
             if !bf.fits(8) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
@@ -213,25 +218,25 @@ fn parse_value(format: &Format, s: &str) -> Result<Value, CodecError> {
             };
             Ok(Value::I8((val, r.clone())))
         }
-        Format::I16((_, r, bf)) => {
+        Format::I16((_, _, r, bf)) => {
             if !bf.fits(16) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_int!(I16, i16, u16, r, s)
         }
-        Format::I32((_, r, bf)) => {
+        Format::I32((_, _, r, bf)) => {
             if !bf.fits(32) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_int!(I32, i32, u32, r, s)
         }
-        Format::I64((_, r, bf)) => {
+        Format::I64((_, _, r, bf)) => {
             if !bf.fits(64) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             parse_int!(I64, i64, u64, r, s)
         }
-        Format::I128((_, r, bf)) => {
+        Format::I128((_, _, r, bf)) => {
             if !bf.fits(128) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
@@ -289,15 +294,15 @@ pub fn encode_value(format: &Format, value: &Value) -> Result<Vec<u16>, CodecErr
             }
         }};
     }
-    match format {
-        Format::F32((e, _)) => match value {
+    let words = match format {
+        Format::F32((e, _, _)) => match value {
             Value::F32((val, _)) => Ok(match e {
                 Endian::Big => val.to_bits().to_be_bytes().iter().into_vec()?,
                 Endian::Little => val.to_bits().to_le_bytes().iter().into_vec()?,
             }),
             _ => Err(mismatch()),
         },
-        Format::F64((e, _)) => match value {
+        Format::F64((e, _, _)) => match value {
             Value::F64((val, _)) => Ok(match e {
                 Endian::Big => val.to_bits().to_be_bytes().iter().into_vec()?,
                 Endian::Little => val.to_bits().to_le_bytes().iter().into_vec()?,
@@ -324,7 +329,7 @@ pub fn encode_value(format: &Format, value: &Value) -> Result<Vec<u16>, CodecErr
             }
             _ => Err(mismatch()),
         },
-        Format::U8((e, _, bf)) => {
+        Format::U8((e, _, _, bf)) => {
             if !bf.fits(8) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
@@ -339,31 +344,31 @@ pub fn encode_value(format: &Format, value: &Value) -> Result<Vec<u16>, CodecErr
                 _ => Err(mismatch()),
             }
         }
-        Format::U16((e, _, bf)) => {
+        Format::U16((e, _, _, bf)) => {
             if !bf.fits(16) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_uint!(U16, u16, e, bf)
         }
-        Format::U32((e, _, bf)) => {
+        Format::U32((e, _, _, bf)) => {
             if !bf.fits(32) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_uint!(U32, u32, e, bf)
         }
-        Format::U64((e, _, bf)) => {
+        Format::U64((e, _, _, bf)) => {
             if !bf.fits(64) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_uint!(U64, u64, e, bf)
         }
-        Format::U128((e, _, bf)) => {
+        Format::U128((e, _, _, bf)) => {
             if !bf.fits(128) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_uint!(U128, u128, e, bf)
         }
-        Format::I8((e, _, bf)) => {
+        Format::I8((e, _, _, bf)) => {
             if !bf.fits(8) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
@@ -378,31 +383,38 @@ pub fn encode_value(format: &Format, value: &Value) -> Result<Vec<u16>, CodecErr
                 _ => Err(mismatch()),
             }
         }
-        Format::I16((e, _, bf)) => {
+        Format::I16((e, _, _, bf)) => {
             if !bf.fits(16) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_int!(I16, i16, u16, e, bf)
         }
-        Format::I32((e, _, bf)) => {
+        Format::I32((e, _, _, bf)) => {
             if !bf.fits(32) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_int!(I32, i32, u32, e, bf)
         }
-        Format::I64((e, _, bf)) => {
+        Format::I64((e, _, _, bf)) => {
             if !bf.fits(64) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_int!(I64, i64, u64, e, bf)
         }
-        Format::I128((e, _, bf)) => {
+        Format::I128((e, _, _, bf)) => {
             if !bf.fits(128) {
                 return Err(CodecError::BitFieldWidth(format.clone()));
             }
             encode_int!(I128, i128, u128, e, bf)
         }
+    };
+    // Register order (MB-R-099): reverse the encoded words *after* the byte-order
+    // rule, so decode (which reverses *before*) stays its exact inverse.
+    let mut words = words?;
+    if format.word_order() == WordOrder::Reversed {
+        words.reverse();
     }
+    Ok(words)
 }
 
 /// Per-word mask selecting the bits an integer [`BitField`] format owns, laid
@@ -419,26 +431,32 @@ pub fn mask_words(format: &Format) -> Vec<u16> {
             }
         }};
     }
-    match format {
-        Format::U8((e, _, bf)) | Format::I8((e, _, bf)) => {
+    let mut words = match format {
+        Format::U8((e, _, _, bf)) | Format::I8((e, _, _, bf)) => {
             let m = bf.mask as u8;
             match e {
                 Endian::Big => vec![m as u16],
                 Endian::Little => vec![(m as u16) << 8],
             }
         }
-        Format::U16((e, _, bf)) | Format::I16((e, _, bf)) => mask_uint!(u16, e, bf),
-        Format::U32((e, _, bf)) | Format::I32((e, _, bf)) => mask_uint!(u32, e, bf),
-        Format::U64((e, _, bf)) | Format::I64((e, _, bf)) => mask_uint!(u64, e, bf),
-        Format::U128((e, _, bf)) | Format::I128((e, _, bf)) => mask_uint!(u128, e, bf),
+        Format::U16((e, _, _, bf)) | Format::I16((e, _, _, bf)) => mask_uint!(u16, e, bf),
+        Format::U32((e, _, _, bf)) | Format::I32((e, _, _, bf)) => mask_uint!(u32, e, bf),
+        Format::U64((e, _, _, bf)) | Format::I64((e, _, _, bf)) => mask_uint!(u64, e, bf),
+        Format::U128((e, _, _, bf)) | Format::I128((e, _, _, bf)) => mask_uint!(u128, e, bf),
         Format::F32(_) | Format::F64(_) | Format::Ascii(_) => vec![0xFFFFu16; format.width()],
+    };
+    // Reverse the mask words in lockstep with the encoded words (MB-R-099) so the
+    // read-modify-write merge still targets the bits each register owns.
+    if format.word_order() == WordOrder::Reversed {
+        words.reverse();
     }
+    words
 }
 
 #[cfg(test)]
 mod tests {
     use crate::codec::{decode, encode, encode_value};
-    use crate::format::{Alignment, BitField, Endian, Format, Resolution, Width};
+    use crate::format::{Alignment, BitField, Endian, Format, Resolution, Width, WordOrder};
     use crate::value::Value;
     use crate::{CodecError, Register, RegisterBuilder};
 
@@ -457,31 +475,31 @@ mod tests {
     // --- Format helpers ---
 
     fn u8_be() -> Format {
-        Format::U8((Endian::Big, res(), bf()))
+        Format::U8((Endian::Big, WordOrder::Normal, res(), bf()))
     }
     fn u8_le() -> Format {
-        Format::U8((Endian::Little, res(), bf()))
+        Format::U8((Endian::Little, WordOrder::Normal, res(), bf()))
     }
     fn u32_be() -> Format {
-        Format::U32((Endian::Big, res(), bf()))
+        Format::U32((Endian::Big, WordOrder::Normal, res(), bf()))
     }
     fn u32_le() -> Format {
-        Format::U32((Endian::Little, res(), bf()))
+        Format::U32((Endian::Little, WordOrder::Normal, res(), bf()))
     }
     fn i8_be() -> Format {
-        Format::I8((Endian::Big, res(), bf()))
+        Format::I8((Endian::Big, WordOrder::Normal, res(), bf()))
     }
     fn i32_be() -> Format {
-        Format::I32((Endian::Big, res(), bf()))
+        Format::I32((Endian::Big, WordOrder::Normal, res(), bf()))
     }
     fn i32_le() -> Format {
-        Format::I32((Endian::Little, res(), bf()))
+        Format::I32((Endian::Little, WordOrder::Normal, res(), bf()))
     }
     fn f32_be() -> Format {
-        Format::F32((Endian::Big, res()))
+        Format::F32((Endian::Big, WordOrder::Normal, res()))
     }
     fn f64_be() -> Format {
-        Format::F64((Endian::Big, res()))
+        Format::F64((Endian::Big, WordOrder::Normal, res()))
     }
 
     // --- Too few bytes ---
@@ -491,7 +509,7 @@ mod tests {
     fn ut_decode_too_few_bytes() {
         assert!(reg(u32_be()).decode(&[0x0001]).is_err());
         assert!(
-            reg(Format::U64((Endian::Big, res(), bf())))
+            reg(Format::U64((Endian::Big, WordOrder::Normal, res(), bf())))
                 .decode(&[])
                 .is_err()
         );
@@ -842,7 +860,12 @@ mod tests {
     #[test]
     /// MB-R-021 — the display resolution scales the shown value but not the words on the wire.
     fn ut_decode_u16_with_resolution() {
-        let r = reg(Format::U16((Endian::Big, Resolution(0.5), bf())));
+        let r = reg(Format::U16((
+            Endian::Big,
+            WordOrder::Normal,
+            Resolution(0.5),
+            bf(),
+        )));
         let words = r.encode("2048").unwrap();
         let decoded = r.decode(&words).unwrap();
         // 2048 * 0.5 = 1024.0
@@ -852,7 +875,7 @@ mod tests {
     // --- Bit-field mask + derived shift ---
 
     fn u16_be_mask(mask: u128) -> Format {
-        Format::U16((Endian::Big, res(), BitField { mask }))
+        Format::U16((Endian::Big, WordOrder::Normal, res(), BitField { mask }))
     }
 
     #[test]
@@ -920,6 +943,7 @@ mod tests {
         // U32 big-endian mask spans two words.
         let r = reg(Format::U32((
             Endian::Big,
+            WordOrder::Normal,
             res(),
             BitField { mask: 0xFFFF_0000 },
         )));
@@ -935,11 +959,11 @@ mod tests {
     fn ut_roundtrip_wide_ints() {
         let e = [Endian::Big, Endian::Little];
         for endian in e {
-            let u64f = Format::U64((endian.clone(), res(), bf()));
-            let u128f = Format::U128((endian.clone(), res(), bf()));
-            let i16f = Format::I16((endian.clone(), res(), bf()));
-            let i64f = Format::I64((endian.clone(), res(), bf()));
-            let i128f = Format::I128((endian.clone(), res(), bf()));
+            let u64f = Format::U64((endian.clone(), WordOrder::Normal, res(), bf()));
+            let u128f = Format::U128((endian.clone(), WordOrder::Normal, res(), bf()));
+            let i16f = Format::I16((endian.clone(), WordOrder::Normal, res(), bf()));
+            let i64f = Format::I64((endian.clone(), WordOrder::Normal, res(), bf()));
+            let i128f = Format::I128((endian.clone(), WordOrder::Normal, res(), bf()));
 
             // Display scales through f64, so values stay within f64's exact
             // integer range (< 2^53) to survive the round-trip string compare.
@@ -957,17 +981,119 @@ mod tests {
         }
     }
 
+    // --- Register (word) order ---
+
+    #[test]
+    /// MB-R-099 — `Reversed` reverses the word sequence before the byte-order rule:
+    /// a Big/Reversed U32 reads wire words `0x0102 0x0304` as `0x03040102`, and a
+    /// Little/Reversed one as `0x02010403`.
+    fn ut_decode_u32_reversed() {
+        let big_rev = reg(Format::U32((Endian::Big, WordOrder::Reversed, res(), bf())));
+        match big_rev.decode(&[0x0102, 0x0304]).unwrap() {
+            Value::U32((v, _)) => assert_eq!(v, 0x0304_0102),
+            _ => panic!("Wrong variant"),
+        }
+        let little_rev = reg(Format::U32((
+            Endian::Little,
+            WordOrder::Reversed,
+            res(),
+            bf(),
+        )));
+        match little_rev.decode(&[0x0102, 0x0304]).unwrap() {
+            Value::U32((v, _)) => assert_eq!(v, 0x0201_0403),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    /// MB-R-099 — encoding under `Reversed` reverses the words *after* the byte-order
+    /// rule, the exact inverse of decode: `0x01020304` becomes wire words `0x0304 0x0102`.
+    fn ut_encode_u32_reversed() {
+        let r = reg(Format::U32((Endian::Big, WordOrder::Reversed, res(), bf())));
+        assert_eq!(r.encode("0x01020304").unwrap(), vec![0x0304, 0x0102]);
+    }
+
+    #[test]
+    /// MB-R-099 — encode and decode stay exact inverses under `Reversed` for every
+    /// multi-register width, in both byte orders.
+    fn ut_roundtrip_reversed_all_widths() {
+        for endian in [Endian::Big, Endian::Little] {
+            let u32f = Format::U32((endian.clone(), WordOrder::Reversed, res(), bf()));
+            let u64f = Format::U64((endian.clone(), WordOrder::Reversed, res(), bf()));
+            let u128f = Format::U128((endian.clone(), WordOrder::Reversed, res(), bf()));
+            let i32f = Format::I32((endian.clone(), WordOrder::Reversed, res(), bf()));
+            for (f, s) in [
+                (u32f, "123456789"),
+                (u64f, "1234567890123"),
+                (u128f, "123456789012345"),
+                (i32f, "-123456789"),
+            ] {
+                let r = reg(f);
+                let words = r.encode(s).unwrap();
+                assert_eq!(r.decode(&words).unwrap().to_string(), s);
+            }
+            // Floats compare by value to avoid display-formatting coupling.
+            let f32r = reg(Format::F32((endian.clone(), WordOrder::Reversed, res())));
+            let w = f32r.encode("1.5").unwrap();
+            match f32r.decode(&w).unwrap() {
+                Value::F32((v, _)) => assert!((v - 1.5f32).abs() < 1e-6),
+                _ => panic!("Wrong variant"),
+            }
+            let f64r = reg(Format::F64((endian.clone(), WordOrder::Reversed, res())));
+            let w = f64r.encode("2.25").unwrap();
+            match f64r.decode(&w).unwrap() {
+                Value::F64((v, _)) => assert!((v - 2.25f64).abs() < 1e-10),
+                _ => panic!("Wrong variant"),
+            }
+        }
+    }
+
+    #[test]
+    /// MB-R-100 — register order is a no-op for single-register formats (width 1):
+    /// `Normal` and `Reversed` encode and decode identically for `U16`/`U8`.
+    fn ut_word_order_noop_single_register() {
+        for e in [Endian::Big, Endian::Little] {
+            let n16 = reg(Format::U16((e.clone(), WordOrder::Normal, res(), bf())));
+            let r16 = reg(Format::U16((e.clone(), WordOrder::Reversed, res(), bf())));
+            assert_eq!(
+                n16.decode(&[0x1234]).unwrap().to_string(),
+                r16.decode(&[0x1234]).unwrap().to_string()
+            );
+            assert_eq!(n16.encode("4660").unwrap(), r16.encode("4660").unwrap());
+
+            let n8 = reg(Format::U8((e.clone(), WordOrder::Normal, res(), bf())));
+            let r8 = reg(Format::U8((e.clone(), WordOrder::Reversed, res(), bf())));
+            assert_eq!(n8.encode("200").unwrap(), r8.encode("200").unwrap());
+        }
+    }
+
+    #[test]
+    /// MB-R-099 / MB-R-009 — the write-mask words reverse in lockstep with the encoded
+    /// words under `Reversed`, so the read-modify-write merge still targets the right bits.
+    fn ut_mask_words_reversed() {
+        let mask = BitField { mask: 0xFFFF_0000 };
+        let normal = reg(Format::U32((
+            Endian::Big,
+            WordOrder::Normal,
+            res(),
+            mask.clone(),
+        )));
+        let reversed = reg(Format::U32((Endian::Big, WordOrder::Reversed, res(), mask)));
+        assert_eq!(normal.write_mask(), vec![0xFFFF, 0x0000]);
+        assert_eq!(reversed.write_mask(), vec![0x0000, 0xFFFF]);
+    }
+
     #[test]
     /// MB-R-018 — floats encode/decode via their bit pattern under little-endian byte order.
     fn ut_roundtrip_floats_little_endian() {
-        let f32le = reg(Format::F32((Endian::Little, res())));
+        let f32le = reg(Format::F32((Endian::Little, WordOrder::Normal, res())));
         let words = f32le.encode("1.5").unwrap();
         match f32le.decode(&words).unwrap() {
             Value::F32((f, _)) => assert!((f - 1.5f32).abs() < 1e-6),
             _ => panic!("Wrong variant"),
         }
 
-        let f64le = reg(Format::F64((Endian::Little, res())));
+        let f64le = reg(Format::F64((Endian::Little, WordOrder::Normal, res())));
         let words = f64le.encode("2.25").unwrap();
         match f64le.decode(&words).unwrap() {
             Value::F64((f, _)) => assert!((f - 2.25f64).abs() < 1e-10),
@@ -992,7 +1118,7 @@ mod tests {
     /// MB-R-012 — a little-endian I8 places the byte in the register's high byte.
     fn ut_encode_i8_little_endian() {
         // I8 little-endian places the byte in the high byte of the word.
-        let r = reg(Format::I8((Endian::Little, res(), bf())));
+        let r = reg(Format::I8((Endian::Little, WordOrder::Normal, res(), bf())));
         assert_eq!(r.encode("-1").unwrap(), vec![(-1i8 as u16) << 8]);
     }
 
@@ -1005,6 +1131,7 @@ mod tests {
         assert_eq!(
             reg(Format::U64((
                 Endian::Big,
+                WordOrder::Normal,
                 res(),
                 BitField {
                     mask: u64::MAX as u128
@@ -1016,6 +1143,7 @@ mod tests {
         assert_eq!(
             reg(Format::U128((
                 Endian::Big,
+                WordOrder::Normal,
                 res(),
                 BitField { mask: u128::MAX }
             )))
@@ -1062,62 +1190,62 @@ mod tests {
         for endian in e {
             let cases: Vec<(Format, Value, &str)> = vec![
                 (
-                    Format::U8((endian.clone(), res(), bf())),
+                    Format::U8((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::U8((200, res())),
                     "200",
                 ),
                 (
-                    Format::I8((endian.clone(), res(), bf())),
+                    Format::I8((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::I8((-1, res())),
                     "-1",
                 ),
                 (
-                    Format::U16((endian.clone(), res(), bf())),
+                    Format::U16((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::U16((1234, res())),
                     "1234",
                 ),
                 (
-                    Format::I16((endian.clone(), res(), bf())),
+                    Format::I16((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::I16((-1234, res())),
                     "-1234",
                 ),
                 (
-                    Format::U32((endian.clone(), res(), bf())),
+                    Format::U32((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::U32((123456789, res())),
                     "123456789",
                 ),
                 (
-                    Format::I32((endian.clone(), res(), bf())),
+                    Format::I32((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::I32((-123456789, res())),
                     "-123456789",
                 ),
                 (
-                    Format::U64((endian.clone(), res(), bf())),
+                    Format::U64((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::U64((1234567890123, res())),
                     "1234567890123",
                 ),
                 (
-                    Format::I64((endian.clone(), res(), bf())),
+                    Format::I64((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::I64((-1234567890123, res())),
                     "-1234567890123",
                 ),
                 (
-                    Format::U128((endian.clone(), res(), bf())),
+                    Format::U128((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::U128((123456789012345, res())),
                     "123456789012345",
                 ),
                 (
-                    Format::I128((endian.clone(), res(), bf())),
+                    Format::I128((endian.clone(), WordOrder::Normal, res(), bf())),
                     Value::I128((-123456789012345, res())),
                     "-123456789012345",
                 ),
                 (
-                    Format::F32((endian.clone(), res())),
+                    Format::F32((endian.clone(), WordOrder::Normal, res())),
                     Value::F32((1.5, res())),
                     "1.5",
                 ),
                 (
-                    Format::F64((endian.clone(), res())),
+                    Format::F64((endian.clone(), WordOrder::Normal, res())),
                     Value::F64((2.25, res())),
                     "2.25",
                 ),
@@ -1145,7 +1273,7 @@ mod tests {
         assert_eq!(words, vec![0x0AB0u16]);
 
         // Resolution is not applied by encode_value, same as the string path.
-        let format = Format::U16((Endian::Big, Resolution(0.5), bf()));
+        let format = Format::U16((Endian::Big, WordOrder::Normal, Resolution(0.5), bf()));
         let words = encode_value(&format, &Value::U16((2048, Resolution(0.5)))).unwrap();
         assert_eq!(words, encode(&format, "2048").unwrap());
     }
@@ -1169,12 +1297,22 @@ mod tests {
     /// MB-R-016 — a mask setting a bit at or above the format width is rejected on decode.
     fn ut_decode_bitfield_mask_out_of_width_errors() {
         // 0x1FF on a U8 sets bit 8, outside the 8-bit width.
-        let format = Format::U8((Endian::Big, res(), BitField { mask: 0x1FF }));
+        let format = Format::U8((
+            Endian::Big,
+            WordOrder::Normal,
+            res(),
+            BitField { mask: 0x1FF },
+        ));
         let err = decode(&format, &[0x0001]).unwrap_err();
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
 
         // 0xFF00 on a U8 masks out every bit of the 8-bit value entirely.
-        let format = Format::U8((Endian::Big, res(), BitField { mask: 0xFF00 }));
+        let format = Format::U8((
+            Endian::Big,
+            WordOrder::Normal,
+            res(),
+            BitField { mask: 0xFF00 },
+        ));
         let err = decode(&format, &[0x0001]).unwrap_err();
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
     }
@@ -1182,7 +1320,12 @@ mod tests {
     #[test]
     /// MB-R-016 — a mask setting a bit at or above the format width is rejected on encode.
     fn ut_encode_bitfield_mask_out_of_width_errors() {
-        let format = Format::U8((Endian::Big, res(), BitField { mask: 0x1FF }));
+        let format = Format::U8((
+            Endian::Big,
+            WordOrder::Normal,
+            res(),
+            BitField { mask: 0x1FF },
+        ));
         let err = encode(&format, "1").unwrap_err();
         assert!(matches!(err, CodecError::BitFieldWidth(_)));
 

--- a/ferrowl-codec/src/format/mod.rs
+++ b/ferrowl-codec/src/format/mod.rs
@@ -4,35 +4,37 @@ mod alignment;
 mod bitfield;
 mod endian;
 mod scalar;
+mod word_order;
 
 pub use alignment::Alignment;
 pub use bitfield::BitField;
 pub use endian::Endian;
 pub use scalar::{Resolution, Width};
+pub use word_order::WordOrder;
 
 use serde::{Deserialize, Serialize};
 
 /// How the raw register words of a value are interpreted.
 ///
-/// Integer variants carry the byte order ([`Endian`]), display scale
-/// ([`Resolution`]) and a [`BitField`] selector; float variants carry just
-/// endian and resolution; [`Ascii`](Self::Ascii) carries its [`Alignment`] and
-/// [`Width`] in registers.
+/// Integer variants carry the byte order ([`Endian`]), the register order
+/// ([`WordOrder`]), display scale ([`Resolution`]) and a [`BitField`] selector;
+/// float variants carry endian, word order and resolution; [`Ascii`](Self::Ascii)
+/// carries its [`Alignment`] and [`Width`] in registers.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum Format {
     Ascii((Alignment, Width)),
-    U8((Endian, Resolution, BitField)),
-    U16((Endian, Resolution, BitField)),
-    U32((Endian, Resolution, BitField)),
-    U64((Endian, Resolution, BitField)),
-    U128((Endian, Resolution, BitField)),
-    I8((Endian, Resolution, BitField)),
-    I16((Endian, Resolution, BitField)),
-    I32((Endian, Resolution, BitField)),
-    I64((Endian, Resolution, BitField)),
-    I128((Endian, Resolution, BitField)),
-    F32((Endian, Resolution)),
-    F64((Endian, Resolution)),
+    U8((Endian, WordOrder, Resolution, BitField)),
+    U16((Endian, WordOrder, Resolution, BitField)),
+    U32((Endian, WordOrder, Resolution, BitField)),
+    U64((Endian, WordOrder, Resolution, BitField)),
+    U128((Endian, WordOrder, Resolution, BitField)),
+    I8((Endian, WordOrder, Resolution, BitField)),
+    I16((Endian, WordOrder, Resolution, BitField)),
+    I32((Endian, WordOrder, Resolution, BitField)),
+    I64((Endian, WordOrder, Resolution, BitField)),
+    I128((Endian, WordOrder, Resolution, BitField)),
+    F32((Endian, WordOrder, Resolution)),
+    F64((Endian, WordOrder, Resolution)),
 }
 
 impl std::fmt::Display for Format {
@@ -47,18 +49,18 @@ impl std::fmt::Display for Format {
             Format::Ascii((alignment, _)) => {
                 write!(fmt, "ASCII ({})", alignment)
             }
-            Format::U8((e, _, _)) => fmt_variant!(U8, e),
-            Format::U16((e, _, _)) => fmt_variant!(U16, e),
-            Format::U32((e, _, _)) => fmt_variant!(U32, e),
-            Format::U64((e, _, _)) => fmt_variant!(U64, e),
-            Format::U128((e, _, _)) => fmt_variant!(U128, e),
-            Format::I8((e, _, _)) => fmt_variant!(I8, e),
-            Format::I16((e, _, _)) => fmt_variant!(I16, e),
-            Format::I32((e, _, _)) => fmt_variant!(I32, e),
-            Format::I64((e, _, _)) => fmt_variant!(I64, e),
-            Format::I128((e, _, _)) => fmt_variant!(I128, e),
-            Format::F32((e, _)) => fmt_variant!(F32, e),
-            Format::F64((e, _)) => fmt_variant!(F64, e),
+            Format::U8((e, _, _, _)) => fmt_variant!(U8, e),
+            Format::U16((e, _, _, _)) => fmt_variant!(U16, e),
+            Format::U32((e, _, _, _)) => fmt_variant!(U32, e),
+            Format::U64((e, _, _, _)) => fmt_variant!(U64, e),
+            Format::U128((e, _, _, _)) => fmt_variant!(U128, e),
+            Format::I8((e, _, _, _)) => fmt_variant!(I8, e),
+            Format::I16((e, _, _, _)) => fmt_variant!(I16, e),
+            Format::I32((e, _, _, _)) => fmt_variant!(I32, e),
+            Format::I64((e, _, _, _)) => fmt_variant!(I64, e),
+            Format::I128((e, _, _, _)) => fmt_variant!(I128, e),
+            Format::F32((e, _, _)) => fmt_variant!(F32, e),
+            Format::F64((e, _, _)) => fmt_variant!(F64, e),
         }
     }
 }
@@ -79,17 +81,19 @@ impl Format {
     pub fn resolution(&self) -> Option<Resolution> {
         match self {
             Self::Ascii((_, _)) => None,
-            Self::U8((_, resolution, _))
-            | Self::U16((_, resolution, _))
-            | Self::I8((_, resolution, _))
-            | Self::I16((_, resolution, _))
-            | Self::U32((_, resolution, _))
-            | Self::I32((_, resolution, _))
-            | Self::U64((_, resolution, _))
-            | Self::I64((_, resolution, _))
-            | Self::U128((_, resolution, _))
-            | Self::I128((_, resolution, _)) => Some(resolution.clone()),
-            Self::F32((_, resolution)) | Self::F64((_, resolution)) => Some(resolution.clone()),
+            Self::U8((_, _, resolution, _))
+            | Self::U16((_, _, resolution, _))
+            | Self::I8((_, _, resolution, _))
+            | Self::I16((_, _, resolution, _))
+            | Self::U32((_, _, resolution, _))
+            | Self::I32((_, _, resolution, _))
+            | Self::U64((_, _, resolution, _))
+            | Self::I64((_, _, resolution, _))
+            | Self::U128((_, _, resolution, _))
+            | Self::I128((_, _, resolution, _)) => Some(resolution.clone()),
+            Self::F32((_, _, resolution)) | Self::F64((_, _, resolution)) => {
+                Some(resolution.clone())
+            }
         }
     }
 
@@ -97,17 +101,36 @@ impl Format {
     /// (full mask, shift 0) for float and ASCII formats.
     pub fn bitfield(&self) -> BitField {
         match self {
-            Self::U8((_, _, bf))
-            | Self::U16((_, _, bf))
-            | Self::U32((_, _, bf))
-            | Self::U64((_, _, bf))
-            | Self::U128((_, _, bf))
-            | Self::I8((_, _, bf))
-            | Self::I16((_, _, bf))
-            | Self::I32((_, _, bf))
-            | Self::I64((_, _, bf))
-            | Self::I128((_, _, bf)) => bf.clone(),
+            Self::U8((_, _, _, bf))
+            | Self::U16((_, _, _, bf))
+            | Self::U32((_, _, _, bf))
+            | Self::U64((_, _, _, bf))
+            | Self::U128((_, _, _, bf))
+            | Self::I8((_, _, _, bf))
+            | Self::I16((_, _, _, bf))
+            | Self::I32((_, _, _, bf))
+            | Self::I64((_, _, _, bf))
+            | Self::I128((_, _, _, bf)) => bf.clone(),
             Self::F32(_) | Self::F64(_) | Self::Ascii(_) => BitField::default(),
+        }
+    }
+
+    /// The register (word) order for numeric formats, or the `Normal` no-op
+    /// default for ASCII.
+    pub fn word_order(&self) -> WordOrder {
+        match self {
+            Self::U8((_, w, _, _))
+            | Self::U16((_, w, _, _))
+            | Self::U32((_, w, _, _))
+            | Self::U64((_, w, _, _))
+            | Self::U128((_, w, _, _))
+            | Self::I8((_, w, _, _))
+            | Self::I16((_, w, _, _))
+            | Self::I32((_, w, _, _))
+            | Self::I64((_, w, _, _))
+            | Self::I128((_, w, _, _)) => *w,
+            Self::F32((_, w, _)) | Self::F64((_, w, _)) => *w,
+            Self::Ascii(_) => WordOrder::Normal,
         }
     }
 
@@ -119,7 +142,7 @@ impl Format {
 
 #[cfg(test)]
 mod tests {
-    use super::{Alignment, BitField, Endian, Format, Resolution, Width};
+    use super::{Alignment, BitField, Endian, Format, Resolution, Width, WordOrder};
 
     fn res() -> Resolution {
         Resolution(1.0)
@@ -133,27 +156,75 @@ mod tests {
     /// MB-R-011 — per-format register widths (1/1/1/1, 2/2/2, 4/4/4, 8/8, Ascii = width).
     fn ut_format_width() {
         assert_eq!(Format::Ascii((Alignment::Left, Width(4))).width(), 4);
-        assert_eq!(Format::U8((Endian::Big, res(), bf())).width(), 1);
-        assert_eq!(Format::U16((Endian::Big, res(), bf())).width(), 1);
-        assert_eq!(Format::I8((Endian::Big, res(), bf())).width(), 1);
-        assert_eq!(Format::I16((Endian::Big, res(), bf())).width(), 1);
-        assert_eq!(Format::U32((Endian::Big, res(), bf())).width(), 2);
-        assert_eq!(Format::I32((Endian::Big, res(), bf())).width(), 2);
-        assert_eq!(Format::F32((Endian::Big, res())).width(), 2);
-        assert_eq!(Format::U64((Endian::Big, res(), bf())).width(), 4);
-        assert_eq!(Format::I64((Endian::Big, res(), bf())).width(), 4);
-        assert_eq!(Format::F64((Endian::Big, res())).width(), 4);
-        assert_eq!(Format::U128((Endian::Big, res(), bf())).width(), 8);
-        assert_eq!(Format::I128((Endian::Big, res(), bf())).width(), 8);
+        assert_eq!(
+            Format::U8((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            1
+        );
+        assert_eq!(
+            Format::U16((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            1
+        );
+        assert_eq!(
+            Format::I8((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            1
+        );
+        assert_eq!(
+            Format::I16((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            1
+        );
+        assert_eq!(
+            Format::U32((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            2
+        );
+        assert_eq!(
+            Format::I32((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            2
+        );
+        assert_eq!(
+            Format::F32((Endian::Big, WordOrder::Normal, res())).width(),
+            2
+        );
+        assert_eq!(
+            Format::U64((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            4
+        );
+        assert_eq!(
+            Format::I64((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            4
+        );
+        assert_eq!(
+            Format::F64((Endian::Big, WordOrder::Normal, res())).width(),
+            4
+        );
+        assert_eq!(
+            Format::U128((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            8
+        );
+        assert_eq!(
+            Format::I128((Endian::Big, WordOrder::Normal, res(), bf())).width(),
+            8
+        );
     }
 
     #[test]
     /// MB-R-011 — byte length is twice the register width.
     fn ut_format_length() {
-        assert_eq!(Format::U8((Endian::Big, res(), bf())).length(), 2);
-        assert_eq!(Format::U32((Endian::Big, res(), bf())).length(), 4);
-        assert_eq!(Format::U64((Endian::Big, res(), bf())).length(), 8);
-        assert_eq!(Format::U128((Endian::Big, res(), bf())).length(), 16);
+        assert_eq!(
+            Format::U8((Endian::Big, WordOrder::Normal, res(), bf())).length(),
+            2
+        );
+        assert_eq!(
+            Format::U32((Endian::Big, WordOrder::Normal, res(), bf())).length(),
+            4
+        );
+        assert_eq!(
+            Format::U64((Endian::Big, WordOrder::Normal, res(), bf())).length(),
+            8
+        );
+        assert_eq!(
+            Format::U128((Endian::Big, WordOrder::Normal, res(), bf())).length(),
+            16
+        );
         assert_eq!(Format::Ascii((Alignment::Left, Width(3))).length(), 6);
     }
 
@@ -163,16 +234,20 @@ mod tests {
         // Integer carries its BitField; float/ASCII report the no-op default.
         let bitfield = BitField { mask: 0xFF00 };
         assert_eq!(
-            Format::U16((Endian::Big, res(), bitfield.clone())).bitfield(),
+            Format::U16((Endian::Big, WordOrder::Normal, res(), bitfield.clone())).bitfield(),
             bitfield
         );
         assert_eq!(
-            Format::U16((Endian::Big, res(), bitfield))
+            Format::U16((Endian::Big, WordOrder::Normal, res(), bitfield))
                 .bitfield()
                 .shift(),
             8
         );
-        assert!(Format::F32((Endian::Big, res())).bitfield().is_full());
+        assert!(
+            Format::F32((Endian::Big, WordOrder::Normal, res()))
+                .bitfield()
+                .is_full()
+        );
         assert!(
             Format::Ascii((Alignment::Left, Width(1)))
                 .bitfield()
@@ -190,21 +265,21 @@ mod tests {
                 .is_none()
         );
         assert_eq!(
-            Format::U8((Endian::Big, r.clone(), bf()))
+            Format::U8((Endian::Big, WordOrder::Normal, r.clone(), bf()))
                 .resolution()
                 .unwrap()
                 .0,
             0.5
         );
         assert_eq!(
-            Format::I16((Endian::Little, r.clone(), bf()))
+            Format::I16((Endian::Little, WordOrder::Normal, r.clone(), bf()))
                 .resolution()
                 .unwrap()
                 .0,
             0.5
         );
         assert_eq!(
-            Format::F32((Endian::Big, r.clone()))
+            Format::F32((Endian::Big, WordOrder::Normal, r.clone()))
                 .resolution()
                 .unwrap()
                 .0,
@@ -218,15 +293,15 @@ mod tests {
         let r = Resolution(0.25);
         let e = Endian::Big;
         for f in [
-            Format::U16((e.clone(), r.clone(), bf())),
-            Format::I8((e.clone(), r.clone(), bf())),
-            Format::U32((e.clone(), r.clone(), bf())),
-            Format::I32((e.clone(), r.clone(), bf())),
-            Format::U64((e.clone(), r.clone(), bf())),
-            Format::I64((e.clone(), r.clone(), bf())),
-            Format::U128((e.clone(), r.clone(), bf())),
-            Format::I128((e.clone(), r.clone(), bf())),
-            Format::F64((e.clone(), r.clone())),
+            Format::U16((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::I8((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::U32((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::I32((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::U64((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::I64((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::U128((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::I128((e.clone(), WordOrder::Normal, r.clone(), bf())),
+            Format::F64((e.clone(), WordOrder::Normal, r.clone())),
         ] {
             assert_eq!(f.resolution().unwrap().0, 0.25);
         }
@@ -238,20 +313,24 @@ mod tests {
         let m = BitField { mask: 0x0FF0 };
         let e = Endian::Big;
         for f in [
-            Format::U8((e.clone(), res(), m.clone())),
-            Format::U32((e.clone(), res(), m.clone())),
-            Format::U64((e.clone(), res(), m.clone())),
-            Format::U128((e.clone(), res(), m.clone())),
-            Format::I8((e.clone(), res(), m.clone())),
-            Format::I16((e.clone(), res(), m.clone())),
-            Format::I32((e.clone(), res(), m.clone())),
-            Format::I64((e.clone(), res(), m.clone())),
-            Format::I128((e.clone(), res(), m.clone())),
+            Format::U8((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::U32((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::U64((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::U128((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::I8((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::I16((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::I32((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::I64((e.clone(), WordOrder::Normal, res(), m.clone())),
+            Format::I128((e.clone(), WordOrder::Normal, res(), m.clone())),
         ] {
             assert_eq!(f.bitfield(), m);
         }
         // Float variant reports the no-op default.
-        assert!(Format::F64((e, res())).bitfield().is_full());
+        assert!(
+            Format::F64((e, WordOrder::Normal, res()))
+                .bitfield()
+                .is_full()
+        );
     }
 
     #[test]
@@ -263,49 +342,52 @@ mod tests {
         );
         let e = Endian::Big;
         assert_eq!(
-            Format::U8((e.clone(), res(), bf())).to_string(),
+            Format::U8((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "U8 (Big Endian)"
         );
         assert_eq!(
-            Format::U16((e.clone(), res(), bf())).to_string(),
+            Format::U16((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "U16 (Big Endian)"
         );
         assert_eq!(
-            Format::U32((e.clone(), res(), bf())).to_string(),
+            Format::U32((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "U32 (Big Endian)"
         );
         assert_eq!(
-            Format::U64((e.clone(), res(), bf())).to_string(),
+            Format::U64((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "U64 (Big Endian)"
         );
         assert_eq!(
-            Format::U128((e.clone(), res(), bf())).to_string(),
+            Format::U128((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "U128 (Big Endian)"
         );
         assert_eq!(
-            Format::I8((e.clone(), res(), bf())).to_string(),
+            Format::I8((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "I8 (Big Endian)"
         );
         assert_eq!(
-            Format::I16((e.clone(), res(), bf())).to_string(),
+            Format::I16((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "I16 (Big Endian)"
         );
         assert_eq!(
-            Format::I32((e.clone(), res(), bf())).to_string(),
+            Format::I32((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "I32 (Big Endian)"
         );
         assert_eq!(
-            Format::I64((e.clone(), res(), bf())).to_string(),
+            Format::I64((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "I64 (Big Endian)"
         );
         assert_eq!(
-            Format::I128((e.clone(), res(), bf())).to_string(),
+            Format::I128((e.clone(), WordOrder::Normal, res(), bf())).to_string(),
             "I128 (Big Endian)"
         );
         assert_eq!(
-            Format::F32((e.clone(), res())).to_string(),
+            Format::F32((e.clone(), WordOrder::Normal, res())).to_string(),
             "F32 (Big Endian)"
         );
-        assert_eq!(Format::F64((e, res())).to_string(), "F64 (Big Endian)");
+        assert_eq!(
+            Format::F64((e, WordOrder::Normal, res())).to_string(),
+            "F64 (Big Endian)"
+        );
     }
 }

--- a/ferrowl-codec/src/format/word_order.rs
+++ b/ferrowl-codec/src/format/word_order.rs
@@ -1,0 +1,38 @@
+//! Register (word) order of a multi-register value.
+
+use serde::{Deserialize, Serialize};
+
+/// Order of the 16-bit register words of a multi-register value, independent of
+/// the byte order ([`Endian`](super::Endian)).
+///
+/// `Normal` keeps the words in natural order; `Reversed` reverses the whole word
+/// sequence (`[w0,w1,w2,w3]` → `[w3,w2,w1,w0]`). For a single-register format it
+/// is a no-op. Defaults to `Normal`, which reproduces the byte-order rule alone.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WordOrder {
+    #[default]
+    Normal,
+    Reversed,
+}
+
+impl std::fmt::Display for WordOrder {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WordOrder::Normal => write!(fmt, "Normal"),
+            WordOrder::Reversed => write!(fmt, "Reversed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WordOrder;
+
+    #[test]
+    /// MB-R-099 — register order is `Normal` or `Reversed`, defaulting to `Normal`.
+    fn ut_word_order_display_and_default() {
+        assert_eq!(WordOrder::Normal.to_string(), "Normal");
+        assert_eq!(WordOrder::Reversed.to_string(), "Reversed");
+        assert_eq!(WordOrder::default(), WordOrder::Normal);
+    }
+}

--- a/ferrowl-codec/src/lib.rs
+++ b/ferrowl-codec/src/lib.rs
@@ -24,7 +24,7 @@ pub use crate::access::Access;
 pub use crate::address::Address;
 pub use crate::codec::{decode, encode, encode_value};
 pub use crate::error::CodecError;
-pub use crate::format::{Alignment, BitField, Endian, Format};
+pub use crate::format::{Alignment, BitField, Endian, Format, WordOrder};
 pub use crate::kind::Kind;
 pub use crate::traits::{IntoVec, ParseFromU8};
 pub use crate::value::Value;
@@ -103,11 +103,16 @@ impl Register {
 
 #[cfg(test)]
 mod tests {
-    use crate::format::{Endian, Format, Resolution, Width};
+    use crate::format::{Endian, Format, Resolution, Width, WordOrder};
     use crate::{Access, Address, Alignment, BitField, Kind, RegisterBuilder};
 
     fn u16_be() -> Format {
-        Format::U16((Endian::Big, Resolution(1.0), BitField::default()))
+        Format::U16((
+            Endian::Big,
+            WordOrder::Normal,
+            Resolution(1.0),
+            BitField::default(),
+        ))
     }
 
     #[test]
@@ -134,13 +139,28 @@ mod tests {
     fn ut_format_width_is_consecutive_address_count() {
         // U16 = 1 word, F32 = 2 words, U64 = 4 words, U128 = 8 words, Ascii = its width.
         assert_eq!(u16_be().width(), 1);
-        assert_eq!(Format::F32((Endian::Big, Resolution(1.0))).width(), 2);
         assert_eq!(
-            Format::U64((Endian::Big, Resolution(1.0), BitField::default())).width(),
+            Format::F32((Endian::Big, WordOrder::Normal, Resolution(1.0))).width(),
+            2
+        );
+        assert_eq!(
+            Format::U64((
+                Endian::Big,
+                WordOrder::Normal,
+                Resolution(1.0),
+                BitField::default()
+            ))
+            .width(),
             4
         );
         assert_eq!(
-            Format::U128((Endian::Big, Resolution(1.0), BitField::default())).width(),
+            Format::U128((
+                Endian::Big,
+                WordOrder::Normal,
+                Resolution(1.0),
+                BitField::default()
+            ))
+            .width(),
             8
         );
         assert_eq!(Format::Ascii((Alignment::Left, Width(5))).width(), 5);

--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -2,7 +2,7 @@
 //! round-tripping typed [`Value`]s through raw register words with `encode_value`/`decode`.
 //! These drive the crate exactly as a consumer (the Modbus module) does, over public paths only.
 
-use ferrowl_codec::format::{Resolution, Width};
+use ferrowl_codec::format::{Resolution, Width, WordOrder};
 use ferrowl_codec::{
     Access, Alignment, BitField, Endian, Format, Kind, RegisterBuilder, Value, decode, encode,
     encode_value,
@@ -13,7 +13,7 @@ fn res() -> Resolution {
 }
 
 fn int(endian: Endian) -> Format {
-    Format::U16((endian, res(), BitField::default()))
+    Format::U16((endian, WordOrder::Normal, res(), BitField::default()))
 }
 
 #[test]
@@ -46,12 +46,17 @@ fn it_u16_value_roundtrips_through_words() {
 fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
     let value = Value::U32((0x0001_0002, res()));
     let be = encode_value(
-        &Format::U32((Endian::Big, res(), BitField::default())),
+        &Format::U32((Endian::Big, WordOrder::Normal, res(), BitField::default())),
         &value,
     )
     .expect("value encodes big-endian");
     let le = encode_value(
-        &Format::U32((Endian::Little, res(), BitField::default())),
+        &Format::U32((
+            Endian::Little,
+            WordOrder::Normal,
+            res(),
+            BitField::default(),
+        )),
         &value,
     )
     .expect("value encodes little-endian");
@@ -62,12 +67,20 @@ fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
         other => panic!("expected U32, got {other:?}"),
     };
     assert_eq!(
-        decoded(Format::U32((Endian::Big, res(), BitField::default())), &be),
+        decoded(
+            Format::U32((Endian::Big, WordOrder::Normal, res(), BitField::default())),
+            &be
+        ),
         0x0001_0002
     );
     assert_eq!(
         decoded(
-            Format::U32((Endian::Little, res(), BitField::default())),
+            Format::U32((
+                Endian::Little,
+                WordOrder::Normal,
+                res(),
+                BitField::default()
+            )),
             &le
         ),
         0x0001_0002
@@ -77,7 +90,7 @@ fn it_u32_big_and_little_endian_swap_word_order_but_decode_equal() {
 #[test]
 /// MB-R-007 — a negative signed value round-trips through raw register words.
 fn it_signed_value_roundtrips_negative() {
-    let fmt = Format::I16((Endian::Big, res(), BitField::default()));
+    let fmt = Format::I16((Endian::Big, WordOrder::Normal, res(), BitField::default()));
     let words = encode_value(&fmt, &Value::I16((-5, res()))).expect("encodes -5");
     match decode(&fmt, &words).expect("decodes") {
         Value::I16((v, _)) => assert_eq!(v, -5),
@@ -88,7 +101,7 @@ fn it_signed_value_roundtrips_negative() {
 #[test]
 /// MB-R-018 — a float value round-trips through its IEEE 754 register words.
 fn it_float_value_roundtrips() {
-    let fmt = Format::F32((Endian::Big, res()));
+    let fmt = Format::F32((Endian::Big, WordOrder::Normal, res()));
     let words = encode_value(&fmt, &Value::F32((1.5, res()))).expect("encodes 1.5");
     match decode(&fmt, &words).expect("decodes") {
         Value::F32((v, _)) => assert_eq!(v, 1.5),
@@ -110,7 +123,7 @@ fn it_ascii_value_roundtrips_through_string_encoding() {
 #[test]
 /// MB-R-023 — decoding fewer words than the format width is rejected.
 fn it_decode_rejects_too_few_words() {
-    let fmt = Format::U32((Endian::Big, res(), BitField::default()));
+    let fmt = Format::U32((Endian::Big, WordOrder::Normal, res(), BitField::default()));
     assert!(
         decode(&fmt, &[0x0001]).is_err(),
         "a u32 needs two words; one must be rejected"

--- a/ferrowl/src/cli/headless.rs
+++ b/ferrowl/src/cli/headless.rs
@@ -518,7 +518,7 @@ mod tests {
 
     fn holding_device_config() -> config::DeviceConfig {
         use crate::module::modbus::config::device::{
-            AccessCfg, AlignmentCfg, EndianCfg, RegisterDef, ValueType,
+            AccessCfg, AlignmentCfg, EndianCfg, RegisterDef, ValueType, WordOrderCfg,
         };
         use ferrowl_codec::Kind;
 
@@ -533,6 +533,7 @@ mod tests {
                 access: AccessCfg::ReadWrite,
                 value_type: ValueType::U16,
                 endian: EndianCfg::Big,
+                word_order: WordOrderCfg::default(),
                 resolution: 1.0,
                 bitmask: None,
                 length: 1,

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -316,7 +316,7 @@ fn sleep_responsive(interval: Duration, stop: &AtomicBool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ferrowl_codec::format::{BitField, Endian, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Access, Format, Kind, RegisterBuilder};
     use ferrowl_modbus::SlaveKey;
     use ferrowl_store::{CellKind as MemKind, CellType, Memory};
@@ -331,6 +331,7 @@ mod tests {
             .address(Address::Fixed(addr))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -380,6 +381,7 @@ mod tests {
                 .address(ferrowl_codec::Address::Virtual)
                 .format(Format::U16((
                     Endian::Big,
+                    WordOrder::Normal,
                     Resolution(1.0),
                     BitField::default(),
                 )))
@@ -673,6 +675,7 @@ mod tests {
                 .address(ferrowl_codec::Address::Virtual)
                 .format(Format::U16((
                     Endian::Big,
+                    WordOrder::Normal,
                     Resolution(1.0),
                     BitField::default(),
                 )))
@@ -703,6 +706,7 @@ mod tests {
                 .address(ferrowl_codec::Address::Virtual)
                 .format(Format::U16((
                     Endian::Big,
+                    WordOrder::Normal,
                     Resolution(1.0),
                     BitField::default(),
                 )))

--- a/ferrowl/src/lua/value_conv.rs
+++ b/ferrowl/src/lua/value_conv.rs
@@ -136,11 +136,16 @@ pub(super) fn value_to_type(value: Value) -> ValueType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ferrowl_codec::format::{Alignment, BitField, Endian, Resolution, Width};
+    use ferrowl_codec::format::{Alignment, BitField, Endian, Resolution, Width, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
 
-    fn int_fmt(kind: fn((Endian, Resolution, BitField)) -> Format) -> Format {
-        kind((Endian::Big, Resolution(1.0), BitField::default()))
+    fn int_fmt(kind: fn((Endian, WordOrder, Resolution, BitField)) -> Format) -> Format {
+        kind((
+            Endian::Big,
+            WordOrder::Normal,
+            Resolution(1.0),
+            BitField::default(),
+        ))
     }
 
     #[test]
@@ -197,7 +202,7 @@ mod tests {
 
     #[test]
     fn ut_typed_value_float_and_ascii_formats() {
-        let f32f = Format::F32((Endian::Big, Resolution(1.0)));
+        let f32f = Format::F32((Endian::Big, WordOrder::Normal, Resolution(1.0)));
         assert!(matches!(
             typed_value_from_type(ValueType::Float(1.25), &f32f).unwrap(),
             Value::F32((v, _)) if v == 1.25

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -31,7 +31,7 @@ use tokio::runtime::Runtime;
 use crate::app::{App, Level, Tab};
 use crate::cli::{CliArgs, SubCommand};
 use crate::config::device::{
-    AccessCfg, AlignmentCfg, EndianCfg, NamedValue, RegisterDef, Scalar, ValueType,
+    AccessCfg, AlignmentCfg, EndianCfg, NamedValue, RegisterDef, Scalar, ValueType, WordOrderCfg,
 };
 use crate::config::ocpp::{OcppProtocol, OcppRole, OcppVersion};
 use crate::config::{
@@ -55,6 +55,7 @@ fn demo_modbus_tab(name: String, role: Role) -> Tab {
             access: AccessCfg::ReadWrite,
             value_type,
             endian: EndianCfg::Big,
+            word_order: WordOrderCfg::default(),
             resolution: 1.0,
             bitmask: None,
             length: 1,

--- a/ferrowl/src/migrate.rs
+++ b/ferrowl/src/migrate.rs
@@ -29,7 +29,7 @@ use serde::Deserialize;
 use crate::cli::MigrateArgs;
 use crate::config::device::{
     AccessCfg, AlignmentCfg, DeviceConfig, EndianCfg, NamedValue, ReadRanges, RegisterDef, Scalar,
-    ValueType,
+    ValueType, WordOrderCfg,
 };
 
 // ── Legacy structure definitions ─────────────────────────────────────────────
@@ -338,6 +338,7 @@ fn convert_def(
         access,
         value_type,
         endian,
+        word_order: WordOrderCfg::default(),
         resolution: src.resolution,
         bitmask: None,
         length: src.length,

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -312,7 +312,7 @@ pub(crate) fn build_instance(
 
 #[cfg(test)]
 mod tests {
-    use ferrowl_codec::format::{BitField, Endian, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Format, Kind, RegisterBuilder};
     use ferrowl_modbus::{Key, SlaveKey};
     use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
@@ -355,7 +355,12 @@ mod tests {
             slave,
             kind,
             addr,
-            Format::U16((Endian::Big, Resolution(1.0), BitField::default())),
+            Format::U16((
+                Endian::Big,
+                WordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
             access,
         )
     }
@@ -370,7 +375,12 @@ mod tests {
             1,
             Kind::HoldingRegister,
             0,
-            Format::U16((Endian::Big, Resolution(0.5), BitField::default())),
+            Format::U16((
+                Endian::Big,
+                WordOrder::Normal,
+                Resolution(0.5),
+                BitField::default(),
+            )),
             Access::ReadWrite,
         )
         .2;
@@ -442,7 +452,12 @@ mod tests {
                     1,
                     Kind::HoldingRegister,
                     i * 8,
-                    Format::U128((Endian::Big, Resolution(1.0), BitField::default())),
+                    Format::U128((
+                        Endian::Big,
+                        WordOrder::Normal,
+                        Resolution(1.0),
+                        BitField::default(),
+                    )),
                     Access::ReadOnly,
                 )
             })
@@ -467,14 +482,24 @@ mod tests {
                 1,
                 Kind::HoldingRegister,
                 20,
-                Format::U128((Endian::Big, Resolution(1.0), BitField::default())), // width 8 -> 20..28
+                Format::U128((
+                    Endian::Big,
+                    WordOrder::Normal,
+                    Resolution(1.0),
+                    BitField::default(),
+                )), // width 8 -> 20..28
                 Access::ReadWrite,
             ),
             entry(
                 1,
                 Kind::HoldingRegister,
                 30,
-                Format::U16((Endian::Big, Resolution(1.0), BitField::default())), // 30..31
+                Format::U16((
+                    Endian::Big,
+                    WordOrder::Normal,
+                    Resolution(1.0),
+                    BitField::default(),
+                )), // 30..31
                 Access::ReadWrite,
             ),
         ];
@@ -592,6 +617,7 @@ mod tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use ferrowl_codec::{
     Address, Format, Kind, Register, RegisterBuilder,
-    format::{BitField, Endian, Resolution, Width},
+    format::{BitField, Endian, Resolution, Width, WordOrder},
 };
 use ferrowl_store::{CellType, Range};
 use ferrowl_ui::traits::ToLabel;
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use crate::config::script::ScriptDef;
 
 mod value_types;
-pub use value_types::{AccessCfg, AlignmentCfg, EndianCfg, Scalar, ValueType, parse_bitmask};
+pub use value_types::{
+    AccessCfg, AlignmentCfg, EndianCfg, Scalar, ValueType, WordOrderCfg, parse_bitmask,
+};
 
 /// Fallback timing (ms) when neither the module spec nor the device config sets a value.
 pub const DEFAULT_TIMEOUT_MS: usize = 3000;
@@ -179,6 +181,11 @@ pub struct RegisterDef {
     pub value_type: ValueType,
     #[serde(default)]
     pub endian: EndianCfg,
+    /// Register (word) order for multi-register numeric types, independent of `endian`.
+    /// Defaults to `Normal`; `Reversed` reverses the word sequence. Inert for
+    /// single-register and ASCII types.
+    #[serde(default)]
+    pub word_order: WordOrderCfg,
     #[serde(default = "default_resolution")]
     pub resolution: f64,
     /// Optional bit-field mask for integer types, as a hex (`"0xFF00"`) or decimal
@@ -252,20 +259,21 @@ impl RegisterDef {
     pub fn format(&self) -> Format {
         let res = Resolution(self.resolution);
         let endian: Endian = self.endian.into();
+        let wo: WordOrder = self.word_order.into();
         let bf = self.bitfield();
         match self.value_type {
-            ValueType::U8 => Format::U8((endian, res, bf)),
-            ValueType::U16 => Format::U16((endian, res, bf)),
-            ValueType::U32 => Format::U32((endian, res, bf)),
-            ValueType::U64 => Format::U64((endian, res, bf)),
-            ValueType::U128 => Format::U128((endian, res, bf)),
-            ValueType::I8 => Format::I8((endian, res, bf)),
-            ValueType::I16 => Format::I16((endian, res, bf)),
-            ValueType::I32 => Format::I32((endian, res, bf)),
-            ValueType::I64 => Format::I64((endian, res, bf)),
-            ValueType::I128 => Format::I128((endian, res, bf)),
-            ValueType::F32 => Format::F32((endian, res)),
-            ValueType::F64 => Format::F64((endian, res)),
+            ValueType::U8 => Format::U8((endian, wo, res, bf)),
+            ValueType::U16 => Format::U16((endian, wo, res, bf)),
+            ValueType::U32 => Format::U32((endian, wo, res, bf)),
+            ValueType::U64 => Format::U64((endian, wo, res, bf)),
+            ValueType::U128 => Format::U128((endian, wo, res, bf)),
+            ValueType::I8 => Format::I8((endian, wo, res, bf)),
+            ValueType::I16 => Format::I16((endian, wo, res, bf)),
+            ValueType::I32 => Format::I32((endian, wo, res, bf)),
+            ValueType::I64 => Format::I64((endian, wo, res, bf)),
+            ValueType::I128 => Format::I128((endian, wo, res, bf)),
+            ValueType::F32 => Format::F32((endian, wo, res)),
+            ValueType::F64 => Format::F64((endian, wo, res)),
             ValueType::Ascii => Format::Ascii((self.alignment.into(), Width(self.length))),
         }
     }
@@ -316,6 +324,7 @@ mod tests {
                 access: AccessCfg::ReadWrite,
                 value_type: ValueType::U16,
                 endian: EndianCfg::Big,
+                word_order: WordOrderCfg::default(),
                 resolution: 1.0,
                 bitmask: None,
                 length: 1,
@@ -336,6 +345,7 @@ mod tests {
                 access: AccessCfg::ReadWrite,
                 value_type: ValueType::I16,
                 endian: EndianCfg::Big,
+                word_order: WordOrderCfg::default(),
                 resolution: 1.0,
                 bitmask: None,
                 length: 1,
@@ -546,6 +556,7 @@ mod tests {
             access: AccessCfg::ReadWrite,
             value_type,
             endian: EndianCfg::Little,
+            word_order: WordOrderCfg::default(),
             resolution: 1.0,
             bitmask: None,
             length: 4,

--- a/ferrowl/src/module/modbus/config/device/value_types.rs
+++ b/ferrowl/src/module/modbus/config/device/value_types.rs
@@ -4,7 +4,7 @@
 
 use ferrowl_codec::{
     Access,
-    format::{Alignment, BitField, Endian, Resolution},
+    format::{Alignment, BitField, Endian, Resolution, WordOrder},
 };
 use serde::{Deserialize, Serialize};
 
@@ -154,6 +154,15 @@ pub enum EndianCfg {
     Little,
 }
 
+/// Config-file spelling of register (word) order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub enum WordOrderCfg {
+    #[default]
+    Normal,
+    Reversed,
+}
+
 /// Config-file spelling of ASCII alignment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
@@ -193,6 +202,15 @@ impl From<EndianCfg> for Endian {
         match e {
             EndianCfg::Big => Endian::Big,
             EndianCfg::Little => Endian::Little,
+        }
+    }
+}
+
+impl From<WordOrderCfg> for WordOrder {
+    fn from(w: WordOrderCfg) -> Self {
+        match w {
+            WordOrderCfg::Normal => WordOrder::Normal,
+            WordOrderCfg::Reversed => WordOrder::Reversed,
         }
     }
 }

--- a/ferrowl/src/module/modbus/dialog/input/build.rs
+++ b/ferrowl/src/module/modbus/dialog/input/build.rs
@@ -52,6 +52,11 @@ impl EditInputDialog {
                 widgets::endian_options(),
                 0,
             ))
+            .number_word_order(widgets::selection(
+                ("Order", HorizontalAlignment::Center),
+                widgets::word_order_options(),
+                0,
+            ))
             .number_resolution(widgets::input_filled::<f64>(
                 ("Resolution", HorizontalAlignment::Center),
                 "1.0",

--- a/ferrowl/src/module/modbus/dialog/input/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/input/mod.rs
@@ -1,12 +1,15 @@
 //! Free-text register edit dialog: every register property as an input field.
 
-use super::{AccessOption, Alignment, Endian, Format, KindOption, ValueType, parse_address};
+use super::{
+    AccessOption, Alignment, Endian, Format, KindOption, ValueType, WordOrder, parse_address,
+};
 use crate::config::device::{NamedValue, Scalar};
 use crate::dialog::NonEmpty;
 use crate::dialog::close_confirm::{CloseConfirmDialog, CloseConfirmEvent};
 use derive_builder::Builder;
 use ferrowl_codec::format::{
     BitField, Endian as RegisterEndian, Format as RegisterFormat, Resolution, Width,
+    WordOrder as RegisterWordOrder,
 };
 use ferrowl_codec::{Address, Kind, Register, RegisterBuilder, encode};
 use ferrowl_ui::{
@@ -53,6 +56,9 @@ pub struct EditInputDialog {
     // Number endianess selection
     #[focus(when = { !self.is_boolean_kind() && self.value_type.get_value() == ValueType::Number })]
     pub number_endian: Widget<SelectionState<Endian>, Selection<Endian>>,
+    // Register (word) order selection (only for multi-register numeric formats)
+    #[focus(when = { !self.is_boolean_kind() && self.value_type.get_value() == ValueType::Number && is_multi_register_format(&self.number_format.get_value().0) })]
+    pub number_word_order: Widget<SelectionState<WordOrder>, Selection<WordOrder>>,
     // Number resolution input
     #[focus(when = { !self.is_boolean_kind() && self.value_type.get_value() == ValueType::Number })]
     pub number_resolution: Widget<InputFieldState, InputField<f64>>,
@@ -241,7 +247,7 @@ impl EditInputDialog {
                 set_input(&mut dialog.text_width, &width.0.to_string());
             }
             numeric => {
-                let (endian, resolution, bitfield) = numeric_parts(numeric);
+                let (endian, word_order, resolution, bitfield) = numeric_parts(numeric);
                 dialog.value_type.state.set_selection(0);
                 dialog
                     .number_format
@@ -251,6 +257,10 @@ impl EditInputDialog {
                     .number_endian
                     .state
                     .set_selection(endian_index(&endian));
+                dialog
+                    .number_word_order
+                    .state
+                    .set_selection(word_order_index(&word_order));
                 set_input(&mut dialog.number_resolution, &resolution.0.to_string());
                 // Show the mask only when it actually selects a sub-field.
                 if !bitfield.is_full() {
@@ -272,12 +282,18 @@ impl EditInputDialog {
         let address = parse_address(self.address.state.input())?;
 
         let format = if self.is_boolean_kind() {
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default()))
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            ))
         } else {
             match self.value_type.state.get_value() {
                 ValueType::Number => {
                     let selected = self.number_format.state.get_value();
                     let endian = self.number_endian.state.get_value().0;
+                    let word_order = self.number_word_order.state.get_value().0;
                     let resolution = Resolution(
                         self.number_resolution
                             .state
@@ -293,7 +309,7 @@ impl EditInputDialog {
                     } else {
                         BitField::default()
                     };
-                    with_numeric_parts(&selected.0, endian, resolution, bitfield)
+                    with_numeric_parts(&selected.0, endian, word_order, resolution, bitfield)
                 }
                 ValueType::Text => {
                     let alignment = self.text_alignment.state.get_value().0;
@@ -394,6 +410,7 @@ impl EditInputDialog {
         d.value_type.state = self.value_type.state.clone();
         d.number_format.state = self.number_format.state.clone();
         d.number_endian.state = self.number_endian.state.clone();
+        d.number_word_order.state = self.number_word_order.state.clone();
         d.number_resolution.state = self.number_resolution.state.clone();
         d.number_bitmask.state = self.number_bitmask.state.clone();
         d.text_alignment.state = self.text_alignment.state.clone();
@@ -497,8 +514,8 @@ impl super::RegisterDialog for EditInputDialog {
 
 use super::{
     AddNamedValueDialog, ConfirmDeleteDialog, SubDialogs, access_index, alignment_index,
-    endian_index, format_index, is_integer_format, kind_index, numeric_parts, parse_bitmask,
-    set_input, with_numeric_parts,
+    endian_index, format_index, is_integer_format, is_multi_register_format, kind_index,
+    numeric_parts, parse_bitmask, set_input, with_numeric_parts, word_order_index,
 };
 use crossterm::event::{KeyCode, KeyModifiers};
 use ferrowl_ui::traits::HandleEvents;
@@ -510,7 +527,7 @@ mod apply_tests {
     use super::EditInputDialog;
     use ferrowl_codec::format::{
         Alignment as TextAlignment, BitField, Endian as RegisterEndian, Format as RegisterFormat,
-        Resolution, Width,
+        Resolution, Width, WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
 
@@ -538,7 +555,12 @@ mod apply_tests {
             Access::ReadWrite,
             Address::Fixed(100),
             7,
-            RegisterFormat::U32((RegisterEndian::Big, Resolution(1.0), BitField::default())),
+            RegisterFormat::U32((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
         );
         let edited = EditInputDialog::from_register("temp", "a sensor", &original, "42", None)
             .apply()
@@ -555,13 +577,39 @@ mod apply_tests {
     }
 
     #[test]
+    /// MB-R-099 — a reversed register order is seeded on open and preserved through apply.
+    fn ut_reversed_word_order_round_trips_through_apply() {
+        let original = reg(
+            Kind::HoldingRegister,
+            Access::ReadWrite,
+            Address::Fixed(10),
+            1,
+            RegisterFormat::U32((
+                RegisterEndian::Big,
+                RegisterWordOrder::Reversed,
+                Resolution(1.0),
+                BitField::default(),
+            )),
+        );
+        let edited = EditInputDialog::from_register("w", "", &original, "1", None)
+            .apply()
+            .expect("valid register should apply");
+        assert_eq!(edited.register.format(), original.format());
+    }
+
+    #[test]
     fn ut_virtual_address_and_read_only_round_trip() {
         let original = reg(
             Kind::InputRegister,
             Access::ReadOnly,
             Address::Virtual,
             1,
-            RegisterFormat::U16((RegisterEndian::Little, Resolution(0.5), BitField::default())),
+            RegisterFormat::U16((
+                RegisterEndian::Little,
+                RegisterWordOrder::Normal,
+                Resolution(0.5),
+                BitField::default(),
+            )),
         );
         let edited = EditInputDialog::from_register("v", "", &original, "3", None)
             .apply()
@@ -581,6 +629,7 @@ mod apply_tests {
             1,
             RegisterFormat::U16((
                 RegisterEndian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField { mask: 0xFF00 },
             )),
@@ -613,7 +662,12 @@ mod apply_tests {
             Access::ReadWrite,
             Address::Fixed(1),
             1,
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default())),
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
         );
         let edited = EditInputDialog::from_register("c", "", &original, "1", None)
             .apply()
@@ -622,7 +676,12 @@ mod apply_tests {
         // Boolean kinds (Coil/DiscreteInput) always serialize as a default big-endian U16.
         assert_eq!(
             *edited.register.format(),
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default()))
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default()
+            ))
         );
     }
 
@@ -643,6 +702,7 @@ mod focus_tests {
     use crossterm::event::{KeyCode, KeyModifiers};
     use ferrowl_codec::format::{
         BitField, Endian as RegisterEndian, Format as RegisterFormat, Resolution,
+        WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
     use ferrowl_ui::traits::HandleEvents;
@@ -655,6 +715,7 @@ mod focus_tests {
             .address(Address::Fixed(0))
             .format(RegisterFormat::U32((
                 RegisterEndian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -672,6 +733,7 @@ mod focus_tests {
             .address(Address::Fixed(0))
             .format(RegisterFormat::U16((
                 RegisterEndian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -736,6 +798,36 @@ mod focus_tests {
                 "cycle missing {expected:?}: {seen:?}"
             );
         }
+    }
+
+    #[test]
+    /// MB-R-099 — the register-order pane is in the cycle for a multi-register format (U32)
+    /// but gated off for a single-register one (U16).
+    fn ut_focus_cycle_gates_word_order_on_register_width() {
+        let mut multi = numeric_dialog(); // U32
+        assert!(
+            forward_cycle(&mut multi).contains(&EditInputDialogFocus::NumberWordOrder),
+            "multi-register cycle should visit NumberWordOrder"
+        );
+
+        let single = RegisterBuilder::default()
+            .slave_id(1u8)
+            .access(Access::ReadWrite)
+            .kind(Kind::HoldingRegister)
+            .address(Address::Fixed(0))
+            .format(RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )))
+            .build()
+            .unwrap();
+        let mut single = EditInputDialog::from_register("name", "", &single, "4", None);
+        assert!(
+            !forward_cycle(&mut single).contains(&EditInputDialogFocus::NumberWordOrder),
+            "single-register cycle should skip NumberWordOrder"
+        );
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/dialog/input/render.rs
+++ b/ferrowl/src/module/modbus/dialog/input/render.rs
@@ -1,6 +1,6 @@
 //! Layout and widget rendering for the free-text register edit dialog.
 
-use super::{EditInputDialog, ValueType, is_integer_format};
+use super::{EditInputDialog, ValueType, is_integer_format, is_multi_register_format};
 use ferrowl_ui::COLOR_SCHEME;
 use ferrowl_ui::widgets::GetValue;
 use ratatui::{
@@ -24,7 +24,7 @@ impl EditInputDialog {
         }
 
         let horizontal_layout: [Rect; 3] =
-            Layout::horizontal([Constraint::Min(1), Constraint::Max(70), Constraint::Min(1)])
+            Layout::horizontal([Constraint::Min(1), Constraint::Max(76), Constraint::Min(1)])
                 .areas(area);
 
         let vertical_layout: [Rect; 3] = Layout::vertical([
@@ -139,37 +139,53 @@ impl EditInputDialog {
         if !self.is_boolean_kind() {
             match self.value_type.state.values()[self.value_type.state.selection()] {
                 ValueType::Number => {
-                    // Integer formats get a 4th column for the bitmask; floats keep 3.
+                    // Columns: Format, Endian, [Register order if multi-register],
+                    // Resolution, [Bitmask if integer].
                     let integer = is_integer_format(&self.number_format.get_value().0);
-                    let columns = if integer { 4 } else { 3 };
+                    let multi = is_multi_register_format(&self.number_format.get_value().0);
+                    let columns = 3 + multi as usize + integer as usize;
                     let cells = Layout::horizontal(vec![Constraint::Min(1); columns])
                         .split(vertical_layout[vertical_index]);
 
+                    let mut col = 0;
                     StatefulWidget::render(
                         &self.number_format.widget,
-                        cells[0],
+                        cells[col],
                         buf,
                         &mut self.number_format.state,
                     );
+                    col += 1;
 
                     StatefulWidget::render(
                         &self.number_endian.widget,
-                        cells[1],
+                        cells[col],
                         buf,
                         &mut self.number_endian.state,
                     );
+                    col += 1;
+
+                    if multi {
+                        StatefulWidget::render(
+                            &self.number_word_order.widget,
+                            cells[col],
+                            buf,
+                            &mut self.number_word_order.state,
+                        );
+                        col += 1;
+                    }
 
                     StatefulWidget::render(
                         &self.number_resolution.widget,
-                        cells[2],
+                        cells[col],
                         buf,
                         &mut self.number_resolution.state,
                     );
+                    col += 1;
 
                     if integer {
                         StatefulWidget::render(
                             &self.number_bitmask.widget,
-                            cells[3],
+                            cells[col],
                             buf,
                             &mut self.number_bitmask.state,
                         );
@@ -298,7 +314,9 @@ mod render_tests {
     //! Render-to-buffer characterization: the dialog draws its box title, fields, and
     //! validation-error text without panicking, in both Add and Edit configurations.
     use super::EditInputDialog;
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{
+        BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
+    };
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
@@ -347,6 +365,7 @@ mod render_tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/module/modbus/dialog/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/mod.rs
@@ -17,7 +17,7 @@ pub use subdialog::*;
 
 use ferrowl_codec::format::{
     Alignment as TextAlignment, BitField, Endian as RegisterEndian, Format as RegisterFormat,
-    Resolution,
+    Resolution, WordOrder as RegisterWordOrder,
 };
 use ferrowl_codec::{Access, Address, Kind};
 
@@ -73,6 +73,19 @@ impl ToLabel for Endian {
         match self.0 {
             RegisterEndian::Big => "Big",
             RegisterEndian::Little => "Little",
+        }
+        .to_string()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WordOrder(RegisterWordOrder);
+
+impl ToLabel for WordOrder {
+    fn to_label(&self) -> String {
+        match self.0 {
+            RegisterWordOrder::Normal => "Normal",
+            RegisterWordOrder::Reversed => "Reversed",
         }
         .to_string()
     }
@@ -178,6 +191,13 @@ pub(super) fn endian_index(endian: &RegisterEndian) -> usize {
     }
 }
 
+pub(super) fn word_order_index(word_order: &RegisterWordOrder) -> usize {
+    match word_order {
+        RegisterWordOrder::Normal => 0,
+        RegisterWordOrder::Reversed => 1,
+    }
+}
+
 /// Index into the `number_format` selection (order matches dialog `new()`).
 ///
 /// `RegisterFormat::Ascii` has no slot in `number_format` (ASCII is a distinct `value_type`, not a
@@ -204,22 +224,29 @@ pub(super) fn format_index(format: &RegisterFormat) -> usize {
     }
 }
 
-pub(super) fn numeric_parts(format: &RegisterFormat) -> (RegisterEndian, Resolution, BitField) {
+pub(super) fn numeric_parts(
+    format: &RegisterFormat,
+) -> (RegisterEndian, RegisterWordOrder, Resolution, BitField) {
     match format {
-        RegisterFormat::U8((e, r, bf))
-        | RegisterFormat::U16((e, r, bf))
-        | RegisterFormat::U32((e, r, bf))
-        | RegisterFormat::U64((e, r, bf))
-        | RegisterFormat::U128((e, r, bf))
-        | RegisterFormat::I8((e, r, bf))
-        | RegisterFormat::I16((e, r, bf))
-        | RegisterFormat::I32((e, r, bf))
-        | RegisterFormat::I64((e, r, bf))
-        | RegisterFormat::I128((e, r, bf)) => (e.clone(), r.clone(), bf.clone()),
-        RegisterFormat::F32((e, r)) | RegisterFormat::F64((e, r)) => {
-            (e.clone(), r.clone(), BitField::default())
+        RegisterFormat::U8((e, w, r, bf))
+        | RegisterFormat::U16((e, w, r, bf))
+        | RegisterFormat::U32((e, w, r, bf))
+        | RegisterFormat::U64((e, w, r, bf))
+        | RegisterFormat::U128((e, w, r, bf))
+        | RegisterFormat::I8((e, w, r, bf))
+        | RegisterFormat::I16((e, w, r, bf))
+        | RegisterFormat::I32((e, w, r, bf))
+        | RegisterFormat::I64((e, w, r, bf))
+        | RegisterFormat::I128((e, w, r, bf)) => (e.clone(), *w, r.clone(), bf.clone()),
+        RegisterFormat::F32((e, w, r)) | RegisterFormat::F64((e, w, r)) => {
+            (e.clone(), *w, r.clone(), BitField::default())
         }
-        RegisterFormat::Ascii(_) => (RegisterEndian::Big, Resolution(1.0), BitField::default()),
+        RegisterFormat::Ascii(_) => (
+            RegisterEndian::Big,
+            RegisterWordOrder::Normal,
+            Resolution(1.0),
+            BitField::default(),
+        ),
     }
 }
 
@@ -241,6 +268,12 @@ pub(super) fn is_integer_format(format: &RegisterFormat) -> bool {
     )
 }
 
+/// Whether `format` occupies more than one register (`width > 1`). Used to gate
+/// the register-order selector, which is inert for single-register formats.
+pub(super) fn is_multi_register_format(format: &RegisterFormat) -> bool {
+    format.width() > 1
+}
+
 /// Parse a bitmask input field (`0x`-prefixed hex or decimal). Empty ⇒ the full
 /// no-op mask. Returns a user-facing error string on a malformed value.
 pub(super) fn parse_bitmask(s: &str) -> Result<BitField, String> {
@@ -258,15 +291,17 @@ pub(super) fn parse_bitmask(s: &str) -> Result<BitField, String> {
 }
 
 /// Rebuild a numeric format of the same variant as `format` with the given
-/// endian/resolution. Integer variants also carry `bitfield`; floats ignore it.
+/// endian/register-order/resolution. Integer variants also carry `bitfield`;
+/// floats ignore it. Register order is inert for single-register variants.
 pub(super) fn with_numeric_parts(
     format: &RegisterFormat,
     endian: RegisterEndian,
+    word_order: RegisterWordOrder,
     resolution: Resolution,
     bitfield: BitField,
 ) -> RegisterFormat {
-    let int = (endian.clone(), resolution.clone(), bitfield);
-    let float = (endian, resolution);
+    let int = (endian.clone(), word_order, resolution.clone(), bitfield);
+    let float = (endian, word_order, resolution);
     match format {
         RegisterFormat::U8(_) => RegisterFormat::U8(int),
         RegisterFormat::U16(_) => RegisterFormat::U16(int),
@@ -322,19 +357,37 @@ mod helper_tests {
         let r = Resolution(1.0);
         let e = RegisterEndian::Big;
         assert_eq!(
-            format_index(&RegisterFormat::U8((e.clone(), r.clone(), bf.clone()))),
+            format_index(&RegisterFormat::U8((
+                e.clone(),
+                RegisterWordOrder::Normal,
+                r.clone(),
+                bf.clone()
+            ))),
             0
         );
         assert_eq!(
-            format_index(&RegisterFormat::I128((e.clone(), r.clone(), bf.clone()))),
+            format_index(&RegisterFormat::I128((
+                e.clone(),
+                RegisterWordOrder::Normal,
+                r.clone(),
+                bf.clone()
+            ))),
             9
         );
         assert_eq!(
-            format_index(&RegisterFormat::F32((e.clone(), r.clone()))),
+            format_index(&RegisterFormat::F32((
+                e.clone(),
+                RegisterWordOrder::Normal,
+                r.clone()
+            ))),
             10
         );
         assert_eq!(
-            format_index(&RegisterFormat::F64((e.clone(), r.clone()))),
+            format_index(&RegisterFormat::F64((
+                e.clone(),
+                RegisterWordOrder::Normal,
+                r.clone()
+            ))),
             11
         );
         // ASCII has no number-format slot and maps to index 0.
@@ -354,16 +407,19 @@ mod helper_tests {
         let e = RegisterEndian::Big;
         assert!(is_integer_format(&RegisterFormat::U16((
             e.clone(),
+            RegisterWordOrder::Normal,
             r.clone(),
             bf.clone()
         ))));
         assert!(is_integer_format(&RegisterFormat::I64((
             e.clone(),
+            RegisterWordOrder::Normal,
             r.clone(),
             bf.clone()
         ))));
         assert!(!is_integer_format(&RegisterFormat::F32((
             e.clone(),
+            RegisterWordOrder::Normal,
             r.clone()
         ))));
         assert!(!is_integer_format(&RegisterFormat::Ascii((
@@ -385,32 +441,48 @@ mod helper_tests {
 
     #[test]
     fn ut_with_numeric_parts_preserves_variant_and_applies_fields() {
-        let src = RegisterFormat::U32((RegisterEndian::Big, Resolution(1.0), BitField::default()));
+        let src = RegisterFormat::U32((
+            RegisterEndian::Big,
+            RegisterWordOrder::Normal,
+            Resolution(1.0),
+            BitField::default(),
+        ));
         let rebuilt = with_numeric_parts(
             &src,
             RegisterEndian::Little,
+            RegisterWordOrder::Reversed,
             Resolution(0.25),
             BitField { mask: 0x0F0F },
         );
-        // Same variant (U32), new endian/resolution/bitfield.
+        // Same variant (U32), new endian/word order/resolution/bitfield.
         assert_eq!(
             rebuilt,
             RegisterFormat::U32((
                 RegisterEndian::Little,
+                RegisterWordOrder::Reversed,
                 Resolution(0.25),
                 BitField { mask: 0x0F0F }
             ))
         );
         // Floats ignore the supplied bitfield.
         let float = with_numeric_parts(
-            &RegisterFormat::F32((RegisterEndian::Big, Resolution(1.0))),
+            &RegisterFormat::F32((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+            )),
             RegisterEndian::Little,
+            RegisterWordOrder::Reversed,
             Resolution(2.0),
             BitField { mask: 0x1234 },
         );
         assert_eq!(
             float,
-            RegisterFormat::F32((RegisterEndian::Little, Resolution(2.0)))
+            RegisterFormat::F32((
+                RegisterEndian::Little,
+                RegisterWordOrder::Reversed,
+                Resolution(2.0)
+            ))
         );
     }
 }

--- a/ferrowl/src/module/modbus/dialog/selection/build.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/build.rs
@@ -48,6 +48,11 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
                 widgets::endian_options(),
                 0,
             ))
+            .number_word_order(widgets::selection(
+                ("Order", HorizontalAlignment::Center),
+                widgets::word_order_options(),
+                0,
+            ))
             .number_resolution(widgets::input_filled::<f64>(
                 ("Resolution", HorizontalAlignment::Right),
                 "1.0",

--- a/ferrowl/src/module/modbus/dialog/selection/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/mod.rs
@@ -3,9 +3,9 @@
 
 use super::{
     AccessOption, AddNamedValueDialog, Alignment, ConfirmDeleteDialog, Endian, Format, KindOption,
-    SubDialogs, ValueType, access_index, alignment_index, endian_index, format_index,
-    is_integer_format, kind_index, numeric_parts, parse_address, parse_bitmask, set_input,
-    with_numeric_parts,
+    SubDialogs, ValueType, WordOrder, access_index, alignment_index, endian_index, format_index,
+    is_integer_format, is_multi_register_format, kind_index, numeric_parts, parse_address,
+    parse_bitmask, set_input, with_numeric_parts, word_order_index,
 };
 use crate::config::device::{NamedValue, Scalar};
 use crate::dialog::EditedRegister;
@@ -105,6 +105,9 @@ where
     // Number endianess selection
     #[focus(when = {self.value_type.get_value() == ValueType::Number})]
     pub number_endian: Widget<SelectionState<Endian>, Selection<Endian>>,
+    // Register (word) order selection (only for multi-register numeric formats)
+    #[focus(when = {self.value_type.get_value() == ValueType::Number && is_multi_register_format(&self.number_format.get_value().0)})]
+    pub number_word_order: Widget<SelectionState<WordOrder>, Selection<WordOrder>>,
     // Number resolution input
     #[focus(when = {self.value_type.get_value() == ValueType::Number})]
     pub number_resolution: Widget<InputFieldState, InputField<f64>>,
@@ -251,7 +254,7 @@ impl EditSelectionDialog<NamedValue> {
                 set_input(&mut dialog.text_width, &width.0.to_string());
             }
             numeric => {
-                let (endian, resolution, bitfield) = numeric_parts(numeric);
+                let (endian, word_order, resolution, bitfield) = numeric_parts(numeric);
                 dialog.value_type.state.set_selection(0);
                 dialog
                     .number_format
@@ -261,6 +264,10 @@ impl EditSelectionDialog<NamedValue> {
                     .number_endian
                     .state
                     .set_selection(endian_index(&endian));
+                dialog
+                    .number_word_order
+                    .state
+                    .set_selection(word_order_index(&word_order));
                 set_input(&mut dialog.number_resolution, &resolution.0.to_string());
                 // Show the mask only when it actually selects a sub-field.
                 if !bitfield.is_full() {
@@ -297,6 +304,7 @@ impl EditSelectionDialog<NamedValue> {
             ValueType::Number => {
                 let selected = self.number_format.state.get_value();
                 let endian = self.number_endian.state.get_value().0;
+                let word_order = self.number_word_order.state.get_value().0;
                 let resolution = Resolution(
                     self.number_resolution
                         .state
@@ -312,7 +320,7 @@ impl EditSelectionDialog<NamedValue> {
                 } else {
                     BitField::default()
                 };
-                with_numeric_parts(&selected.0, endian, resolution, bitfield)
+                with_numeric_parts(&selected.0, endian, word_order, resolution, bitfield)
             }
             ValueType::Text => {
                 let alignment = self.text_alignment.state.get_value().0;
@@ -403,6 +411,7 @@ impl EditSelectionDialog<NamedValue> {
         d.value_type.state = self.value_type.state.clone();
         d.number_format.state = self.number_format.state.clone();
         d.number_endian.state = self.number_endian.state.clone();
+        d.number_word_order.state = self.number_word_order.state.clone();
         d.number_resolution.state = self.number_resolution.state.clone();
         d.number_bitmask.state = self.number_bitmask.state.clone();
         d.text_alignment.state = self.text_alignment.state.clone();
@@ -502,6 +511,7 @@ mod apply_tests {
     use crate::config::device::{NamedValue, Scalar};
     use ferrowl_codec::format::{
         BitField, Endian as RegisterEndian, Format as RegisterFormat, Resolution,
+        WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
 
@@ -534,7 +544,12 @@ mod apply_tests {
         let original = reg(
             Kind::HoldingRegister,
             Address::Fixed(10),
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default())),
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
         );
         let edited = EditSelectionDialog::from_register(
             "state",
@@ -559,7 +574,12 @@ mod apply_tests {
         let original = reg(
             Kind::HoldingRegister,
             Address::Fixed(0),
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default())),
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
         );
         let dialog = EditSelectionDialog::from_register(
             "s",
@@ -578,7 +598,12 @@ mod apply_tests {
         let original = reg(
             Kind::HoldingRegister,
             Address::Fixed(0),
-            RegisterFormat::U16((RegisterEndian::Big, Resolution(1.0), BitField::default())),
+            RegisterFormat::U16((
+                RegisterEndian::Big,
+                RegisterWordOrder::Normal,
+                Resolution(1.0),
+                BitField::default(),
+            )),
         );
         let mut dialog = EditSelectionDialog::from_register(
             "s",
@@ -613,6 +638,7 @@ mod focus_tests {
     use crate::config::device::{NamedValue, Scalar};
     use ferrowl_codec::format::{
         BitField, Endian as RegisterEndian, Format as RegisterFormat, Resolution,
+        WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
 
@@ -624,6 +650,7 @@ mod focus_tests {
             .address(Address::Fixed(0))
             .format(RegisterFormat::U16((
                 RegisterEndian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -667,7 +694,9 @@ mod default_and_conversion_tests {
     use super::{EditSelectionDialog, EditSelectionDialogFocus};
     use crate::config::device::{NamedValue, Scalar};
     use crossterm::event::{KeyCode, KeyModifiers};
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{
+        BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
+    };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
     use ferrowl_ui::traits::HandleEvents;
 
@@ -679,6 +708,7 @@ mod default_and_conversion_tests {
             .address(Address::Fixed(7))
             .format(Format::U16((
                 Endian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/module/modbus/dialog/selection/render.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/render.rs
@@ -1,6 +1,6 @@
 //! Layout and widget rendering for the selection-based register edit dialog.
 
-use super::{EditSelectionDialog, ValueType, is_integer_format};
+use super::{EditSelectionDialog, ValueType, is_integer_format, is_multi_register_format};
 use ferrowl_ui::{
     COLOR_SCHEME,
     style::TextStyle,
@@ -24,7 +24,7 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
         }
 
         let horizontal_layout: [Rect; 3] =
-            Layout::horizontal([Constraint::Min(1), Constraint::Max(70), Constraint::Min(1)])
+            Layout::horizontal([Constraint::Min(1), Constraint::Max(76), Constraint::Min(1)])
                 .areas(area);
 
         let vertical_layout: [Rect; 3] = Layout::vertical([
@@ -128,37 +128,53 @@ impl<V: ToLabel + Clone> EditSelectionDialog<V> {
 
         match self.value_type.state.values()[self.value_type.state.selection()] {
             ValueType::Number => {
-                // Integer formats get a 4th column for the bitmask; floats keep 3.
+                // Columns: Format, Endian, [Register order if multi-register],
+                // Resolution, [Bitmask if integer].
                 let integer = is_integer_format(&self.number_format.get_value().0);
-                let columns = if integer { 4 } else { 3 };
+                let multi = is_multi_register_format(&self.number_format.get_value().0);
+                let columns = 3 + multi as usize + integer as usize;
                 let cells = Layout::horizontal(vec![Constraint::Min(1); columns])
                     .split(vertical_layout[vertical_index]);
 
+                let mut col = 0;
                 StatefulWidget::render(
                     &self.number_format.widget,
-                    cells[0],
+                    cells[col],
                     buf,
                     &mut self.number_format.state,
                 );
+                col += 1;
 
                 StatefulWidget::render(
                     &self.number_endian.widget,
-                    cells[1],
+                    cells[col],
                     buf,
                     &mut self.number_endian.state,
                 );
+                col += 1;
+
+                if multi {
+                    StatefulWidget::render(
+                        &self.number_word_order.widget,
+                        cells[col],
+                        buf,
+                        &mut self.number_word_order.state,
+                    );
+                    col += 1;
+                }
 
                 StatefulWidget::render(
                     &self.number_resolution.widget,
-                    cells[2],
+                    cells[col],
                     buf,
                     &mut self.number_resolution.state,
                 );
+                col += 1;
 
                 if integer {
                     StatefulWidget::render(
                         &self.number_bitmask.widget,
-                        cells[3],
+                        cells[col],
                         buf,
                         &mut self.number_bitmask.state,
                     );
@@ -326,7 +342,9 @@ mod render_tests {
     //! and named-value list without panicking, in both Add and Edit configurations.
     use super::EditSelectionDialog;
     use crate::config::device::{NamedValue, Scalar};
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{
+        BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
+    };
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
@@ -373,6 +391,7 @@ mod render_tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                RegisterWordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/module/modbus/dialog/widgets.rs
+++ b/ferrowl/src/module/modbus/dialog/widgets.rs
@@ -7,10 +7,10 @@
 //! through the dialog build code. No user input flows into these builders — user input is
 //! parsed in the dialogs' `validate()`/`apply()` paths and surfaced as dialog error messages.
 
-use super::{AccessOption, Alignment, Endian, Format, KindOption};
+use super::{AccessOption, Alignment, Endian, Format, KindOption, WordOrder};
 use ferrowl_codec::format::{
     Alignment as TextAlignment, BitField, Endian as RegisterEndian, Format as RegisterFormat,
-    Resolution,
+    Resolution, WordOrder as RegisterWordOrder,
 };
 use ferrowl_codec::{Access, Kind};
 use ferrowl_ui::state::ButtonState;
@@ -200,7 +200,14 @@ pub(super) fn access_options() -> Vec<AccessOption> {
 
 /// The numeric format options, in display order.
 pub(super) fn format_options() -> Vec<Format> {
-    let n = || (RegisterEndian::Big, Resolution(1.0), BitField::default());
+    let n = || {
+        (
+            RegisterEndian::Big,
+            RegisterWordOrder::Normal,
+            Resolution(1.0),
+            BitField::default(),
+        )
+    };
     vec![
         Format(RegisterFormat::U8(n())),
         Format(RegisterFormat::U16(n())),
@@ -212,14 +219,30 @@ pub(super) fn format_options() -> Vec<Format> {
         Format(RegisterFormat::I32(n())),
         Format(RegisterFormat::I64(n())),
         Format(RegisterFormat::I128(n())),
-        Format(RegisterFormat::F32((RegisterEndian::Big, Resolution(1.0)))),
-        Format(RegisterFormat::F64((RegisterEndian::Big, Resolution(1.0)))),
+        Format(RegisterFormat::F32((
+            RegisterEndian::Big,
+            RegisterWordOrder::Normal,
+            Resolution(1.0),
+        ))),
+        Format(RegisterFormat::F64((
+            RegisterEndian::Big,
+            RegisterWordOrder::Normal,
+            Resolution(1.0),
+        ))),
     ]
 }
 
 /// The endianness options, in display order.
 pub(super) fn endian_options() -> Vec<Endian> {
     vec![Endian(RegisterEndian::Big), Endian(RegisterEndian::Little)]
+}
+
+/// The register (word) order options, in display order.
+pub(super) fn word_order_options() -> Vec<WordOrder> {
+    vec![
+        WordOrder(RegisterWordOrder::Normal),
+        WordOrder(RegisterWordOrder::Reversed),
+    ]
 }
 
 /// The text-alignment options, in display order.

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -446,7 +446,7 @@ mod tests {
         use crate::config::DeviceConfig;
         use crate::config::device::{
             AccessCfg, AlignmentCfg, EndianCfg, NamedValue, ReadRanges, RegisterDef, Scalar,
-            ValueType,
+            ValueType, WordOrderCfg,
         };
         use std::collections::BTreeMap;
 
@@ -458,6 +458,7 @@ mod tests {
             access: AccessCfg::ReadWrite,
             value_type: ValueType::U16,
             endian: EndianCfg::Big,
+            word_order: WordOrderCfg::default(),
             resolution: 1.0,
             bitmask: None,
             length: 1,
@@ -672,7 +673,7 @@ mod tests {
         use crate::config::DeviceConfig;
         use crate::config::device::{
             AccessCfg, AlignmentCfg, EndianCfg, NamedValue, ReadRanges, RegisterDef, Scalar,
-            ValueType,
+            ValueType, WordOrderCfg,
         };
         use std::collections::BTreeMap;
 
@@ -687,6 +688,7 @@ mod tests {
                 access: AccessCfg::ReadWrite,
                 value_type: ValueType::U16,
                 endian: EndianCfg::Big,
+                word_order: WordOrderCfg::default(),
                 resolution: 1.0,
                 bitmask: None,
                 length: 1,

--- a/ferrowl/src/module/modbus/registers.rs
+++ b/ferrowl/src/module/modbus/registers.rs
@@ -6,7 +6,7 @@ use ferrowl_modbus::{Command, Key, SlaveKey};
 use ferrowl_store::{CellKind as MemKind, CellType, Range};
 
 use crate::config::device::{
-    AccessCfg, AlignmentCfg, EndianCfg, RegisterDef, ValueType as DevValueType,
+    AccessCfg, AlignmentCfg, EndianCfg, RegisterDef, ValueType as DevValueType, WordOrderCfg,
 };
 
 /// Modbus memory type backing a register.
@@ -95,9 +95,10 @@ pub(crate) fn sync_register_def(def: &mut RegisterDef, register: &Register) {
     // Integer formats carry (endian, resolution, bitfield); the bitfield is
     // written back as a hex string (or cleared when it's the full no-op mask).
     macro_rules! integer {
-        ($vt:ident, $e:expr, $r:expr, $bf:expr) => {{
+        ($vt:ident, $e:expr, $w:expr, $r:expr, $bf:expr) => {{
             def.value_type = DevValueType::$vt;
             def.endian = endian_cfg($e);
+            def.word_order = word_order_cfg($w);
             def.resolution = $r.0;
             def.bitmask = if $bf.is_full() {
                 None
@@ -106,28 +107,29 @@ pub(crate) fn sync_register_def(def: &mut RegisterDef, register: &Register) {
             };
         }};
     }
-    // Float formats carry only (endian, resolution); they never have a bitfield.
+    // Float formats carry (endian, word order, resolution); they never have a bitfield.
     macro_rules! float {
-        ($vt:ident, $e:expr, $r:expr) => {{
+        ($vt:ident, $e:expr, $w:expr, $r:expr) => {{
             def.value_type = DevValueType::$vt;
             def.endian = endian_cfg($e);
+            def.word_order = word_order_cfg($w);
             def.resolution = $r.0;
             def.bitmask = None;
         }};
     }
     match register.format() {
-        Format::U8((e, r, bf)) => integer!(U8, e, r, bf),
-        Format::U16((e, r, bf)) => integer!(U16, e, r, bf),
-        Format::U32((e, r, bf)) => integer!(U32, e, r, bf),
-        Format::U64((e, r, bf)) => integer!(U64, e, r, bf),
-        Format::U128((e, r, bf)) => integer!(U128, e, r, bf),
-        Format::I8((e, r, bf)) => integer!(I8, e, r, bf),
-        Format::I16((e, r, bf)) => integer!(I16, e, r, bf),
-        Format::I32((e, r, bf)) => integer!(I32, e, r, bf),
-        Format::I64((e, r, bf)) => integer!(I64, e, r, bf),
-        Format::I128((e, r, bf)) => integer!(I128, e, r, bf),
-        Format::F32((e, r)) => float!(F32, e, r),
-        Format::F64((e, r)) => float!(F64, e, r),
+        Format::U8((e, w, r, bf)) => integer!(U8, e, w, r, bf),
+        Format::U16((e, w, r, bf)) => integer!(U16, e, w, r, bf),
+        Format::U32((e, w, r, bf)) => integer!(U32, e, w, r, bf),
+        Format::U64((e, w, r, bf)) => integer!(U64, e, w, r, bf),
+        Format::U128((e, w, r, bf)) => integer!(U128, e, w, r, bf),
+        Format::I8((e, w, r, bf)) => integer!(I8, e, w, r, bf),
+        Format::I16((e, w, r, bf)) => integer!(I16, e, w, r, bf),
+        Format::I32((e, w, r, bf)) => integer!(I32, e, w, r, bf),
+        Format::I64((e, w, r, bf)) => integer!(I64, e, w, r, bf),
+        Format::I128((e, w, r, bf)) => integer!(I128, e, w, r, bf),
+        Format::F32((e, w, r)) => float!(F32, e, w, r),
+        Format::F64((e, w, r)) => float!(F64, e, w, r),
         Format::Ascii((align, width)) => {
             def.value_type = DevValueType::Ascii;
             def.alignment = match align {
@@ -147,11 +149,18 @@ fn endian_cfg(e: &ferrowl_codec::format::Endian) -> EndianCfg {
     }
 }
 
+fn word_order_cfg(w: &ferrowl_codec::format::WordOrder) -> WordOrderCfg {
+    match w {
+        ferrowl_codec::format::WordOrder::Normal => WordOrderCfg::Normal,
+        ferrowl_codec::format::WordOrder::Reversed => WordOrderCfg::Reversed,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::script::ScriptDef;
-    use ferrowl_codec::format::{BitField, Endian, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Address, Format, RegisterBuilder};
 
     fn reg(kind: Kind, address: Address) -> Register {
@@ -162,6 +171,7 @@ mod tests {
             .address(address)
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -249,6 +259,7 @@ mod tests {
     }
 
     #[test]
+    /// MB-R-099 — sync writes the codec register's order back into the config def.
     fn ut_sync_register_def_writes_back_edited_fields() {
         let mut def = RegisterDef {
             slave_id: 0,
@@ -258,6 +269,7 @@ mod tests {
             access: AccessCfg::ReadOnly,
             value_type: DevValueType::U16,
             endian: EndianCfg::Big,
+            word_order: WordOrderCfg::Normal,
             resolution: 1.0,
             bitmask: None,
             length: 4,
@@ -272,7 +284,11 @@ mod tests {
             .access(Access::WriteOnly)
             .kind(Kind::Coil)
             .address(Address::Virtual)
-            .format(Format::F32((Endian::Little, Resolution(0.5))))
+            .format(Format::F32((
+                Endian::Little,
+                WordOrder::Reversed,
+                Resolution(0.5),
+            )))
             .build()
             .unwrap();
         sync_register_def(&mut def, &register);
@@ -282,6 +298,7 @@ mod tests {
         assert!(def.is_virtual && def.address.is_none());
         assert!(matches!(def.value_type, DevValueType::F32));
         assert!(matches!(def.endian, EndianCfg::Little));
+        assert!(matches!(def.word_order, WordOrderCfg::Reversed));
         assert_eq!(def.resolution, 0.5);
         assert!(def.bitmask.is_none());
     }

--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -288,7 +288,7 @@ impl TableView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
 
     fn definition() -> Definition {
@@ -299,6 +299,7 @@ mod tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -339,6 +340,7 @@ mod tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -1029,7 +1029,7 @@ mod tests {
     use crate::module::modbus::table::Definition;
     use crate::module::view::{CommandResult, ModuleView};
     use crossterm::event::{KeyCode, KeyModifiers};
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder, Value};
     use ferrowl_modbus::{Key, SlaveKey};
     use ferrowl_store::{CellKind, Memory, Range};
@@ -1083,6 +1083,7 @@ mod tests {
             .address(Address::Fixed(0))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -1099,6 +1100,7 @@ mod tests {
             .address(Address::Virtual)
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -1388,7 +1390,7 @@ mod tests {
     fn device_with_defs() -> DeviceConfig {
         use crate::config::device::{
             AccessCfg, AlignmentCfg, EndianCfg, NamedValue, RegisterDef, Scalar,
-            ValueType as CfgValueType,
+            ValueType as CfgValueType, WordOrderCfg,
         };
 
         let base = |address: u16, values: Vec<NamedValue>| RegisterDef {
@@ -1399,6 +1401,7 @@ mod tests {
             access: AccessCfg::ReadWrite,
             value_type: CfgValueType::U16,
             endian: EndianCfg::Big,
+            word_order: WordOrderCfg::default(),
             resolution: 1.0,
             bitmask: None,
             length: 1,

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -62,6 +62,7 @@ impl ModbusModuleView {
             access: crate::config::device::AccessCfg::ReadWrite,
             value_type: crate::config::device::ValueType::U16,
             endian: crate::config::device::EndianCfg::default(),
+            word_order: crate::config::device::WordOrderCfg::default(),
             resolution: 1.0,
             bitmask: None,
             length: 1,
@@ -399,7 +400,7 @@ mod tests {
     use super::*;
     use crate::config::{DeviceConfig, Endpoint, ModuleSpec, Role};
     use crate::module::modbus::dialog::EditedRegister;
-    use ferrowl_codec::format::{BitField, Endian, Format, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
 
     fn spec(role: Role) -> ModuleSpec {
@@ -429,6 +430,7 @@ mod tests {
             .address(Address::Fixed(addr))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))
@@ -444,6 +446,7 @@ mod tests {
             .address(Address::Virtual)
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/registry.rs
+++ b/ferrowl/src/registry.rs
@@ -299,7 +299,7 @@ mod tests {
 
     // --- End-to-end through a real Lua context ----------------------------------
 
-    use ferrowl_codec::format::{BitField, Endian, Resolution};
+    use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Access, Format, Kind, RegisterBuilder};
     use ferrowl_lua::ContextBuilder;
     use ferrowl_lua::module::{ModuleDirModule, ValueType};
@@ -314,6 +314,7 @@ mod tests {
             .address(ferrowl_codec::Address::Fixed(addr))
             .format(Format::U16((
                 Endian::Big,
+                WordOrder::Normal,
                 Resolution(1.0),
                 BitField::default(),
             )))

--- a/ferrowl/src/session/e2e_tests.rs
+++ b/ferrowl/src/session/e2e_tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use parking_lot::RwLock;
 
-use ferrowl_codec::format::{BitField, Endian, Resolution};
+use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
 use ferrowl_codec::{Access, Format, Kind, Register, RegisterBuilder};
 use ferrowl_lua::module::{ModuleDirectory, ModuleHost, ValueType};
 use ferrowl_modbus::{Key, SlaveKey};
@@ -74,6 +74,7 @@ fn holding(addr: u16) -> Register {
         .address(ferrowl_codec::Address::Fixed(addr))
         .format(Format::U16((
             Endian::Big,
+            WordOrder::Normal,
             Resolution(1.0),
             BitField::default(),
         )))


### PR DESCRIPTION
## Background

Modbus values wider than one register (U32, F32, U64, …) span several 16-bit registers. Ferrowl exposed only **byte order** (`endian` = `Big`/`Little`): `Big` is wire order, `Little` fully reverses the byte stream (word order *and* intra-word byte order flip together). That reaches only two of the four layouts real devices use — it cannot express the register-swapped-but-bytes-preserved case, where wire words `0x0102 0x0304` should read as `0x03040102` rather than `0x01020304` (Big) or `0x04030201` (Little).

## Goal

Add a second, independent axis — **register order** (`Normal`/`Reversed`) — orthogonal to byte endianness, yielding all four combinations. Default `Normal` keeps every existing config and both current layouts unchanged.

## Requirement changes

New requirements (`docs/specs/modbus/requirements.md`):

- **MB-R-099** — Every integer and float format shall additionally carry a register order of `Normal` or `Reversed`, independent of its byte order (MB-R-013). The register order shall act on the sequence of the format's 16-bit words: `Normal` leaves them in natural order; `Reversed` reverses the whole word sequence. It shall be applied to the words **before** the byte-order rule on decode and **after** it on encode, so decode and encode remain exact inverses. It shall default to `Normal`, under which behavior is identical to the byte-order rule applied alone.
- **MB-R-100** — For a single-register format (width 1: `U8`, `I8`, `U16`, `I16`), register order shall be a no-op, since reversing a one-word sequence yields the same sequence.

Supporting contract edits: `data-contract.md` §2.2a (4-combination table), `api-contract.md` §6.2 (`word_order` field on `RegisterDef`), `edge-cases.md` (single-register no-op; `word_order` ignored on ASCII).

## How it was resolved

- **Codec** (`ferrowl-codec`): new `WordOrder { Normal, Reversed }` enum; every numeric `Format` variant carries it (`(Endian, WordOrder, Resolution, BitField)` for ints, `(Endian, WordOrder, Resolution)` for floats). Decode reverses the word slice **before** the endian step; encode and `mask_words` reverse **after**, keeping them exact inverses. ASCII unchanged.
- **Config** (`ferrowl`): `WordOrderCfg` (serde PascalCase, `#[serde(default)] = Normal`) on `RegisterDef`, threaded into `format()`; `sync_register_def` writes it back via a `word_order_cfg` helper. Absent field deserializes to `Normal` (backward compatible).
- **TUI**: an **Order** selector beside Endian in both edit dialogs, gated to multi-register numeric formats (width > 1) via `#[focus(when = …)]` — hidden and skipped in the focus cycle for U8/I8/U16/I16 and ASCII (rides UI-R-022). Dialog widened by 6.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check` — all green.
- New tests cite their IDs: `ut_decode_u32_reversed`, `ut_roundtrip_reversed_all_widths`, `ut_word_order_noop_single_register` (MB-R-100), `ut_mask_words_reversed`, `ut_focus_cycle_gates_word_order_on_register_width`, `ut_reversed_word_order_round_trips_through_apply`, sync-writeback (all MB-R-099).
- Manual TUI drive of `--demo` (U32 shows Order, U16 hides it; `Reversed` survives save/load).

Closes #135
