### PR TITLE
Add ICCID, IMSI, and meter identity fields to OCPP 1.6 boot notification

### DIFF
--- a/docs/specs/ocpp/api-contract.md
+++ b/docs/specs/ocpp/api-contract.md
@@ -242,6 +242,10 @@ than `ws`/`wss` is an error.
 | `vendor` | optional string | unset | **client only**: CS boot identity vendor |
 | `firmware_version` | optional string | unset | **client only**: CS boot identity firmware version |
 | `serial_number` | optional string | unset | **client only**: CS boot identity serial number |
+| `iccid` | optional string | unset | **client only, 1.6 only**: SIM ICCID, seeded/written like `model`/`vendor`. Inert for 2.0.1/2.1 |
+| `imsi` | optional string | unset | **client only, 1.6 only**: SIM IMSI |
+| `meter_serial_number` | optional string | unset | **client only, 1.6 only**: installed meter's serial number |
+| `meter_type` | optional string | unset | **client only, 1.6 only**: installed meter's type/model |
 | `security` | `OcppSecurityConfig` | all-unset | §9 |
 
 A device config file written before any of these fields existed still loads: every

--- a/docs/specs/ocpp/data-contract.md
+++ b/docs/specs/ocpp/data-contract.md
@@ -167,6 +167,7 @@ the Lua sim thread.
 | Field | Notes |
 |---|---|
 | model, vendor, firmware version, serial number | boot identity, sent in `BootNotification` |
+| ICCID, IMSI, meter serial number, meter type (1.6 only) | optional identity fields, sent in `BootNotification` only when non-empty; no 2.x equivalent |
 | configuration / variable store | list of `(key, value, readonly)`; answers `GetConfiguration` (1.6) / `GetVariables` (2.x) and is mutated by `ChangeConfiguration` / `SetVariables`. Seeded from the device config, or from the version's built-in defaults when that is empty |
 | heartbeat interval | seconds, taken from the CSMS's `BootNotification` response. Unset until a boot round-trips |
 | reservation | id tag + reservation id of a charge-point-wide reservation |

--- a/docs/specs/ocpp/edge-cases.md
+++ b/docs/specs/ocpp/edge-cases.md
@@ -104,6 +104,7 @@ mistaken for an oversight and silently "fixed".
 | RFID accept-lists all empty | every tag is accepted (open mode) |
 | A tag listed only on connector A, presented at connector B | rejected at B — connector lists are not inherited sideways. But it **does** authorize a connector-less authorization request, which unions every list |
 | Message buffer exceeds 200 messages | the oldest are evicted from memory. Messages are teed to the persistent log file on each refresh tick, so an evicted message is still logged provided it survived until the next tick (see §6.11) |
+| 1.6 ICCID/IMSI/meter serial/meter type left empty | field omitted from `BootNotification` entirely, not sent as an empty string — the wire field requires length ≥ 1 when present |
 
 ---
 

--- a/docs/specs/ocpp/requirements.md
+++ b/docs/specs/ocpp/requirements.md
@@ -405,6 +405,17 @@ into the CS state, overriding the built-in defaults only when the field is
 present in the file. Absence of a field falls back to its built-in default, so
 a file predating this field still loads.
 
+**OC-R-104** — In OCPP 1.6, a CS's charge-point-wide state shall additionally
+carry four optional identity fields: SIM ICCID, SIM IMSI, meter serial number,
+and meter type. Each shall be persisted by `:wd`/`:write-device` and seeded on
+device-config load the same way as the existing boot identity fields
+(OC-R-103), overriding the built-in default (empty/unset) only when the field
+is present in the file. A field left empty shall be omitted from
+`BootNotification` entirely; a field holding a value shall be included under
+its wire name (`iccid`, `imsi`, `meterSerialNumber`, `meterType`). These fields
+shall not apply to OCPP 2.0.1 or 2.1, which have no equivalent
+`BootNotification` fields.
+
 **OC-R-082** — The connection or listener configuration shall be rebuilt from the
 current module spec on every start, so an edited endpoint or security section
 always takes effect on the next start without a stale copy.

--- a/ferrowl/src/module/ocpp/client/v1_6/state.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/state.rs
@@ -75,6 +75,16 @@ pub struct CsState {
     pub vendor: String,
     pub firmware_version: String,
     pub serial_number: String,
+    /// SIM ICCID (OC-R-104). Empty = unset; omitted from `BootNotification` when empty.
+    pub iccid: String,
+    /// SIM IMSI (OC-R-104). Empty = unset; omitted from `BootNotification` when empty.
+    pub imsi: String,
+    /// Installed meter's serial number (OC-R-104). Empty = unset; omitted from
+    /// `BootNotification` when empty.
+    pub meter_serial_number: String,
+    /// Installed meter's type/model (OC-R-104). Empty = unset; omitted from `BootNotification`
+    /// when empty.
+    pub meter_type: String,
     /// idTag of the latest accepted charge-point-wide ReserveNow (`connectorId` 0), cleared on a
     /// matching CancelReservation. Per-connector reservations live on [`ConnectorState`].
     pub reserved_rfid: Option<String>,
@@ -100,6 +110,10 @@ impl Default for CsState {
             vendor: "Ferrowl".to_string(),
             firmware_version: "1.0.0".to_string(),
             serial_number: "FERROWL-0001".to_string(),
+            iccid: String::new(),
+            imsi: String::new(),
+            meter_serial_number: String::new(),
+            meter_type: String::new(),
             reserved_rfid: None,
             reservation_id: None,
             heartbeat_interval_secs: None,
@@ -207,6 +221,10 @@ impl CsState {
                     .map(|id| id.to_string())
                     .unwrap_or_else(|| "—".to_string()),
             ),
+            nv("ICCID", self.iccid.clone()),
+            nv("IMSI", self.imsi.clone()),
+            nv("Meter Serial Number", self.meter_serial_number.clone()),
+            nv("Meter Type", self.meter_type.clone()),
         ]
     }
 
@@ -218,6 +236,10 @@ impl CsState {
             "Vendor" => Vt::String(self.vendor.clone()),
             "FirmwareVersion" => Vt::String(self.firmware_version.clone()),
             "SerialNumber" => Vt::String(self.serial_number.clone()),
+            "Iccid" => Vt::String(self.iccid.clone()),
+            "Imsi" => Vt::String(self.imsi.clone()),
+            "MeterSerialNumber" => Vt::String(self.meter_serial_number.clone()),
+            "MeterType" => Vt::String(self.meter_type.clone()),
             "ReservedRfid" => Vt::String(self.reserved_rfid.clone().unwrap_or_default()),
             "ReservationId" => match self.reservation_id {
                 Some(id) => Vt::Int(id as i128),
@@ -235,6 +257,10 @@ impl CsState {
             ("Vendor", Vt::String(s)) => self.vendor = s,
             ("FirmwareVersion", Vt::String(s)) => self.firmware_version = s,
             ("SerialNumber", Vt::String(s)) => self.serial_number = s,
+            ("Iccid", Vt::String(s)) => self.iccid = s,
+            ("Imsi", Vt::String(s)) => self.imsi = s,
+            ("MeterSerialNumber", Vt::String(s)) => self.meter_serial_number = s,
+            ("MeterType", Vt::String(s)) => self.meter_type = s,
             _ => return false,
         }
         true
@@ -512,6 +538,17 @@ mod tests {
         let mut s = CsState::default();
         assert!(s.cs_set_field("Model", Vt::String("M".into())));
         assert!(matches!(s.cs_get_field("Model"), Some(Vt::String(ref v)) if v == "M"));
+        // OC-R-104 — the four 1.6-only meter/modem identity fields roundtrip the same way.
+        assert!(s.cs_set_field("Iccid", Vt::String("8912".into())));
+        assert!(s.cs_set_field("Imsi", Vt::String("2901".into())));
+        assert!(s.cs_set_field("MeterSerialNumber", Vt::String("MTR-1".into())));
+        assert!(s.cs_set_field("MeterType", Vt::String("MT-X".into())));
+        assert!(matches!(s.cs_get_field("Iccid"), Some(Vt::String(ref v)) if v == "8912"));
+        assert!(matches!(s.cs_get_field("Imsi"), Some(Vt::String(ref v)) if v == "2901"));
+        assert!(
+            matches!(s.cs_get_field("MeterSerialNumber"), Some(Vt::String(ref v)) if v == "MTR-1")
+        );
+        assert!(matches!(s.cs_get_field("MeterType"), Some(Vt::String(ref v)) if v == "MT-X"));
         // Connector fields are not CS-level; they live on ConnectorState.
         assert!(s.cs_get_field("Power").is_none());
         // One default connector; adding is idempotent by id.

--- a/ferrowl/src/module/ocpp/client/v1_6/version.rs
+++ b/ferrowl/src/module/ocpp/client/v1_6/version.rs
@@ -235,6 +235,10 @@ impl ClientVersion for V1_6 {
             EditField::Vendor => EditKind::Text(text_input(&s.vendor)),
             EditField::FirmwareVersion => EditKind::Text(text_input(&s.firmware_version)),
             EditField::SerialNumber => EditKind::Text(text_input(&s.serial_number)),
+            EditField::Iccid => EditKind::Text(text_input(&s.iccid)),
+            EditField::Imsi => EditKind::Text(text_input(&s.imsi)),
+            EditField::MeterSerialNumber => EditKind::Text(text_input(&s.meter_serial_number)),
+            EditField::MeterType => EditKind::Text(text_input(&s.meter_type)),
             // 1.6 has no EVSE id field; the row map never produces it.
             EditField::EvseId => return None,
         })
@@ -285,6 +289,10 @@ impl ClientVersion for V1_6 {
                 EditField::Vendor => s.vendor = value,
                 EditField::FirmwareVersion => s.firmware_version = value,
                 EditField::SerialNumber => s.serial_number = value,
+                EditField::Iccid => s.iccid = value,
+                EditField::Imsi => s.imsi = value,
+                EditField::MeterSerialNumber => s.meter_serial_number = value,
+                EditField::MeterType => s.meter_type = value,
                 _ => {}
             },
         }
@@ -299,12 +307,28 @@ impl ClientVersion for V1_6 {
         let rfid = conn.map(|c| c.rfid.clone()).unwrap_or_default();
         match name {
             "Authorize" => serde_json::json!({ "idTag": rfid }),
-            "BootNotification" => serde_json::json!({
-                "chargePointModel": s.model,
-                "chargePointVendor": s.vendor,
-                "chargePointSerialNumber": s.serial_number,
-                "firmwareVersion": s.firmware_version,
-            }),
+            "BootNotification" => {
+                let mut payload = serde_json::json!({
+                    "chargePointModel": s.model,
+                    "chargePointVendor": s.vendor,
+                    "chargePointSerialNumber": s.serial_number,
+                    "firmwareVersion": s.firmware_version,
+                });
+                // OC-R-104 — optional identity fields are included only when set; the wire field
+                // requires length >= 1 when present, so an empty value must be omitted, not sent
+                // as "".
+                for (key, value) in [
+                    ("iccid", &s.iccid),
+                    ("imsi", &s.imsi),
+                    ("meterSerialNumber", &s.meter_serial_number),
+                    ("meterType", &s.meter_type),
+                ] {
+                    if !value.is_empty() {
+                        payload[key] = serde_json::json!(value);
+                    }
+                }
+                payload
+            }
             "Heartbeat" => serde_json::json!({}),
             "MeterValues" => serde_json::json!({
                 "connectorId": cid,
@@ -519,6 +543,34 @@ mod tests {
         assert_eq!(payload("StartTransaction")["connectorId"], 1);
         assert_eq!(payload("StatusNotification")["errorCode"], "NoError");
         assert_eq!(payload("Unknown"), serde_json::json!({}));
+    }
+
+    #[test]
+    /// OC-R-104 — the four optional meter/modem identity fields are omitted from
+    /// `BootNotification` when unset and included under their wire names when set, and the
+    /// resulting payload still decodes as a valid 1.6 BootNotification request.
+    fn ut_boot_notification_omits_empty_meter_fields() {
+        use ferrowl_ocpp::{V1_6 as Codec, Version};
+
+        let s = state_with(&[1]);
+        let sc = Scope::connector(1);
+        let empty = <V1_6 as ClientVersion>::state_payload(&s, "BootNotification", sc);
+        for key in ["iccid", "imsi", "meterSerialNumber", "meterType"] {
+            assert!(empty.get(key).is_none(), "{key} should be omitted");
+        }
+        assert!(Codec::decode_call("BootNotification", empty).is_ok());
+
+        let mut s = state_with(&[1]);
+        s.iccid = "8912".to_string();
+        s.imsi = "2901".to_string();
+        s.meter_serial_number = "MTR-1".to_string();
+        s.meter_type = "MT-X".to_string();
+        let filled = <V1_6 as ClientVersion>::state_payload(&s, "BootNotification", sc);
+        assert_eq!(filled["iccid"], "8912");
+        assert_eq!(filled["imsi"], "2901");
+        assert_eq!(filled["meterSerialNumber"], "MTR-1");
+        assert_eq!(filled["meterType"], "MT-X");
+        assert!(Codec::decode_call("BootNotification", filled).is_ok());
     }
 
     #[test]

--- a/ferrowl/src/module/ocpp/client/v2_common.rs
+++ b/ferrowl/src/module/ocpp/client/v2_common.rs
@@ -266,6 +266,14 @@ pub(crate) fn edit_kind(s: &CsState, scope: Scope, cs: bool, field: EditField) -
         EditField::Vendor => EditKind::Text(text_input(&s.vendor)),
         EditField::FirmwareVersion => EditKind::Text(text_input(&s.firmware_version)),
         EditField::SerialNumber => EditKind::Text(text_input(&s.serial_number)),
+        // OC-R-104's meter/modem identity fields are 1.6-only; the row map never produces them
+        // for 2.0.1/2.1.
+        EditField::Iccid
+        | EditField::Imsi
+        | EditField::MeterSerialNumber
+        | EditField::MeterType => {
+            return None;
+        }
     })
 }
 

--- a/ferrowl/src/module/ocpp/client/view/backend.rs
+++ b/ferrowl/src/module/ocpp/client/view/backend.rs
@@ -123,6 +123,11 @@ impl<V: ClientVersion> ClientView<V> {
         device.vendor = self.with_state(|s| cs_string_field(s, "Vendor"));
         device.firmware_version = self.with_state(|s| cs_string_field(s, "FirmwareVersion"));
         device.serial_number = self.with_state(|s| cs_string_field(s, "SerialNumber"));
+        // Persist the 1.6-only meter/modem identity fields (OC-R-104); a no-op on 2.0.1/2.1.
+        device.iccid = self.with_state(|s| cs_string_field(s, "Iccid"));
+        device.imsi = self.with_state(|s| cs_string_field(s, "Imsi"));
+        device.meter_serial_number = self.with_state(|s| cs_string_field(s, "MeterSerialNumber"));
+        device.meter_type = self.with_state(|s| cs_string_field(s, "MeterType"));
         match Converter::save(&device, path, ty) {
             Ok(()) => CommandResult::Handled(Some((
                 Level::Info,
@@ -214,6 +219,10 @@ impl<V: ClientVersion> ClientView<V> {
                 device.vendor = self.device.vendor.clone();
                 device.firmware_version = self.device.firmware_version.clone();
                 device.serial_number = self.device.serial_number.clone();
+                device.iccid = self.device.iccid.clone();
+                device.imsi = self.device.imsi.clone();
+                device.meter_serial_number = self.device.meter_serial_number.clone();
+                device.meter_type = self.device.meter_type.clone();
                 if spec.role == OcppRole::Server {
                     if let Err(e) = self.backend.stop().await {
                         self.log.write().await.write(

--- a/ferrowl/src/module/ocpp/client/view/mod.rs
+++ b/ferrowl/src/module/ocpp/client/view/mod.rs
@@ -285,16 +285,27 @@ pub enum EditField {
     Vendor,
     FirmwareVersion,
     SerialNumber,
+    // CS-level, 1.6 only (OC-R-104)
+    Iccid,
+    Imsi,
+    MeterSerialNumber,
+    MeterType,
 }
 
 impl EditField {
-    /// Map a CS-level state-table row (see `CsState::cs_rows`). Reserved RFID (row 4) is read-only.
+    /// Map a CS-level state-table row (see `CsState::cs_rows`). Reserved RFID (row 4) and
+    /// Reservation ID (row 5) are read-only. Rows 6-9 (OC-R-104) exist only on 1.6's state table;
+    /// 2.0.1/2.1 never render that many CS-level rows, so those indices are never queried there.
     pub fn from_cs_row(row: usize) -> Option<EditField> {
         Some(match row {
             0 => EditField::Model,
             1 => EditField::Vendor,
             2 => EditField::FirmwareVersion,
             3 => EditField::SerialNumber,
+            6 => EditField::Iccid,
+            7 => EditField::Imsi,
+            8 => EditField::MeterSerialNumber,
+            9 => EditField::MeterType,
             _ => return None,
         })
     }
@@ -320,6 +331,10 @@ impl EditField {
             EditField::Vendor => "Vendor",
             EditField::FirmwareVersion => "Firmware Version",
             EditField::SerialNumber => "Serial Number",
+            EditField::Iccid => "ICCID",
+            EditField::Imsi => "IMSI",
+            EditField::MeterSerialNumber => "Meter Serial Number",
+            EditField::MeterType => "Meter Type",
         }
     }
 }
@@ -501,6 +516,10 @@ impl<V: ClientVersion> ClientView<V> {
                 ("Vendor", &device.vendor),
                 ("FirmwareVersion", &device.firmware_version),
                 ("SerialNumber", &device.serial_number),
+                ("Iccid", &device.iccid),
+                ("Imsi", &device.imsi),
+                ("MeterSerialNumber", &device.meter_serial_number),
+                ("MeterType", &device.meter_type),
             ] {
                 if let Some(value) = value {
                     s.cs_set(name, ferrowl_lua::module::ValueType::String(value.clone()));
@@ -1143,6 +1162,52 @@ mod tests {
         with_state(&reloaded.state, |s| {
             assert!(matches!(s.cs_get("Vendor"), Some(ValueType::String(v)) if v == "Acme"));
             assert!(matches!(s.cs_get("Model"), Some(ValueType::String(v)) if v == "Acme-EVSE"));
+        });
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    /// OC-R-104 — `:wd` persists the 1.6-only meter/modem identity fields, and reloading the
+    /// written device config seeds them back into a fresh view.
+    async fn ut_write_device_persists_and_reloads_meter_identity() {
+        use crate::module::view::CommandResult;
+        use ferrowl_lua::module::ValueType;
+        use ferrowl_util::convert::{Converter, FileType};
+
+        let mut v = client_view::<V1_6>(OcppVersion::V1_6);
+        with_state_mut(&v.state, |s| {
+            s.cs_set("Iccid", ValueType::String("8912".into()));
+            s.cs_set("Imsi", ValueType::String("2901".into()));
+            s.cs_set("MeterSerialNumber", ValueType::String("MTR-1".into()));
+            s.cs_set("MeterType", ValueType::String("MT-X".into()));
+        });
+
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-ocpp-client-meter-identity-{}.toml",
+            std::process::id()
+        ));
+        let p = path.to_str().expect("temp path is valid UTF-8").to_string();
+        let CommandResult::Handled(Some(_)) = v.handle_command_impl(&format!("wd {p}")).await
+        else {
+            panic!(":wd must be handled with a message");
+        };
+
+        let device: OcppDeviceConfig =
+            Converter::load(&p, FileType::Toml).expect("reload saved device config");
+        assert_eq!(device.iccid.as_deref(), Some("8912"));
+        assert_eq!(device.imsi.as_deref(), Some("2901"));
+        assert_eq!(device.meter_serial_number.as_deref(), Some("MTR-1"));
+        assert_eq!(device.meter_type.as_deref(), Some("MT-X"));
+
+        let reloaded = ClientView::<V1_6>::new(v.spec.clone(), p.clone(), device);
+        with_state(&reloaded.state, |s| {
+            assert!(matches!(s.cs_get("Iccid"), Some(ValueType::String(v)) if v == "8912"));
+            assert!(matches!(s.cs_get("Imsi"), Some(ValueType::String(v)) if v == "2901"));
+            assert!(
+                matches!(s.cs_get("MeterSerialNumber"), Some(ValueType::String(v)) if v == "MTR-1")
+            );
+            assert!(matches!(s.cs_get("MeterType"), Some(ValueType::String(v)) if v == "MT-X"));
         });
 
         let _ = std::fs::remove_file(&path);

--- a/ferrowl/src/module/ocpp/config/device.rs
+++ b/ferrowl/src/module/ocpp/config/device.rs
@@ -214,6 +214,21 @@ pub struct OcppDeviceConfig {
     /// the server role.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub serial_number: Option<String>,
+    /// SIM ICCID (OC-R-104). Unset = keep the built-in default (empty). OCPP 1.6 only; ignored
+    /// for 2.0.1/2.1 and the server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iccid: Option<String>,
+    /// SIM IMSI (OC-R-104). OCPP 1.6 only; ignored for 2.0.1/2.1 and the server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imsi: Option<String>,
+    /// Installed meter's serial number (OC-R-104). OCPP 1.6 only; ignored for 2.0.1/2.1 and the
+    /// server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meter_serial_number: Option<String>,
+    /// Installed meter's type/model (OC-R-104). OCPP 1.6 only; ignored for 2.0.1/2.1 and the
+    /// server role.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meter_type: Option<String>,
     /// Websocket transport security: Basic Auth and/or TLS/mTLS. Default (all `None`/`false`) is
     /// the pre-existing plain `ws://` behaviour.
     #[serde(default, skip_serializing_if = "OcppSecurityConfig::is_empty")]
@@ -249,6 +264,10 @@ impl OcppDeviceConfig {
             vendor: None,
             firmware_version: None,
             serial_number: None,
+            iccid: None,
+            imsi: None,
+            meter_serial_number: None,
+            meter_type: None,
             security: spec.security.clone(),
         }
     }
@@ -324,6 +343,10 @@ mod tests {
             vendor: Some("Acme".into()),
             firmware_version: Some("2.3.1".into()),
             serial_number: Some("SN-0042".into()),
+            iccid: Some("8912345678901234567".into()),
+            imsi: Some("290123456789012".into()),
+            meter_serial_number: Some("MTR-0042".into()),
+            meter_type: Some("MT-X".into()),
             security: OcppSecurityConfig {
                 username: Some("cp001".into()),
                 password: Some("s3cret".into()),


### PR DESCRIPTION
## Why

OCPP 1.6's `BootNotification` request already defines optional identity fields —
`iccid`, `imsi`, `meterSerialNumber`, `meterType` — that ferrowl's Charging Station
simulator never populated or exposed for editing. An operator wanting to report an
installed meter's serial number and model (or SIM card identifiers) as part of boot
identity had no way to do so, unlike model/vendor/firmware version/serial number,
which are already editable and persisted.

OCPP 2.0.1/2.1 have no equivalent fields in `BootNotification` — meter identity there
is reported through the generic Component/Variable device-model mechanism
(`GetVariables`/`SetVariables`), which ferrowl's existing configuration/variable key
store already supports. So this change is scoped to OCPP 1.6 only.

## What changed (spec)

New requirement **OC-R-104** (`docs/specs/ocpp/requirements.md`): in OCPP 1.6, a CS's
charge-point-wide state additionally carries four optional identity fields — SIM
ICCID, SIM IMSI, meter serial number, and meter type — persisted by
`:wd`/`:write-device` and seeded on load the same way as the existing boot identity
(OC-R-103). A field left empty is omitted from `BootNotification` entirely rather than
sent as an empty string, since the wire field requires length ≥ 1 when present. These
fields don't apply to 2.0.1/2.1.

New edge case (`docs/specs/ocpp/edge-cases.md` §5) documenting that omission rule.

## How it was resolved

- `v1_6::CsState` gains the four fields (plain `String`, empty = unset), a `cs_rows()`
  entry each, and `cs_get_field`/`cs_set_field` match arms — all 1.6-only, since 1.6
  and 2.0.1/2.1 use separate `CsState` types with separate `ClientFields` impls.
- The shared `EditField` enum/`from_cs_row` (`client/view/mod.rs`) gains the four new
  variants at CS-table rows 6–9, appended after the existing 6 rows so 2.0.1/2.1's
  row 0–5 mapping (which never renders past row 5) is untouched — guarded by the
  existing `edit_field_cs_rows_align_v2_0_1` test. `v2_common.rs`'s `edit_kind` gets an
  explicit `None` arm for the four new variants, since they're never produced there.
  `v1_6/version.rs`'s `edit_kind`/`apply_edit` wire them up as text fields.
- `v1_6/version.rs`'s `state_payload` includes `iccid`/`imsi`/`meterSerialNumber`/
  `meterType` in the `BootNotification` JSON only when non-empty.
- `OcppDeviceConfig` (`config/device.rs`) gains the four fields as `Option<String>`,
  same style as `model`/`vendor`; `view/backend.rs`'s `save_device_to` and
  `refresh_impl` persist/reconcile them alongside the existing boot-identity fields.

## Verification

- `cargo test --workspace` — all suites green, including two new tests
  (`ut_boot_notification_omits_empty_meter_fields`,
  `ut_write_device_persists_and_reloads_meter_identity`) and the pre-existing
  `edit_field_cs_rows_align_v2_0_1` regression guard.
- `cargo clippy --workspace -- -D warnings` — clean.
- `cargo fmt --check` — clean.

Closes #138.
