### PR TITLE
Persist charge point boot identity (model/vendor/firmware/serial) via :wd

### DIFF
--- a/docs/specs/ocpp/api-contract.md
+++ b/docs/specs/ocpp/api-contract.md
@@ -186,8 +186,9 @@ as `GenericError`.
 ## 6. Module instance spec (session / `--ocpp`)
 
 One OCPP module instance. This is the per-instance, on-the-wire endpoint; the
-version, role, timeout, security, scripts, connectors, and configuration keys all
-live in the referenced device config (§8), never here.
+version, role, timeout, security, scripts, connectors, configuration keys, and
+(client role) CS boot identity all live in the referenced device config (§8),
+never here.
 
 | Field | Type | Default | Valid values |
 |---|---|---|---|
@@ -237,6 +238,10 @@ than `ws`/`wss` is an error.
 | `connector_rfids` | list of `ConnectorRfids` | empty | **server only**: per-connector accept-lists |
 | `connectors` | list of `ConnectorRef` | empty | **client only**: connector-table seed. Empty = CS-level only. Unbounded |
 | `config` | list of `ConfigKeyDef` | empty | **client only**: persisted configuration/variable key store. Empty = built-in defaults |
+| `model` | optional string | unset | **client only**: CS boot identity model, seeded/written like `connectors`/`config` |
+| `vendor` | optional string | unset | **client only**: CS boot identity vendor |
+| `firmware_version` | optional string | unset | **client only**: CS boot identity firmware version |
+| `serial_number` | optional string | unset | **client only**: CS boot identity serial number |
 | `security` | `OcppSecurityConfig` | all-unset | §9 |
 
 A device config file written before any of these fields existed still loads: every

--- a/docs/specs/ocpp/requirements.md
+++ b/docs/specs/ocpp/requirements.md
@@ -394,8 +394,16 @@ actions and are therefore version-locked.
 
 **OC-R-081** — The session entry shall carry only the instance name, the device
 config path, and the endpoint (scheme, ip, port, path). Version, role, timeout,
-security, scripts, connectors, and configuration keys shall live in the device
-config.
+security, scripts, connectors, configuration keys, and (client role) CS boot
+identity shall live in the device config.
+
+**OC-R-103** — A charging-station (client) device config shall persist the CS
+boot identity (model, vendor, firmware version, serial number) the same way it
+persists connectors and configuration keys: `:wd`/`:write-device` shall write
+the station's current values, and loading the device config shall seed them
+into the CS state, overriding the built-in defaults only when the field is
+present in the file. Absence of a field falls back to its built-in default, so
+a file predating this field still loads.
 
 **OC-R-082** — The connection or listener configuration shall be rebuilt from the
 current module spec on every start, so an edited endpoint or security section

--- a/ferrowl/src/module/ocpp/client/view/backend.rs
+++ b/ferrowl/src/module/ocpp/client/view/backend.rs
@@ -6,7 +6,7 @@ use crate::app::Level;
 use crate::module::ocpp::client::backend::{DEFAULT_HEARTBEAT_SECS, TICKS_PER_SEC};
 use crate::module::ocpp::client::build_client_view;
 use crate::module::ocpp::client::lua_sim::{
-    merge_overrides, run_client_script_once, run_client_sim,
+    ClientFields, merge_overrides, run_client_script_once, run_client_sim,
 };
 use crate::module::ocpp::config::device::{ConfigKeyDef, OcppDeviceConfig};
 use crate::module::ocpp::config::session::OcppRole;
@@ -19,6 +19,15 @@ use super::{
     ClientState, ClientVersion, ClientView, OCPP_CLIENT_COMMAND_SPECS, OcppClientCmd, config_rows,
     conn_rows, msg_row, nv_rows,
 };
+
+/// Read a CS-level string field (boot identity) by its `ClientFields` name, for persisting on
+/// `:wd` (OC-R-103). `None` if the field is missing or not a string.
+fn cs_string_field<S: ClientFields>(s: &S, name: &str) -> Option<String> {
+    match s.cs_get(name) {
+        Some(ferrowl_lua::module::ValueType::String(v)) => Some(v),
+        _ => None,
+    }
+}
 
 impl<V: ClientVersion> ClientView<V> {
     pub(super) fn start_sim(&mut self) {
@@ -109,6 +118,11 @@ impl<V: ClientVersion> ClientView<V> {
                 })
                 .collect()
         });
+        // Persist CS boot identity (OC-R-103).
+        device.model = self.with_state(|s| cs_string_field(s, "Model"));
+        device.vendor = self.with_state(|s| cs_string_field(s, "Vendor"));
+        device.firmware_version = self.with_state(|s| cs_string_field(s, "FirmwareVersion"));
+        device.serial_number = self.with_state(|s| cs_string_field(s, "SerialNumber"));
         match Converter::save(&device, path, ty) {
             Ok(()) => CommandResult::Handled(Some((
                 Level::Info,
@@ -196,6 +210,10 @@ impl<V: ClientVersion> ClientView<V> {
                 device.log_file = self.device.log_file.clone();
                 device.connectors = self.device.connectors.clone();
                 device.config = self.device.config.clone();
+                device.model = self.device.model.clone();
+                device.vendor = self.device.vendor.clone();
+                device.firmware_version = self.device.firmware_version.clone();
+                device.serial_number = self.device.serial_number.clone();
                 if spec.role == OcppRole::Server {
                     if let Err(e) = self.backend.stop().await {
                         self.log.write().await.write(

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -493,6 +493,20 @@ impl<V: ClientVersion> ClientView<V> {
                     .collect();
             });
         }
+        // Seed CS boot identity from the device config (OC-R-103); a field left unset keeps the
+        // built-in default rather than being overwritten with an empty string.
+        with_state_mut(&state, |s| {
+            for (name, value) in [
+                ("Model", &device.model),
+                ("Vendor", &device.vendor),
+                ("FirmwareVersion", &device.firmware_version),
+                ("SerialNumber", &device.serial_number),
+            ] {
+                if let Some(value) = value {
+                    s.cs_set(name, ferrowl_lua::module::ValueType::String(value.clone()));
+                }
+            }
+        });
         let cp = spec.name.clone();
         let (conn_rows, state_rows, config_rows) = with_state(&state, |s| {
             (
@@ -1093,6 +1107,44 @@ mod tests {
         };
         assert!(msg.contains("Saved device config"), "unexpected: {msg}");
         assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    /// OC-R-103 — `:wd` persists CS boot identity, and reloading the written device config seeds
+    /// it back into a fresh view instead of the built-in defaults.
+    async fn ut_write_device_persists_and_reloads_boot_identity() {
+        use crate::module::view::CommandResult;
+        use ferrowl_lua::module::ValueType;
+        use ferrowl_util::convert::{Converter, FileType};
+
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        with_state_mut(&v.state, |s| {
+            s.cs_set("Vendor", ValueType::String("Acme".into()));
+            s.cs_set("Model", ValueType::String("Acme-EVSE".into()));
+        });
+
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-ocpp-client-boot-identity-{}.toml",
+            std::process::id()
+        ));
+        let p = path.to_str().expect("temp path is valid UTF-8").to_string();
+        let CommandResult::Handled(Some(_)) = v.handle_command_impl(&format!("wd {p}")).await
+        else {
+            panic!(":wd must be handled with a message");
+        };
+
+        let device: OcppDeviceConfig =
+            Converter::load(&p, FileType::Toml).expect("reload saved device config");
+        assert_eq!(device.vendor.as_deref(), Some("Acme"));
+        assert_eq!(device.model.as_deref(), Some("Acme-EVSE"));
+
+        let reloaded = ClientView::<V1_6>::new(v.spec.clone(), p.clone(), device);
+        with_state(&reloaded.state, |s| {
+            assert!(matches!(s.cs_get("Vendor"), Some(ValueType::String(v)) if v == "Acme"));
+            assert!(matches!(s.cs_get("Model"), Some(ValueType::String(v)) if v == "Acme-EVSE"));
+        });
+
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -198,6 +198,22 @@ pub struct OcppDeviceConfig {
     /// role (CSMS config is per-connected-station and transient).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub config: Vec<ConfigKeyDef>,
+    /// CS boot identity model, seeded into state on load and written by `:wd` (OC-R-103). Unset =
+    /// keep the built-in default. Ignored for the server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// CS boot identity vendor (OC-R-103). Unset = keep the built-in default. Ignored for the
+    /// server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vendor: Option<String>,
+    /// CS boot identity firmware version (OC-R-103). Unset = keep the built-in default. Ignored
+    /// for the server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
+    /// CS boot identity serial number (OC-R-103). Unset = keep the built-in default. Ignored for
+    /// the server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial_number: Option<String>,
     /// Websocket transport security: Basic Auth and/or TLS/mTLS. Default (all `None`/`false`) is
     /// the pre-existing plain `ws://` behaviour.
     #[serde(default, skip_serializing_if = "OcppSecurityConfig::is_empty")]
@@ -229,6 +245,10 @@ impl OcppDeviceConfig {
             connector_rfids: Vec::new(),
             connectors: Vec::new(),
             config: Vec::new(),
+            model: None,
+            vendor: None,
+            firmware_version: None,
+            serial_number: None,
             security: spec.security.clone(),
         }
     }
@@ -300,6 +320,10 @@ mod tests {
                     readonly: true,
                 },
             ],
+            model: Some("Ferrowl-EVSE-Pro".into()),
+            vendor: Some("Acme".into()),
+            firmware_version: Some("2.3.1".into()),
+            serial_number: Some("SN-0042".into()),
             security: OcppSecurityConfig {
                 username: Some("cp001".into()),
                 password: Some("s3cret".into()),


### PR DESCRIPTION
## Why
Changing model/vendor/firmware version/serial number for an OCPP charging-station (client) in the TUI wasn't persisted by `:wd`/`:write-device`, unlike connectors and configuration keys which already round-trip. Users had to re-enter this on every restart.

## Spec
- Amended **OC-R-081**: device-config-owned fields now explicitly include (client role) CS boot identity.
- Added **OC-R-103**: `:wd` persists model/vendor/firmware_version/serial_number; loading a device config seeds them into CS state, falling back to the built-in default when a field is absent (old files still load).
- `api-contract.md` §6/§8 updated with the four new optional device-config fields.

## How it was resolved
- `OcppDeviceConfig` gains four `Option<String>` fields (`model`, `vendor`, `firmware_version`, `serial_number`), same shape/omit-on-default convention as the rest of the file.
- `ClientView::new` seeds them into CS state on load via the existing `ClientFields::cs_set` bridge (the same generic mechanism already used by the Lua `C_OCPP` bindings) — only overriding a field when the loaded config has it set.
- `save_device_to` (`:wd`) reads them back via `ClientFields::cs_get` and writes them into the saved config, mirroring how connectors/config keys are already persisted.
- The role/version-switch reconcile path in `refresh_impl` carries the fields from `self.device` the same way it already carries `connectors`/`config`.
- No new trait methods needed — the mechanism is generic across 1.6/2.0.1/2.1 since all three route through `ClientFields::cs_get`/`cs_set`.

## Verification
- New test `ut_write_device_persists_and_reloads_boot_identity` (OC-R-103): sets vendor/model, `:wd`s to a temp file, reloads it into a fresh `ClientView`, asserts the values survive instead of falling back to defaults.
- Extended `ut_device_config_roundtrip` (CS-R-004) to cover the four new fields through TOML/JSON.
- `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` all clean.
- Manually verified in the TUI (`--demo`): edited vendor/model, `:wd`, reloaded — confirmed working.

Closes #137