### PR TITLE
Build Ferrowl's Modbus support on rust-modbus instead of tokio-modbus

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,7 @@ published independently.
 | `ferrowl-lua-derive` | Proc macro `#[derive(Module)]`, which bridges a Rust host type into a Lua `C_*` module. |
 | `ferrowl-codec` | Register descriptions (slave id, function code, address, access, format) and the codec between raw `u16` words and typed values. |
 | `ferrowl-store` | In-memory model of a Modbus register space — access-checked value cells, shared as `Arc<RwLock<Memory>>`. |
-| `ferrowl-modbus` | Modbus client and server tasks over TCP and RTU, on [tokio-modbus](https://github.com/slowtec/tokio-modbus). |
+| `ferrowl-modbus` | Modbus client and server tasks over TCP and RTU, on [rust-modbus](https://github.com/TumbleOwlee/rust-modbus). |
 | `ferrowl-ocpp` | OCPP transport and engine core: JSON-on-WebSocket framing, connection and correlation, and the version-generic Charging Station / CSMS engine cores (a `Version` trait over 1.6 / 2.0.1 / 2.1), wrapping [rust-ocpp](https://github.com/codelabsab/rust-ocpp). The per-version actions, spec tables, and device state machines live in the `ferrowl` binary. |
 | `ferrowl-lua` | Embedded Lua 5.4 runtime ([mlua](https://github.com/mlua-rs/mlua)) and the `C_*` module framework — the restricted sandbox and the trait shells scripts call. It has no dependency on the Modbus or OCPP crates; the concrete `C_Register` / `C_OCPP` wiring to `ferrowl-store::Memory` and the OCPP state lives in the `ferrowl` binary. |
 | `ferrowl-templates` | The bundled Lua script-template library. A build script walks `templates/<context>/…` and generates the `TEMPLATES` array at compile time; carries its own `TemplateContext`, which the binary maps to its `ScriptContext`. |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,12 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,9 +841,9 @@ dependencies = [
  "derive_builder",
  "getset",
  "itertools 0.15.0",
+ "rust-modbus",
  "serde",
  "thiserror 2.0.19",
- "tokio-modbus",
 ]
 
 [[package]]
@@ -880,12 +874,11 @@ dependencies = [
  "ferrowl-store",
  "itertools 0.15.0",
  "parking_lot",
+ "rust-modbus",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "tokio-modbus",
- "tokio-serial",
 ]
 
 [[package]]
@@ -2266,6 +2259,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-modbus"
+version = "0.1.0"
+source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=2c7b22cc629e409003dacf9ab1a0966211f857e0#2c7b22cc629e409003dacf9ab1a0966211f857e0"
+dependencies = [
+ "crc",
+ "serde",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-serial",
+ "winnow",
+]
+
+[[package]]
 name = "rust-ocpp"
 version = "3.0.4"
 source = "git+https://github.com/TumbleOwlee/rust-ocpp?rev=d9d8364e7d802dacfd8a4bfc479ce89a3210dece#d9d8364e7d802dacfd8a4bfc479ce89a3210dece"
@@ -2870,27 +2876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-modbus"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d06136e737e962c71d922a09148f5a264f6609a021fdf031ad16ffd172c818"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "crc",
- "futures-core",
- "futures-util",
- "log",
- "smallvec",
- "socket2",
- "thiserror 2.0.19",
- "tokio",
- "tokio-serial",
- "tokio-util",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,20 +2914,6 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "libc",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ ratatui = { version = "0.30.0", features = [
 rcgen = "0.14.8"
 # Pinned by rev, not branch: `cargo update` must not silently move us to whatever the fork's
 # `main` points at. Bump the rev deliberately when pulling in upstream changes.
+rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "2c7b22cc629e409003dacf9ab1a0966211f857e0", default-features = false }
 rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "d9d8364e7d802dacfd8a4bfc479ce89a3210dece", default-features = false }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",
@@ -74,9 +75,7 @@ serde_json = "1.0.149"
 syn = "2.0.117"
 thiserror = "2.0"
 tokio = "1.49.0"
-tokio-modbus = "0.17.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
-tokio-serial = "5.4.5"
 tokio-tungstenite = { version = "0.30", default-features = false, features = [
     "connect",
     "handshake",

--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -45,11 +45,14 @@ Registers), nor any other code.
 | 16 | Write Multiple Registers | applied to the store |
 | 23 | Read/Write Multiple Registers | applied to the store, atomically (server-only) |
 
-Explicitly **rejected** with exception `IllegalFunction` (`0x01`):
+Every other code — that is, everything outside 1, 2, 3, 4, 5, 6, 15, 16 and 23 —
+is **rejected** with exception `IllegalFunction` (`0x01`). Among them:
 
 - Report Server Id (17)
 - Mask Write Register (22)
 - Read Device Identification (43 / MEI)
+- Diagnostics (8), Get Comm Event Counter (11), Get Comm Event Log (12)
+- Read File Record (20), Write File Record (21), Read FIFO Queue (24)
 - any custom/user-defined function code
 
 ### 1.3 Exception codes emitted by the server

--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -193,7 +193,7 @@ reversed entries are skipped silently.
 
 | Field | Type | Default | Valid values |
 |---|---|---|---|
-| `slave_id` | u8 | `0` | 0–255 |
+| `slave_id` | u8 | `1` | 0–255 |
 | `kind` | enum | `InputRegister` | `Coil`, `DiscreteInput`, `HoldingRegister`, `InputRegister` |
 | `address` | optional u16 | unset ⇒ virtual | 0–65535 |
 | `virtual` | bool | `false` | `true` forces virtual even with an `address` set |

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -114,12 +114,12 @@ The config is therefore only ever reached through its serde path (session and
 device config files, and the `--module` key/value form), which is unaffected. No
 Modbus RTU flag is exposed as a top-level CLI flag.
 
-### 5.3 The RTU `slave` config field is inert in application use
+### 5.3 The RTU `slave` config field is inert
 
-The RTU config carries a `slave` field (default 1), used to attach the serial
-context to a slave on connect. An application-built RTU client always passes `0`
-for it, because the client re-targets the slave before every single request using
-the slave id carried by the operation or command. The field therefore has no
+The RTU config carries a `slave` field (default 1). It is read by no code path:
+the client carries a slave id on every individual request, taken from the
+operation or command, and never attaches the link to one slave. The field is kept
+only so existing session and device config files keep parsing, and has no
 observable effect on a running module.
 
 An RTU **server** ignores the field entirely: it answers for whichever slave ids

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -61,6 +61,8 @@ mistaken for an oversight and silently "fixed".
 | `interval_ms = 0` | treated as a 1 ms tick, not a busy loop |
 | Ticks missed while a slow request is in flight | the schedule is delayed; no burst of catch-up requests |
 | `delay_ms` | applied on **every** (re)connection, not only the first |
+| Read operation addressed to slave id 0 on RTU | fails locally, never sent; follows the exception-retry path (MB-R-101). On TCP, unit 0 is an ordinary unit and is sent normally |
+| Write command addressed to slave id 0 on RTU | fire-and-forget: written and not awaited, always logged as executed even if no device applied it (MB-R-102) |
 
 ---
 
@@ -71,10 +73,11 @@ mistaken for an oversight and silently "fixed".
 | Read of an address range not declared in the store | exception `IllegalDataAddress` |
 | Write to an address range that is not writable | exception `IllegalDataAddress` |
 | Coil request against register cells, or the reverse | exception `IllegalDataAddress` |
-| Unsupported function code (report-server-id, mask-write-register, read-device-identification, custom) | exception `IllegalFunction`, request logged |
+| Any function code outside the nine of MB-R-058 (report-server-id, mask-write-register, read-device-identification, diagnostics, comm-event, file record, FIFO queue, custom) | exception `IllegalFunction`, request logged |
 | Read/write-multiple-registers whose read range is unreadable or write range is unwritable | exception `IllegalDataAddress`, and **no** write is applied |
 | Read/write-multiple-registers under concurrent load | the read-check, write-check, read and write happen under a single exclusive hold; no request can interleave |
 | Request for a slave id with no declared regions | the store lookup fails → exception `IllegalDataAddress`. The server does not filter by slave id up front |
+| RTU request addressed to slave id 0 | applied to the store, answered with silence — a store failure that would otherwise be an `IllegalDataAddress` exception is invisible to the sender (MB-R-103) |
 | Malformed frame / framing error on the wire | rejected by the protocol layer before it reaches the request handler; the TCP server logs a processing failure and drops the connection, and the accept loop keeps running |
 | TCP client disconnects mid-request | the connection's serve task ends; the accept loop and the store are unaffected |
 | RTU serial port disappears mid-serve | the serve loop ends and the server task ends with an error. There is **no** RTU server reconnect (see §5.4) |

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -18,8 +18,9 @@ behavior, stated limitations).
 **MB-R-001** — A register shall be described by exactly five properties: a slave
 id, an access direction, a register table (kind), an address, and a data format.
 
-**MB-R-002** — Slave id shall be an 8-bit value (0–255). It shall default to 0
-when unspecified.
+**MB-R-002** — Slave id shall be an 8-bit value (0–255). It shall default to 1
+when unspecified, 0 being reserved as the RTU broadcast address (MB-R-101,
+MB-R-103).
 
 **MB-R-003** — A register's address shall be either a fixed 16-bit Modbus address
 (0–65535) or *virtual* (no wire address). It shall default to virtual when
@@ -354,8 +355,8 @@ start, and the error shall be surfaced to the caller rather than retried.
 
 **MB-R-072** — An RTU client shall open the serial port at `path` with the
 configured `baud_rate`, and shall apply `parity`, `data_bits`, and `stop_bits`
-when they are set, leaving the serial library's own default in place when they are
-not.
+when they are set. An unset parameter shall take the Modbus serial-line default —
+8 data bits, even parity, one stop bit.
 
 **MB-R-073** — `data_bits` shall accept exactly 5, 6, 7, or 8; `stop_bits` shall
 accept exactly 1 or 2; `parity` shall accept exactly `even`, `odd`, or `none`,

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -240,6 +240,15 @@ transport.
 shall disconnect the client, end its task with success, and emit a client-
 disconnected status.
 
+**MB-R-101** — On the RTU transport, a poll operation addressed to slave id 0 (the
+broadcast address) shall fail locally without reaching the wire. The client shall
+treat that failure as a Modbus exception per MB-R-043 — retried, then skipped after
+3 consecutive occurrences — and shall not disconnect.
+
+**MB-R-102** — On the RTU transport, a write command addressed to slave id 0 shall
+be transmitted without awaiting a response, logged as executed, and shall not
+disconnect the client.
+
 ---
 
 ## Reconnect
@@ -282,9 +291,11 @@ own.
 holding registers, read input registers, write single coil, write single register,
 write multiple coils, write multiple registers, and read/write multiple registers.
 
-**MB-R-059** — A server shall reject report-server-id, mask-write-register,
-read-device-identification, and any custom function code with the Modbus exception
-`IllegalFunction`.
+**MB-R-059** — A server shall reject every function code other than those of
+MB-R-058 — including report-server-id, mask-write-register,
+read-device-identification, diagnostics, get-comm-event-counter,
+get-comm-event-log, read/write file record, read-FIFO-queue, and any custom
+function code — with the Modbus exception `IllegalFunction`.
 
 **MB-R-060** — A server read whose range is not fully covered by declared regions,
 or whose cells are not readable as the requested cell type, shall be answered with
@@ -310,6 +321,10 @@ exception `IllegalDataAddress` and shall apply no write.
 
 **MB-R-065** — A server shall serve any slave id for which memory regions are
 declared; it shall not filter requests by a configured slave id.
+
+**MB-R-103** — An RTU server shall apply an inbound request addressed to slave id 0
+(the broadcast address) to the store exactly as it would any other request, but
+shall emit no response frame for it — including no exception response.
 
 **MB-R-066** — A server shall log a "request received" line for every inbound
 request, including for rejected function codes.

--- a/ferrowl-codec/Cargo.toml
+++ b/ferrowl-codec/Cargo.toml
@@ -15,4 +15,4 @@ getset = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-tokio-modbus = { workspace = true }
+rust-modbus = { workspace = true, features = ["serde"] }

--- a/ferrowl-codec/src/lib.rs
+++ b/ferrowl-codec/src/lib.rs
@@ -17,8 +17,8 @@ pub mod value;
 
 use derive_builder::Builder;
 use getset::{CopyGetters, Getters, Setters, WithSetters};
+pub use rust_modbus::UnitId;
 use serde::{Deserialize, Serialize};
-use tokio_modbus::SlaveId;
 
 pub use crate::access::Access;
 pub use crate::address::Address;
@@ -41,8 +41,8 @@ pub use crate::value::Value;
 #[getset(set = "pub")]
 pub struct Register {
     #[getset(get = "pub")]
-    #[builder(default = "0")]
-    slave_id: SlaveId,
+    #[builder(default = "UnitId(1)")]
+    slave_id: UnitId,
     #[getset(get = "pub")]
     #[builder(default = "Access::ReadWrite")]
     access: Access,
@@ -104,7 +104,7 @@ impl Register {
 #[cfg(test)]
 mod tests {
     use crate::format::{Endian, Format, Resolution, Width, WordOrder};
-    use crate::{Access, Address, Alignment, BitField, Kind, RegisterBuilder};
+    use crate::{Access, Address, Alignment, BitField, Kind, RegisterBuilder, UnitId};
 
     fn u16_be() -> Format {
         Format::U16((
@@ -119,7 +119,7 @@ mod tests {
     /// MB-R-001 — a register is described by exactly five properties: slave id, access, kind, address, format.
     fn ut_register_carries_five_properties() {
         let r = RegisterBuilder::default()
-            .slave_id(7)
+            .slave_id(UnitId(7))
             .access(Access::ReadOnly)
             .kind(Kind::InputRegister)
             .address(Address::Fixed(100))
@@ -127,7 +127,7 @@ mod tests {
             .build()
             .unwrap();
 
-        assert_eq!(*r.slave_id(), 7);
+        assert_eq!(*r.slave_id(), UnitId(7));
         assert_eq!(*r.access(), Access::ReadOnly);
         assert_eq!(*r.kind(), Kind::InputRegister);
         assert_eq!(*r.address(), Address::Fixed(100));

--- a/ferrowl-codec/tests/codec_roundtrip.rs
+++ b/ferrowl-codec/tests/codec_roundtrip.rs
@@ -4,8 +4,8 @@
 
 use ferrowl_codec::format::{Resolution, Width, WordOrder};
 use ferrowl_codec::{
-    Access, Alignment, BitField, Endian, Format, Kind, RegisterBuilder, Value, decode, encode,
-    encode_value,
+    Access, Alignment, BitField, Endian, Format, Kind, RegisterBuilder, UnitId, Value, decode,
+    encode, encode_value,
 };
 
 fn res() -> Resolution {
@@ -17,14 +17,14 @@ fn int(endian: Endian) -> Format {
 }
 
 #[test]
-/// MB-R-002 — an unspecified slave id defaults to 0 (access defaults to `ReadWrite`, MB-R-005;
+/// MB-R-002 — an unspecified slave id defaults to 1 (access defaults to `ReadWrite`, MB-R-005;
 /// kind defaults to holding register, MB-R-097).
 fn it_register_builder_applies_documented_defaults() {
     let reg = RegisterBuilder::default()
         .format(int(Endian::Big))
         .build()
         .expect("only `format` is required to build a Register");
-    assert_eq!(*reg.slave_id(), 0);
+    assert_eq!(*reg.slave_id(), UnitId(1));
     assert_eq!(*reg.access(), Access::ReadWrite);
     assert_eq!(*reg.kind(), Kind::HoldingRegister);
 }

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -19,12 +19,7 @@ itertools = { workspace = true }
 serde = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-tokio-modbus = { workspace = true, features = [
-    "futures-util",
-    "rtu-server",
-    "tcp-server",
-] }
-tokio-serial = { workspace = true }
+rust-modbus = { workspace = true, features = ["std", "rtu", "serde"] }
 clap = { workspace = true }
 
 [dev-dependencies]

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -30,6 +30,7 @@ clap = { workspace = true }
 # request path is synchronous end-to-end and also passes on a current-thread runtime).
 # `ferrowl-store`/`ferrowl-codec` let that test build and seed memory directly.
 tokio = { workspace = true, features = [
+    "io-util",
     "rt",
     "rt-multi-thread",
     "macros",

--- a/ferrowl-modbus/src/client_core.rs
+++ b/ferrowl-modbus/src/client_core.rs
@@ -1,33 +1,35 @@
 //! Transport-agnostic Modbus client loop shared by the TCP and RTU clients.
 //!
-//! Both transports produce the same concrete `tokio_modbus::client::Context`; only how the
-//! context is *constructed* differs (socket connect vs serial open). Everything after that —
-//! the read/run loop and command execution — is identical and lives here.
+//! The two transports differ only in the stream and framing they instantiate this with (a
+//! socket under `Tcp`, a serial port under `Rtu`) and in how that connection is *established*.
+//! Everything after that — the read/run loop and command execution — is identical and lives
+//! here, generic over both.
 
 use crate::{Command, Error, Key, KeyParams, LogFn, ModbusError, Operation, RunConfig};
 
 use ferrowl_store::Memory;
 use parking_lot::RwLock as MemLock;
+use rust_modbus::{
+    Address, Client, ClientFraming, ExceptionCode, FunctionCode, Quantity, RegisterValue, UnitId,
+};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::sleep;
-use tokio_modbus::FunctionCode;
-use tokio_modbus::client::Context;
-use tokio_modbus::prelude::{Client as ModbusClient, Reader, Slave, SlaveContext, Writer};
 
 /// Outcome of one connection attempt, as reported by a transport's `connect` closure passed to
 /// [`ClientCore::run_reconnect_loop`]. Bundles the just-read config snapshot (`reconnect` plus
 /// the timing fields `run` needs) alongside the connection result itself, since `reconnect` must
 /// be known even when the connect attempt failed.
-pub(crate) struct ConnectAttempt {
+pub(crate) struct ConnectAttempt<S, F> {
     pub(crate) reconnect: bool,
     pub(crate) timeout_ms: usize,
     pub(crate) delay_ms: usize,
     pub(crate) interval_ms: usize,
-    pub(crate) client: Result<ClientCore, Error>,
+    pub(crate) client: Result<ClientCore<S, F>, Error>,
 }
 
 /// Number of consecutive Modbus exceptions tolerated before the client skips the operation.
@@ -38,50 +40,56 @@ pub(crate) const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// Reconnect backoff cap; doubles from [`INITIAL_BACKOFF`] up to this.
 pub(crate) const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
-/// Owns a connected Modbus client context and drives the read/command loop. Transport-neutral:
-/// the TCP and RTU `Client` types each construct the `Context` then hand it here.
-pub(crate) struct ClientCore {
-    pub(crate) context: Context,
+/// Logs the "about to read" intent line shared by every read function code.
+async fn log_read_intent<L>(log: &L, name: &str, slave_id: UnitId, start: usize, end: usize)
+where
+    L: LogFn,
+{
+    log.invoke(format!(
+        "Perform {name} request for slave ID {slave_id} and range [{start}, {end})."
+    ))
+    .await;
 }
 
-impl ClientCore {
-    /// Logs the "about to read" intent line shared by every read function code.
-    async fn log_read_intent<L>(
-        log: &L,
-        name: &str,
-        slave_id: tokio_modbus::SlaveId,
-        start: usize,
-        end: usize,
-    ) where
-        L: LogFn,
-    {
-        log.invoke(format!(
-            "Perform {name} request for slave ID {slave_id} and range [{start}, {end})."
-        ))
-        .await;
-    }
+/// Converts a coil/discrete-input bit vector to the `u16` shape the shared memory store uses.
+pub(crate) fn bits_to_words(bits: Vec<bool>) -> Vec<u16> {
+    bits.into_iter().map(|b| if b { 1 } else { 0 }).collect()
+}
 
-    /// Converts a coil/discrete-input bit vector to the `u16` shape the shared memory store uses.
-    fn bits_to_words(bits: Vec<bool>) -> Vec<u16> {
-        bits.into_iter().map(|b| if b { 1 } else { 0 }).collect()
-    }
+/// Unwraps register values into the bare `u16` shape the shared memory store uses.
+pub(crate) fn words(registers: Vec<RegisterValue>) -> Vec<u16> {
+    registers.into_iter().map(|v| v.0).collect()
+}
 
-    /// Classifies a completed timeout+request result into the single `ModbusError` shape shared
-    /// by every read and write outcome.
-    fn classify<V>(
-        result: Result<
-            Result<Result<V, tokio_modbus::ExceptionCode>, tokio_modbus::Error>,
-            tokio::time::error::Elapsed,
-        >,
-    ) -> Result<V, ModbusError> {
-        match result {
-            Ok(Ok(Ok(v))) => Ok(v),
-            Ok(Ok(Err(e))) => Err(ModbusError::Exception(e)),
-            Ok(Err(e)) => Err(ModbusError::Error(e)),
-            Err(e) => Err(ModbusError::Timeout(e)),
+/// Classifies a completed timeout+request result into the single `ModbusError` shape shared
+/// by every read and write outcome.
+/// A device's refusal arrives as `Error::Exception`, alongside — not inside — the transport
+/// failures, so the exception path (retry, no disconnect) is separated here rather than by
+/// the shape of the `Result`.
+pub(crate) fn classify<V>(
+    result: Result<Result<V, rust_modbus::Error>, tokio::time::error::Elapsed>,
+) -> Result<V, ModbusError> {
+    match result {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(rust_modbus::Error::Exception { exception, .. })) => {
+            Err(ModbusError::Exception(exception))
         }
+        Ok(Err(e)) => Err(ModbusError::Error(e)),
+        Err(e) => Err(ModbusError::Timeout(e)),
     }
+}
 
+/// Owns a connected Modbus client and drives the read/command loop. Transport-neutral: the TCP
+/// and RTU `Client` types each establish the connection, then hand the client here.
+pub(crate) struct ClientCore<S, F> {
+    pub(crate) client: Client<S, F>,
+}
+
+impl<S, F> ClientCore<S, F>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+    F: ClientFraming,
+{
     async fn read<L>(
         &mut self,
         op: &Operation,
@@ -96,58 +104,68 @@ impl ClientCore {
         let Ok(count) = u16::try_from(end - start) else {
             return (
                 "Unknown",
-                Err(ModbusError::Exception(
-                    tokio_modbus::ExceptionCode::IllegalDataValue,
-                )),
+                Err(ModbusError::Exception(ExceptionCode::IllegalDataValue)),
             );
         };
+        // MB-R-101: on a framing that has a broadcast address (RTU; never TCP), a read
+        // addressed to it cannot be answered by anyone. Refused here, in the same local-
+        // exception shape as an over-long range, so it follows the retry path of MB-R-043
+        // instead of surfacing as a transport error that would disconnect the client.
+        if F::is_broadcast(op.slave_id) {
+            log.invoke(format!(
+                "Read request for slave ID {} skipped: address 0 is the broadcast address, which no device answers.",
+                op.slave_id
+            ))
+            .await;
+            return (
+                "Broadcast",
+                Err(ModbusError::Exception(ExceptionCode::IllegalDataAddress)),
+            );
+        }
+        let (address, quantity) = (Address(start as u16), Quantity(count));
         match op.fn_code {
             FunctionCode::ReadCoils => {
-                Self::log_read_intent(log, "ReadCoils", op.slave_id, start, end).await;
-                self.context.set_slave(Slave(op.slave_id));
+                log_read_intent(log, "ReadCoils", op.slave_id, start, end).await;
                 let res = tokio::time::timeout(
                     Duration::from_millis(timeout_ms as u64),
-                    self.context.read_coils(start as u16, count),
+                    self.client.read_coils(op.slave_id, address, quantity),
                 )
                 .await;
-                ("ReadCoils", Self::classify(res).map(Self::bits_to_words))
+                ("ReadCoils", classify(res).map(bits_to_words))
             }
             FunctionCode::ReadDiscreteInputs => {
-                Self::log_read_intent(log, "ReadDiscreteInputs", op.slave_id, start, end).await;
-                self.context.set_slave(Slave(op.slave_id));
+                log_read_intent(log, "ReadDiscreteInputs", op.slave_id, start, end).await;
                 let res = tokio::time::timeout(
                     Duration::from_millis(timeout_ms as u64),
-                    self.context.read_discrete_inputs(start as u16, count),
+                    self.client
+                        .read_discrete_inputs(op.slave_id, address, quantity),
                 )
                 .await;
-                (
-                    "ReadDiscreteInputs",
-                    Self::classify(res).map(Self::bits_to_words),
-                )
+                ("ReadDiscreteInputs", classify(res).map(bits_to_words))
             }
             FunctionCode::ReadInputRegisters => {
-                Self::log_read_intent(log, "ReadInputRegisters", op.slave_id, start, end).await;
-                self.context.set_slave(Slave(op.slave_id));
+                log_read_intent(log, "ReadInputRegisters", op.slave_id, start, end).await;
                 let res = tokio::time::timeout(
                     Duration::from_millis(timeout_ms as u64),
-                    self.context.read_input_registers(start as u16, count),
+                    self.client
+                        .read_input_registers(op.slave_id, address, quantity),
                 )
                 .await;
-                ("ReadInputRegisters", Self::classify(res))
+                ("ReadInputRegisters", classify(res).map(words))
             }
             FunctionCode::ReadHoldingRegisters => {
-                Self::log_read_intent(log, "ReadHoldingRegisters", op.slave_id, start, end).await;
-                self.context.set_slave(Slave(op.slave_id));
+                log_read_intent(log, "ReadHoldingRegisters", op.slave_id, start, end).await;
                 let res = tokio::time::timeout(
                     Duration::from_millis(timeout_ms as u64),
-                    self.context.read_holding_registers(start as u16, count),
+                    self.client
+                        .read_holding_registers(op.slave_id, address, quantity),
                 )
                 .await;
-                ("ReadHoldingRegisters", Self::classify(res))
+                ("ReadHoldingRegisters", classify(res).map(words))
             }
             _ => (
                 "Unknown",
-                Self::classify(Ok(Ok(Err(tokio_modbus::ExceptionCode::IllegalFunction)))),
+                Err(ModbusError::Exception(ExceptionCode::IllegalFunction)),
             ),
         }
     }
@@ -159,10 +177,7 @@ impl ClientCore {
     /// "failed" for the exception case).
     async fn handle_write_result<V, L>(
         &mut self,
-        result: Result<
-            Result<Result<V, tokio_modbus::ExceptionCode>, tokio_modbus::Error>,
-            tokio::time::error::Elapsed,
-        >,
+        result: Result<Result<V, rust_modbus::Error>, tokio::time::error::Elapsed>,
         label: &str,
         detail: &str,
         invalid_word: &str,
@@ -171,7 +186,7 @@ impl ClientCore {
     where
         L: LogFn,
     {
-        match Self::classify(result) {
+        match classify(result) {
             Ok(_) => {
                 log.invoke(format!(
                     "{label} request to {detail} successfully executed."
@@ -187,7 +202,6 @@ impl ClientCore {
                 Ok(())
             }
             Err(ModbusError::Error(e)) => {
-                let _ = self.context.disconnect().await;
                 log.invoke(format!(
                     "{label} request to {detail} failed. Disconnecting client. [{e:?}]"
                 ))
@@ -195,7 +209,6 @@ impl ClientCore {
                 Err(ModbusError::Error(e).into())
             }
             Err(ModbusError::Timeout(e)) => {
-                let _ = self.context.disconnect().await;
                 log.invoke(format!(
                     "{label} request to {detail} timed out. Disconnecting client. [{e:?}]"
                 ))
@@ -273,14 +286,12 @@ impl ClientCore {
                     *retries = 0;
                 }
                 (s, Err(ModbusError::Timeout(e))) => {
-                    let _ = self.context.disconnect().await;
                     log.invoke(format!(
                             "{s} request to read [{start}, {end}) timed out. Disconnecting client. [{e:?}]"
                         )).await;
                     return Err(ModbusError::Timeout(e).into());
                 }
                 (s, Err(ModbusError::Error(e))) => {
-                    let _ = self.context.disconnect().await;
                     log.invoke(format!(
                         "{s} request to read [{start}, {end}) failed. Disconnecting client. [{e:?}]"
                     ))
@@ -303,22 +314,22 @@ impl ClientCore {
         Ok(())
     }
 
-    /// Runs the read/command loop against the connected `context` until a graceful
+    /// Runs the read/command loop against the connected client until a graceful
     /// `Command::Terminate` (or the command channel closing) or a transport error. Returns
     /// whether at least one read succeeded during this run alongside the outcome, so the
     /// caller's reconnect backoff can reset after a connection that was live for a while rather
     /// than one that never got a read through.
-    pub(crate) async fn run<T, L, S>(
+    pub(crate) async fn run<T, L, St>(
         mut self,
         operations: Arc<RwLock<Vec<Operation>>>,
         memory: Arc<MemLock<Memory<Key<T>>>>,
         receiver: &mut Receiver<Command>,
-        config: RunConfig<L, S>,
+        config: RunConfig<L, St>,
     ) -> (bool, Result<(), Error>)
     where
         T: KeyParams,
         L: LogFn,
-        S: LogFn,
+        St: LogFn,
     {
         let RunConfig {
             log,
@@ -355,17 +366,15 @@ impl ClientCore {
                 // that the same as an explicit `Terminate`.
                 cmd = receiver.recv() => match cmd.unwrap_or(Command::Terminate) {
                     Command::Terminate => {
-                        let _ = self.context.disconnect().await;
                         log.invoke("Client gracefully terminated.".to_string())
                             .await;
                         status.invoke("Client disconnected".to_string()).await;
                         return (had_success, Ok(()));
                     }
                     Command::WriteSingleCoil(slave, addr, coil) => {
-                        self.context.set_slave(Slave(slave));
                         let result = tokio::time::timeout(
                             Duration::from_millis(timeout_ms as u64),
-                            self.context.write_single_coil(addr, coil),
+                            self.client.write_single_coil(slave, addr, coil),
                         )
                         .await;
                         if let Err(e) = self
@@ -376,10 +385,9 @@ impl ClientCore {
                         }
                     }
                     Command::WriteMultipleCoils(slave, addr, coils) => {
-                        self.context.set_slave(Slave(slave));
                         let result = tokio::time::timeout(
                             Duration::from_millis(timeout_ms as u64),
-                            self.context.write_multiple_coils(addr, &coils),
+                            self.client.write_multiple_coils(slave, addr, &coils),
                         )
                         .await;
                         if let Err(e) = self
@@ -390,10 +398,9 @@ impl ClientCore {
                         }
                     }
                     Command::WriteSingleRegister(slave, addr, value) => {
-                        self.context.set_slave(Slave(slave));
                         let result = tokio::time::timeout(
                             Duration::from_millis(timeout_ms as u64),
-                            self.context.write_single_register(addr, value),
+                            self.client.write_single_register(slave, addr, value),
                         )
                         .await;
                         if let Err(e) = self
@@ -404,10 +411,9 @@ impl ClientCore {
                         }
                     }
                     Command::WriteMultipleRegister(slave, addr, values) => {
-                        self.context.set_slave(Slave(slave));
                         let result = tokio::time::timeout(
                             Duration::from_millis(timeout_ms as u64),
-                            self.context.write_multiple_registers(addr, &values),
+                            self.client.write_multiple_registers(slave, addr, &values),
                         )
                         .await;
                         if let Err(e) = self
@@ -429,20 +435,20 @@ impl ClientCore {
     /// the loop cleanly at any point; with `reconnect` unset for the current config snapshot, a
     /// transport error ends the loop instead of backing off. `connect` alone differs between the
     /// TCP and RTU transports (socket dial vs. serial open); everything else here is shared.
-    pub(crate) async fn run_reconnect_loop<T, L, S, F, Fut>(
+    pub(crate) async fn run_reconnect_loop<T, L, St, C, Fut>(
         mut receiver: Receiver<Command>,
         log: L,
-        status: S,
+        status: St,
         operations: Arc<RwLock<Vec<Operation>>>,
         memory: Arc<MemLock<Memory<Key<T>>>>,
-        mut connect: F,
+        mut connect: C,
     ) -> Result<(), Error>
     where
         T: KeyParams,
         L: LogFn + Clone,
-        S: LogFn + Clone,
-        F: FnMut() -> Fut,
-        Fut: Future<Output = ConnectAttempt>,
+        St: LogFn + Clone,
+        C: FnMut() -> Fut,
+        Fut: Future<Output = ConnectAttempt<S, F>>,
     {
         let mut backoff = INITIAL_BACKOFF;
         loop {
@@ -467,7 +473,7 @@ impl ClientCore {
                     }
                     log.invoke(format!("{e} Reconnecting in {}s.", backoff.as_secs()))
                         .await;
-                    if Self::wait_reconnect_backoff(&mut receiver, backoff, &log).await {
+                    if wait_reconnect_backoff(&mut receiver, backoff, &log).await {
                         status.invoke("Client disconnected".to_string()).await;
                         return Ok(());
                     }
@@ -498,7 +504,7 @@ impl ClientCore {
                     }
                     log.invoke(format!("{e} Reconnecting in {}s.", backoff.as_secs()))
                         .await;
-                    if Self::wait_reconnect_backoff(&mut receiver, backoff, &log).await {
+                    if wait_reconnect_backoff(&mut receiver, backoff, &log).await {
                         status.invoke("Client disconnected".to_string()).await;
                         return Ok(());
                     }
@@ -507,57 +513,53 @@ impl ClientCore {
             }
         }
     }
+}
 
-    /// Waits out a reconnect backoff, aborting early on `Command::Terminate` or the command
-    /// channel closing (returns `true`). Any other command received while disconnected is
-    /// dropped with a log line rather than queued for after reconnect.
-    pub(crate) async fn wait_reconnect_backoff<L>(
-        receiver: &mut Receiver<Command>,
-        backoff: Duration,
-        log: &L,
-    ) -> bool
-    where
-        L: LogFn,
-    {
-        let deadline = tokio::time::Instant::now() + backoff;
-        loop {
-            tokio::select! {
-                _ = tokio::time::sleep_until(deadline) => return false,
-                cmd = receiver.recv() => match cmd {
-                    None | Some(Command::Terminate) => return true,
-                    Some(_) => {
-                        log.invoke(
-                            "Command dropped: client is disconnected and reconnecting.".to_string(),
-                        )
-                        .await;
-                    }
-                },
-            }
+/// Waits out a reconnect backoff, aborting early on `Command::Terminate` or the command
+/// channel closing (returns `true`). Any other command received while disconnected is
+/// dropped with a log line rather than queued for after reconnect.
+pub(crate) async fn wait_reconnect_backoff<L>(
+    receiver: &mut Receiver<Command>,
+    backoff: Duration,
+    log: &L,
+) -> bool
+where
+    L: LogFn,
+{
+    let deadline = tokio::time::Instant::now() + backoff;
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep_until(deadline) => return false,
+            cmd = receiver.recv() => match cmd {
+                None | Some(Command::Terminate) => return true,
+                Some(_) => {
+                    log.invoke(
+                        "Command dropped: client is disconnected and reconnecting.".to_string(),
+                    )
+                    .await;
+                }
+            },
         }
     }
 }
 
-// `poll_once`/`run`/`handle_write_result` all drive a real `tokio_modbus::client::Context`
-// (constructed from an actual TCP socket or serial port), so exercising them meaningfully needs a
-// live transport; that end-to-end coverage lives in `tests/tcp_loopback.rs` (round-robin advance,
+// `poll_once`/`run`/`handle_write_result` all drive a real connected `Client` (over an actual
+// TCP socket or serial port), so exercising them meaningfully needs a live transport; that
+// end-to-end coverage lives in `tests/tcp_loopback.rs` (round-robin advance,
 // retry-then-skip past `MAX_RETRIES`, every write outcome, reconnect/backoff, graceful
 // termination). What's unit-testable in isolation here is the pure classification/conversion
 // logic those methods build on.
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_modbus::ExceptionCode;
 
-    type ReadResult<V> = Result<
-        Result<Result<V, tokio_modbus::ExceptionCode>, tokio_modbus::Error>,
-        tokio::time::error::Elapsed,
-    >;
+    type ReadResult<V> = Result<Result<V, rust_modbus::Error>, tokio::time::error::Elapsed>;
 
     #[test]
     /// MB-R-042 — coil/discrete-input reads map to one word per bit: `1` for set, `0` for clear.
     fn ut_bits_to_words_maps_true_false_to_one_zero() {
         assert_eq!(
-            ClientCore::bits_to_words(vec![true, false, true, true]),
+            bits_to_words(vec![true, false, true, true]),
             vec![1u16, 0, 1, 1]
         );
     }
@@ -565,20 +567,23 @@ mod tests {
     #[test]
     /// MB-R-042 — an empty coil/discrete read maps to no words.
     fn ut_bits_to_words_empty_is_empty() {
-        assert_eq!(ClientCore::bits_to_words(vec![]), Vec::<u16>::new());
+        assert_eq!(bits_to_words(vec![]), Vec::<u16>::new());
     }
 
     #[test]
     fn ut_classify_success_unwraps_value() {
-        let res: ReadResult<u16> = Ok(Ok(Ok(42)));
-        assert_eq!(ClientCore::classify(res).unwrap(), 42);
+        let res: ReadResult<u16> = Ok(Ok(42));
+        assert_eq!(classify(res).unwrap(), 42);
     }
 
     #[test]
     /// MB-R-043 — a read returning a Modbus exception is classified as an exception (retried, not a disconnect).
     fn ut_classify_exception_maps_to_modbus_exception() {
-        let res: ReadResult<u16> = Ok(Ok(Err(ExceptionCode::IllegalDataAddress)));
-        let e = ClientCore::classify(res).unwrap_err();
+        let res: ReadResult<u16> = Ok(Err(rust_modbus::Error::Exception {
+            function: FunctionCode::ReadHoldingRegisters,
+            exception: ExceptionCode::IllegalDataAddress,
+        }));
+        let e = classify(res).unwrap_err();
         assert!(matches!(
             e,
             ModbusError::Exception(ExceptionCode::IllegalDataAddress)
@@ -588,9 +593,10 @@ mod tests {
     #[test]
     /// MB-R-045 — a transport error is classified as an error (disconnects the client).
     fn ut_classify_transport_error_maps_to_modbus_error() {
-        let io_err = std::io::Error::other("boom");
-        let res: ReadResult<u16> = Ok(Err(tokio_modbus::Error::Transport(io_err)));
-        let e = ClientCore::classify(res).unwrap_err();
+        let res: ReadResult<u16> = Ok(Err(rust_modbus::Error::Io {
+            kind: std::io::ErrorKind::ConnectionReset,
+        }));
+        let e = classify(res).unwrap_err();
         assert!(matches!(e, ModbusError::Error(_)));
     }
 
@@ -603,7 +609,7 @@ mod tests {
             .await
             .unwrap_err();
         let res: ReadResult<u16> = Err(elapsed);
-        let e = ClientCore::classify(res).unwrap_err();
+        let e = classify(res).unwrap_err();
         assert!(matches!(e, ModbusError::Timeout(_)));
     }
 
@@ -638,11 +644,14 @@ mod tests {
         };
         // A non-terminate command sent before the backoff elapses must be dropped, so the wait
         // still runs to completion and returns `false` (not aborted).
-        tx.send(Command::WriteSingleRegister(1, 0, 42))
-            .await
-            .unwrap();
-        let aborted =
-            ClientCore::wait_reconnect_backoff(&mut rx, Duration::from_millis(50), &log).await;
+        tx.send(Command::WriteSingleRegister(
+            UnitId(1),
+            Address(0),
+            RegisterValue(42),
+        ))
+        .await
+        .unwrap();
+        let aborted = wait_reconnect_backoff(&mut rx, Duration::from_millis(50), &log).await;
         assert!(!aborted);
         assert!(lines.lock().iter().any(|l| l.contains("Command dropped")));
     }
@@ -654,22 +663,20 @@ mod tests {
         // Terminate aborts (returns true).
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Command>(4);
         tx.send(Command::Terminate).await.unwrap();
-        assert!(ClientCore::wait_reconnect_backoff(&mut rx, Duration::from_secs(30), &sink).await);
+        assert!(wait_reconnect_backoff(&mut rx, Duration::from_secs(30), &sink).await);
         // The channel closing aborts too.
         let (tx2, mut rx2) = tokio::sync::mpsc::channel::<Command>(4);
         drop(tx2);
-        assert!(ClientCore::wait_reconnect_backoff(&mut rx2, Duration::from_secs(30), &sink).await);
+        assert!(wait_reconnect_backoff(&mut rx2, Duration::from_secs(30), &sink).await);
     }
 
     #[test]
     /// MB-R-042 — a successful coil read is mapped through to one word per bit.
     fn ut_classify_maps_bits_through_to_words_on_success() {
         // Same classify() call the ReadCoils/ReadDiscreteInputs arms make, chained with
-        // `.map(Self::bits_to_words)` as `read()` does.
-        let res: ReadResult<Vec<bool>> = Ok(Ok(Ok(vec![true, false])));
-        let words = ClientCore::classify(res)
-            .map(ClientCore::bits_to_words)
-            .unwrap();
+        // `.map(bits_to_words)` as `read()` does.
+        let res: ReadResult<Vec<bool>> = Ok(Ok(vec![true, false]));
+        let words = classify(res).map(bits_to_words).unwrap();
         assert_eq!(words, vec![1u16, 0]);
     }
 }

--- a/ferrowl-modbus/src/client_core.rs
+++ b/ferrowl-modbus/src/client_core.rs
@@ -552,8 +552,126 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SlaveKey;
+    use ferrowl_store::Range;
+    use rust_modbus::{FrameTransport, Rtu};
+    use tokio::io::{AsyncReadExt, DuplexStream};
 
     type ReadResult<V> = Result<Result<V, rust_modbus::Error>, tokio::time::error::Elapsed>;
+
+    /// An RTU-framed client over an in-memory duplex link, plus the peer end of that link.
+    /// Nothing ever answers on the peer end: the broadcast tests below are about what the
+    /// client does *without* a response.
+    fn rtu_client_over_duplex() -> (ClientCore<DuplexStream, Rtu>, DuplexStream) {
+        let (client_end, peer) = tokio::io::duplex(256);
+        let core = ClientCore {
+            client: Client::new(FrameTransport::<_, Rtu>::new(client_end)),
+        };
+        (core, peer)
+    }
+
+    /// A `LogFn` that records every line into a shared buffer for assertions.
+    fn recording_log() -> (impl LogFn + Clone, Arc<parking_lot::Mutex<Vec<String>>>) {
+        let lines = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let sink = lines.clone();
+        let log = move |s: String| {
+            let sink = sink.clone();
+            async move {
+                sink.lock().push(s);
+            }
+        };
+        (log, lines)
+    }
+
+    /// Reads whatever the peer end received within a short window, or nothing if the wire
+    /// stayed silent.
+    async fn drain_peer(peer: &mut DuplexStream) -> Vec<u8> {
+        let mut buf = [0u8; 64];
+        match tokio::time::timeout(Duration::from_millis(100), peer.read(&mut buf)).await {
+            Ok(Ok(n)) => buf[..n].to_vec(),
+            _ => Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    /// MB-R-101 — an RTU read addressed to slave id 0 fails locally, never reaching the wire,
+    /// and fails as a Modbus exception so it follows the retry path of MB-R-043 rather than
+    /// disconnecting the client.
+    async fn ut_rtu_broadcast_read_is_refused_locally() {
+        let (mut core, mut peer) = rtu_client_over_duplex();
+        let (log, lines) = recording_log();
+        let op = Operation {
+            slave_id: UnitId(0),
+            fn_code: FunctionCode::ReadHoldingRegisters,
+            range: Range::new(0, 2),
+        };
+
+        let (label, result) = core.read(&op, 200, &log).await;
+
+        assert_eq!(label, "Broadcast");
+        assert!(matches!(
+            result,
+            Err(ModbusError::Exception(ExceptionCode::IllegalDataAddress))
+        ));
+        assert!(
+            lines.lock().iter().any(|l| l.contains("broadcast address")),
+            "the refusal is logged: {:?}",
+            lines.lock()
+        );
+        assert!(
+            drain_peer(&mut peer).await.is_empty(),
+            "a broadcast read must not reach the wire"
+        );
+    }
+
+    #[tokio::test]
+    /// MB-R-102 — an RTU write addressed to slave id 0 is transmitted without awaiting a
+    /// response, logged as executed, and does not disconnect the client.
+    async fn ut_rtu_broadcast_write_is_fire_and_forget() {
+        let (core, mut peer) = rtu_client_over_duplex();
+        let (log, lines) = recording_log();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Command>(4);
+        tx.send(Command::WriteSingleRegister(
+            UnitId(0),
+            Address(1),
+            RegisterValue(7),
+        ))
+        .await
+        .unwrap();
+        tx.send(Command::Terminate).await.unwrap();
+
+        // No operations, so the poll ticker has nothing to do: the run is the two commands.
+        let (_had_success, result) = core
+            .run::<SlaveKey, _, _>(
+                Arc::new(RwLock::new(Vec::new())),
+                Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default())),
+                &mut rx,
+                RunConfig {
+                    log,
+                    status: |_s: String| async move {},
+                    timeout_ms: 200,
+                    delay_ms: 0,
+                    interval_ms: 60_000,
+                },
+            )
+            .await;
+
+        // Nothing answered, yet the write neither timed out nor ended the run: the client
+        // stayed up all the way to the graceful terminate.
+        assert!(result.is_ok(), "a broadcast write must not disconnect");
+        assert!(
+            lines
+                .lock()
+                .iter()
+                .any(|l| l.contains("WriteSingleRegister") && l.contains("successfully executed")),
+            "the write is logged as executed: {:?}",
+            lines.lock()
+        );
+        assert!(
+            !drain_peer(&mut peer).await.is_empty(),
+            "a broadcast write is still transmitted"
+        );
+    }
 
     #[test]
     /// MB-R-042 — coil/discrete-input reads map to one word per bit: `1` for set, `0` for clear.

--- a/ferrowl-modbus/src/command.rs
+++ b/ferrowl-modbus/src/command.rs
@@ -1,6 +1,6 @@
 //! Commands sent to a running client task.
 
-use tokio_modbus::SlaveId;
+use rust_modbus::UnitId;
 
 use crate::scalar::{Address, Coil, Word};
 
@@ -8,8 +8,8 @@ use crate::scalar::{Address, Coil, Word};
 pub enum Command {
     /// Stop the client loop.
     Terminate,
-    WriteSingleCoil(SlaveId, Address, Coil),
-    WriteMultipleCoils(SlaveId, Address, Vec<Coil>),
-    WriteSingleRegister(SlaveId, Address, Word),
-    WriteMultipleRegister(SlaveId, Address, Vec<Word>),
+    WriteSingleCoil(UnitId, Address, Coil),
+    WriteMultipleCoils(UnitId, Address, Vec<Coil>),
+    WriteSingleRegister(UnitId, Address, Word),
+    WriteMultipleRegister(UnitId, Address, Vec<Word>),
 }

--- a/ferrowl-modbus/src/common.rs
+++ b/ferrowl-modbus/src/common.rs
@@ -2,19 +2,26 @@
 
 use crate::SerialError;
 
-use tokio_serial::{DataBits, Parity, SerialPortBuilder, StopBits};
+use rust_modbus::{DataBits, Parity, SerialConfig, StopBits};
 
-/// Build a `tokio_serial` port builder from the optional serial parameters, validating each.
+/// Build a serial port configuration from the optional serial parameters, validating each.
+///
+/// An unset parameter is left at the Modbus serial-line default the protocol library
+/// declares (8 data bits, even parity, one stop bit — MB-R-072); only the fields the
+/// device config states are overridden. The port path is not part of the configuration:
+/// it is passed alongside it to `open_serial`.
 pub(crate) fn serial_config_from(
-    path: &str,
     baud_rate: u32,
     data_bits: Option<u8>,
     stop_bits: Option<u8>,
     parity: Option<&str>,
-) -> Result<SerialPortBuilder, SerialError> {
-    let mut builder = tokio_serial::new(path, baud_rate);
+) -> Result<SerialConfig, SerialError> {
+    let mut config = SerialConfig {
+        baud_rate,
+        ..SerialConfig::default()
+    };
     if let Some(v) = data_bits {
-        builder = builder.data_bits(match v {
+        config.data_bits = match v {
             5 => DataBits::Five,
             6 => DataBits::Six,
             7 => DataBits::Seven,
@@ -24,10 +31,10 @@ pub(crate) fn serial_config_from(
                     "Invalid data bits specified".to_string(),
                 ));
             }
-        });
+        };
     }
     if let Some(v) = stop_bits {
-        builder = builder.stop_bits(match v {
+        config.stop_bits = match v {
             1 => StopBits::One,
             2 => StopBits::Two,
             _ => {
@@ -35,23 +42,23 @@ pub(crate) fn serial_config_from(
                     "Invalid stop bits specified".to_string(),
                 ));
             }
-        });
+        };
     }
     if let Some(v) = parity {
         let v = v.to_lowercase();
         if v == "odd" {
-            builder = builder.parity(Parity::Odd);
+            config.parity = Parity::Odd;
         } else if v == "even" {
-            builder = builder.parity(Parity::Even);
+            config.parity = Parity::Even;
         } else if v == "none" {
-            builder = builder.parity(Parity::None);
+            config.parity = Parity::None;
         } else {
             return Err(SerialError::Configuration(
                 "Invalid parity specified".to_string(),
             ));
         }
     }
-    Ok(builder)
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -61,16 +68,21 @@ mod tests {
     use std::future::Future;
 
     #[test]
-    /// MB-R-072 — unset serial parameters leave the library's own default in place.
+    /// MB-R-072 — unset serial parameters leave the Modbus serial-line default (8E1) in place.
     fn ut_serial_config_valid_minimal() {
-        // No optional fields set: builder construction must succeed.
-        assert!(serial_config_from("/dev/null", 9600, None, None, None).is_ok());
+        // No optional fields set: the configuration carries the stated baud rate and the
+        // library's Modbus defaults for everything else.
+        let cfg = serial_config_from(9600, None, None, None).unwrap();
+        assert_eq!(cfg.baud_rate, 9600);
+        assert_eq!(cfg.data_bits, DataBits::Eight);
+        assert_eq!(cfg.parity, Parity::Even);
+        assert_eq!(cfg.stop_bits, StopBits::One);
     }
 
     #[test]
     /// MB-R-073 — valid `data_bits`/`stop_bits`/`parity` values are accepted.
     fn ut_serial_config_valid_full() {
-        let r = serial_config_from("/dev/null", 19200, Some(8), Some(1), Some("even"));
+        let r = serial_config_from(19200, Some(8), Some(1), Some("even"));
         assert!(r.is_ok());
     }
 
@@ -78,14 +90,14 @@ mod tests {
     /// MB-R-073 — `parity` accepts `even`/`odd`/`none` case-insensitively.
     fn ut_serial_config_parity_case_insensitive() {
         // Parity is lower-cased before matching, so mixed case is accepted.
-        assert!(serial_config_from("/dev/null", 9600, None, None, Some("ODD")).is_ok());
-        assert!(serial_config_from("/dev/null", 9600, None, None, Some("None")).is_ok());
+        assert!(serial_config_from(9600, None, None, Some("ODD")).is_ok());
+        assert!(serial_config_from(9600, None, None, Some("None")).is_ok());
     }
 
     #[test]
     /// MB-R-073 — a `data_bits` value other than 5/6/7/8 fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_data_bits() {
-        let e = serial_config_from("/dev/null", 9600, Some(9), None, None).unwrap_err();
+        let e = serial_config_from(9600, Some(9), None, None).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("data bits"));
     }
@@ -93,7 +105,7 @@ mod tests {
     #[test]
     /// MB-R-073 — a `stop_bits` value other than 1/2 fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_stop_bits() {
-        let e = serial_config_from("/dev/null", 9600, None, Some(3), None).unwrap_err();
+        let e = serial_config_from(9600, None, Some(3), None).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("stop bits"));
     }
@@ -101,7 +113,7 @@ mod tests {
     #[test]
     /// MB-R-073 — a `parity` value other than even/odd/none fails with a serial configuration error.
     fn ut_serial_config_rejects_bad_parity() {
-        let e = serial_config_from("/dev/null", 9600, None, None, Some("bogus")).unwrap_err();
+        let e = serial_config_from(9600, None, None, Some("bogus")).unwrap_err();
         assert!(matches!(e, SerialError::Configuration(_)));
         assert!(e.to_string().contains("parity"));
     }
@@ -110,15 +122,15 @@ mod tests {
     /// MB-R-073 — `data_bits` accepts exactly 5, 6, 7, and 8.
     fn ut_serial_config_accepts_all_data_bit_widths() {
         for bits in [5u8, 6, 7, 8] {
-            assert!(serial_config_from("/dev/null", 9600, Some(bits), None, None).is_ok());
+            assert!(serial_config_from(9600, Some(bits), None, None).is_ok());
         }
     }
 
     #[test]
     /// MB-R-073 — `stop_bits` accepts exactly 1 and 2.
     fn ut_serial_config_accepts_both_stop_bits() {
-        assert!(serial_config_from("/dev/null", 9600, None, Some(1), None).is_ok());
-        assert!(serial_config_from("/dev/null", 9600, None, Some(2), None).is_ok());
+        assert!(serial_config_from(9600, None, Some(1), None).is_ok());
+        assert!(serial_config_from(9600, None, Some(2), None).is_ok());
     }
 
     // Verifies the stable `LogFn` blanket impl (replacing the former nightly `async_fn_traits`

--- a/ferrowl-modbus/src/error.rs
+++ b/ferrowl-modbus/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for Modbus protocol and transport failures.
 
-use tokio_modbus::ExceptionCode;
+use rust_modbus::ExceptionCode;
 
 /// Errors from Modbus protocol operations.
 #[derive(Debug, thiserror::Error)]
@@ -8,7 +8,7 @@ pub enum ModbusError {
     #[error("Modbus exception: {0:?}")]
     Exception(ExceptionCode),
     #[error("Modbus error: {0}")]
-    Error(tokio_modbus::Error),
+    Error(rust_modbus::Error),
     #[error("Modbus timeout: {0}")]
     Timeout(tokio::time::error::Elapsed),
 }
@@ -17,7 +17,7 @@ pub enum ModbusError {
 #[derive(Debug, thiserror::Error)]
 pub enum SerialError {
     #[error("Serial error: {0}")]
-    Error(tokio_serial::Error),
+    Error(rust_modbus::Error),
     #[error("Serial configuration error: {0}")]
     Configuration(String),
 }
@@ -30,7 +30,7 @@ pub enum TcpError {
     #[error("TCP configuration error: {0}")]
     Configuration(String),
     #[error("TCP error: {0}")]
-    Error(tokio::io::Error),
+    Error(rust_modbus::Error),
     #[error("TCP timeout: {0}")]
     Timeout(tokio::time::error::Elapsed),
 }
@@ -45,13 +45,13 @@ pub enum Error {
     #[error("{0}")]
     Tcp(#[from] TcpError),
     #[error("Server error: {0}")]
-    Server(std::io::Error),
+    Server(rust_modbus::Error),
 }
 
 #[cfg(test)]
 mod tests {
     use super::{Error, ModbusError, SerialError, TcpError};
-    use tokio_modbus::ExceptionCode;
+    use rust_modbus::ExceptionCode;
 
     #[test]
     fn ut_serial_error_configuration_display() {

--- a/ferrowl-modbus/src/key.rs
+++ b/ferrowl-modbus/src/key.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use ferrowl_codec::Kind;
-use tokio_modbus::{FunctionCode, SlaveId};
+use rust_modbus::{FunctionCode, UnitId};
 
 /// Parameters identifying a memory region for a request.
 ///
@@ -13,7 +13,7 @@ use tokio_modbus::{FunctionCode, SlaveId};
 /// partitioned. See [`SlaveKey`] for the default.
 pub trait KeyParams: Hash + Eq + Clone + Default + Debug + Send + Sync + 'static {
     /// Derives the key for a request addressed at `slave_id` with `fn_code`.
-    fn from_slave_fn(slave_id: SlaveId, fn_code: FunctionCode) -> Self;
+    fn from_slave_fn(slave_id: UnitId, fn_code: FunctionCode) -> Self;
 }
 
 /// Memory key wrapping [`KeyParams`]; used as the device key of the shared
@@ -32,14 +32,27 @@ impl<T: KeyParams> Key<T> {
 /// Default concrete key params: slave address + register kind. Each
 /// (slave, register table) pair gets its own memory region; the kind is
 /// derived from the request's function code.
-#[derive(Hash, Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Hash, Debug, PartialEq, Eq, Clone)]
 pub struct SlaveKey {
-    pub slave_id: SlaveId,
+    pub slave_id: UnitId,
     pub kind: Kind,
 }
 
+// Hand-written because `UnitId` is a transparent wrapper with no `Default` of its
+// own. The default unit is 1, not 0: on RTU, 0 is the broadcast address, which no
+// server answers and no client may read from (MB-R-101, MB-R-103), so it is the one
+// value an unconfigured key must not take.
+impl Default for SlaveKey {
+    fn default() -> Self {
+        Self {
+            slave_id: UnitId(1),
+            kind: Kind::default(),
+        }
+    }
+}
+
 impl KeyParams for SlaveKey {
-    fn from_slave_fn(slave_id: SlaveId, fn_code: FunctionCode) -> Self {
+    fn from_slave_fn(slave_id: UnitId, fn_code: FunctionCode) -> Self {
         Self {
             slave_id,
             kind: match fn_code {
@@ -61,12 +74,12 @@ impl KeyParams for SlaveKey {
 mod tests {
     use super::{Key, KeyParams, SlaveKey};
     use ferrowl_codec::Kind;
-    use tokio_modbus::FunctionCode;
+    use rust_modbus::{FunctionCode, UnitId};
 
     #[test]
     fn ut_key_new_stores_fields() {
         let sk = SlaveKey {
-            slave_id: 7,
+            slave_id: UnitId(7),
             kind: Kind::HoldingRegister,
         };
         let key = Key::new(sk.clone());
@@ -83,8 +96,8 @@ mod tests {
     #[test]
     /// MB-R-027 — coil-family function codes derive the coil register table.
     fn ut_slave_kind_from_slave_fn_coil() {
-        let sk = SlaveKey::from_slave_fn(3, FunctionCode::ReadCoils);
-        assert_eq!(sk.slave_id, 3);
+        let sk = SlaveKey::from_slave_fn(UnitId(3), FunctionCode::ReadCoils);
+        assert_eq!(sk.slave_id, UnitId(3));
         assert_eq!(sk.kind, Kind::Coil);
     }
 }

--- a/ferrowl-modbus/src/lib.rs
+++ b/ferrowl-modbus/src/lib.rs
@@ -30,4 +30,4 @@ pub use run_config::RunConfig;
 pub use scalar::{Address, Coil, Word};
 pub use transport::Transport;
 
-pub use tokio_modbus::{FunctionCode, SlaveId};
+pub use rust_modbus::{FunctionCode, Quantity, UnitId};

--- a/ferrowl-modbus/src/operation.rs
+++ b/ferrowl-modbus/src/operation.rs
@@ -1,13 +1,13 @@
 //! A single recurring Modbus operation performed each poll cycle.
 
 use ferrowl_store::Range;
-use tokio_modbus::{FunctionCode, SlaveId};
+use rust_modbus::{FunctionCode, UnitId};
 
 /// A single recurring Modbus operation a client performs each poll cycle:
 /// the function code applied to an address range on a slave.
 #[derive(Debug, Clone)]
 pub struct Operation {
-    pub slave_id: SlaveId,
+    pub slave_id: UnitId,
     pub fn_code: FunctionCode,
     pub range: Range,
 }

--- a/ferrowl-modbus/src/rtu/client.rs
+++ b/ferrowl-modbus/src/rtu/client.rs
@@ -10,8 +10,8 @@ use tokio::task::JoinHandle;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Receiver;
-use tokio_modbus::prelude::{Slave, rtu};
-use tokio_serial::SerialStream;
+
+use rust_modbus::{Client as ModbusClient, Rtu, SerialStream, open_serial};
 
 /// Builds and spawns a Modbus RTU client task that polls `operations` into
 /// the shared `memory` and executes incoming [`Command`]s.
@@ -78,25 +78,28 @@ impl<T: KeyParams> ClientBuilder<T> {
 }
 
 /// A connected Modbus RTU client. Connection setup is serial-specific; the read/command loop is
-/// shared via the internal `ClientCore`.
+/// shared via the internal `ClientCore`, over a serial port carrying RTU framing.
 pub struct Client {
-    pub(crate) core: ClientCore,
+    pub(crate) core: ClientCore<SerialStream, Rtu>,
 }
 
 impl Client {
-    /// Opens the configured serial port and attaches it to the configured
-    /// slave address.
+    /// Opens the configured serial port under RTU framing.
+    ///
+    /// The port is not bound to a slave address: each request carries the slave id of the
+    /// operation or command that issued it (MB-R-048).
     pub async fn connect(config: &Config) -> Result<Self, Error> {
-        let builder = serial_config_from(
-            &config.path,
+        let serial = serial_config_from(
             config.baud_rate,
             config.data_bits,
             config.stop_bits,
             config.parity.as_deref(),
         )?;
-        match SerialStream::open(&builder).map(|s| rtu::attach_slave(s, Slave(config.slave))) {
-            Ok(context) => Ok(Self {
-                core: ClientCore { context },
+        match open_serial::<Rtu>(&config.path, serial) {
+            Ok(transport) => Ok(Self {
+                core: ClientCore {
+                    client: ModbusClient::new(transport),
+                },
             }),
             Err(e) => Err(SerialError::Error(e).into()),
         }

--- a/ferrowl-modbus/src/rtu/server.rs
+++ b/ferrowl-modbus/src/rtu/server.rs
@@ -9,11 +9,10 @@ use ferrowl_store::Memory;
 
 // External
 use parking_lot::RwLock as MemLock;
+use rust_modbus::{Rtu, Server as ModbusServer, open_serial};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tokio_modbus::server::rtu::Server as RtuServer;
-use tokio_serial::SerialStream;
 
 /// Builds and spawns a Modbus RTU server task answering requests from the
 /// shared `memory`.
@@ -49,23 +48,20 @@ where
     T: KeyParams,
     L: LogFn + Clone,
 {
-    let builder = serial_config_from(
-        &config.path,
+    let serial = serial_config_from(
         config.baud_rate,
         config.data_bits,
         config.stop_bits,
         config.parity.as_deref(),
     )?;
-    match SerialStream::open(&builder) {
-        Ok(serial_stream) => {
-            let rtu_server = RtuServer::new(serial_stream);
+    match open_serial::<Rtu>(&config.path, serial) {
+        Ok(transport) => {
             // RTU servers stay quiet on per-request outcomes (verbose = false).
-            let server = Server::new(memory, log, false);
-            Ok(tokio::task::spawn(async {
-                rtu_server
-                    .serve_forever(server)
-                    .await
-                    .map_err(Error::Server)
+            let server = ModbusServer::new(Server::new(memory, log, false));
+            // One port, one link, no accept loop (MB-R-074). The default `ServerConfig` filters
+            // by no unit id, so every slave id with declared regions is served (MB-R-065).
+            Ok(tokio::task::spawn(async move {
+                server.serve_link(transport).await.map_err(Error::Server)
             }))
         }
         Err(e) => Err(SerialError::Error(e).into()),

--- a/ferrowl-modbus/src/scalar.rs
+++ b/ferrowl-modbus/src/scalar.rs
@@ -1,8 +1,10 @@
-//! Primitive wire-scalar aliases used across the Modbus API.
+//! Primitive wire-scalar types used across the Modbus API.
+//!
+//! Addresses and register values are the protocol library's own newtypes, so one
+//! cannot be passed where the other is meant. A coil stays a bare `bool`: the
+//! library takes and returns `bool` for single-bit data.
 
-/// A Modbus register address.
-pub type Address = u16;
-/// A raw 16-bit register value.
-pub type Word = u16;
+pub use rust_modbus::{Address, RegisterValue as Word};
+
 /// A coil (single-bit) value.
 pub type Coil = bool;

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -1,16 +1,15 @@
 //! Transport-agnostic Modbus server request handler shared by the TCP and RTU servers.
 
-use crate::{Key, KeyParams, LogFn, SlaveId};
+use crate::{Key, KeyParams, LogFn};
 
 use ferrowl_store::{CellType, Memory, Range};
 use parking_lot::RwLock;
+use rust_modbus::{
+    Connection, ExceptionCode, FunctionCode, Quantity, RegisterValue, RequestPdu, ResponsePdu,
+    Service, UnitId,
+};
 use std::fmt::Display;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use tokio_modbus::FunctionCode;
-use tokio_modbus::Request;
-use tokio_modbus::prelude::{ExceptionCode, Response, SlaveRequest};
 
 /// Shared body of the four read function codes: log the request, read `[addr, addr+cnt)` for the
 /// `(slave, fc)` key as `cell`, log the outcome when `verbose`, and return the raw words. The
@@ -18,7 +17,7 @@ use tokio_modbus::prelude::{ExceptionCode, Response, SlaveRequest};
 #[allow(clippy::too_many_arguments)] // request context (name/slave/fc/cell/addr/cnt) + server state
 async fn handle_read<T, L>(
     name: &str,
-    slave: SlaveId,
+    slave: UnitId,
     fc: FunctionCode,
     cell: CellType,
     addr: u16,
@@ -77,7 +76,7 @@ where
 #[allow(clippy::too_many_arguments)] // request context (name/slave/fc/cell/addr/values) + server state
 async fn handle_write_multi<T, L>(
     name: &str,
-    slave: SlaveId,
+    slave: UnitId,
     fc: FunctionCode,
     cell: CellType,
     addr: u16,
@@ -136,7 +135,7 @@ where
 #[allow(clippy::too_many_arguments)] // request context (name/slave/fc/cell/addr/value/stored) + server state
 async fn handle_write_single<T, L, V>(
     name: &str,
-    slave: SlaveId,
+    slave: UnitId,
     fc: FunctionCode,
     cell: CellType,
     addr: u16,
@@ -190,133 +189,146 @@ where
 /// Every arm logs a "request received" line. When `verbose` is set (TCP), each arm additionally
 /// logs per-request success/failure; RTU passes `verbose = false` and stays quiet on the outcome.
 pub(crate) async fn handle_request<T, L>(
-    slave: SlaveId,
-    request: Request<'static>,
+    slave: UnitId,
+    request: RequestPdu,
     memory: &Arc<RwLock<Memory<Key<T>>>>,
     log: &L,
     verbose: bool,
-) -> Result<Response, ExceptionCode>
+) -> Result<ResponsePdu, ExceptionCode>
 where
     T: KeyParams,
     L: LogFn + Clone,
 {
     match request {
-        Request::ReadCoils(addr, cnt) => {
+        RequestPdu::ReadCoils { address, quantity } => {
             let v = handle_read(
                 "ReadCoils",
                 slave,
                 FunctionCode::ReadCoils,
                 CellType::Coil,
-                addr,
-                cnt,
+                address.0,
+                quantity.0,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::ReadCoils(v.into_iter().map(|b| b != 0).collect()))
+            Ok(ResponsePdu::ReadCoils {
+                coils: v.into_iter().map(|b| b != 0).collect(),
+            })
         }
-        Request::ReadDiscreteInputs(addr, cnt) => {
+        RequestPdu::ReadDiscreteInputs { address, quantity } => {
             let v = handle_read(
                 "ReadDiscreteInputs",
                 slave,
                 FunctionCode::ReadDiscreteInputs,
                 CellType::Coil,
-                addr,
-                cnt,
+                address.0,
+                quantity.0,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::ReadDiscreteInputs(
-                v.into_iter().map(|b| b != 0).collect(),
-            ))
+            Ok(ResponsePdu::ReadDiscreteInputs {
+                inputs: v.into_iter().map(|b| b != 0).collect(),
+            })
         }
-        Request::ReadInputRegisters(addr, cnt) => {
+        RequestPdu::ReadInputRegisters { address, quantity } => {
             let v = handle_read(
                 "ReadInputRegisters",
                 slave,
                 FunctionCode::ReadInputRegisters,
                 CellType::Register,
-                addr,
-                cnt,
+                address.0,
+                quantity.0,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::ReadInputRegisters(v))
+            Ok(ResponsePdu::ReadInputRegisters {
+                registers: v.into_iter().map(RegisterValue).collect(),
+            })
         }
-        Request::ReadHoldingRegisters(addr, cnt) => {
+        RequestPdu::ReadHoldingRegisters { address, quantity } => {
             let v = handle_read(
                 "ReadHoldingRegisters",
                 slave,
                 FunctionCode::ReadHoldingRegisters,
                 CellType::Register,
-                addr,
-                cnt,
+                address.0,
+                quantity.0,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::ReadHoldingRegisters(v))
+            Ok(ResponsePdu::ReadHoldingRegisters {
+                registers: v.into_iter().map(RegisterValue).collect(),
+            })
         }
-        Request::WriteMultipleRegisters(addr, values) => {
+        RequestPdu::WriteMultipleRegisters { address, registers } => {
+            let values: Vec<u16> = registers.iter().map(|v| v.0).collect();
             let len = handle_write_multi(
                 "WriteMultipleRegisters",
                 slave,
                 FunctionCode::WriteMultipleRegisters,
                 CellType::Register,
-                addr,
+                address.0,
                 &values,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::WriteMultipleRegisters(addr, len))
+            Ok(ResponsePdu::WriteMultipleRegisters {
+                address,
+                quantity: Quantity(len),
+            })
         }
-        Request::WriteSingleRegister(addr, value) => {
+        RequestPdu::WriteSingleRegister { address, value } => {
             handle_write_single(
                 "WriteSingleRegister",
                 slave,
                 FunctionCode::WriteSingleRegister,
                 CellType::Register,
-                addr,
-                value,
-                value,
+                address.0,
+                value.0,
+                value.0,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::WriteSingleRegister(addr, value))
+            Ok(ResponsePdu::WriteSingleRegister { address, value })
         }
-        Request::WriteMultipleCoils(addr, values) => {
-            let values: Vec<u16> = values.iter().map(|v| *v as u16).collect();
+        RequestPdu::WriteMultipleCoils { address, coils } => {
+            let values: Vec<u16> = coils.iter().map(|v| *v as u16).collect();
             let len = handle_write_multi(
                 "WriteMultipleCoils",
                 slave,
                 FunctionCode::WriteMultipleCoils,
                 CellType::Coil,
-                addr,
+                address.0,
                 &values,
                 memory,
                 log,
                 verbose,
             )
             .await?;
-            Ok(Response::WriteMultipleCoils(addr, len))
+            Ok(ResponsePdu::WriteMultipleCoils {
+                address,
+                quantity: Quantity(len),
+            })
         }
-        Request::WriteSingleCoil(addr, value) => {
+        RequestPdu::WriteSingleCoil { address, value } => {
             handle_write_single(
                 "WriteSingleCoil",
                 slave,
                 FunctionCode::WriteSingleCoil,
                 CellType::Coil,
-                addr,
+                address.0,
                 value,
                 value as u16,
                 memory,
@@ -324,25 +336,16 @@ where
                 verbose,
             )
             .await?;
-            Ok(Response::WriteSingleCoil(addr, value))
+            Ok(ResponsePdu::WriteSingleCoil { address, value })
         }
-        Request::ReportServerId => {
-            log.invoke(format!(
-                "ReportServerId request received for slave ID {}. Unsupported function.",
-                slave,
-            ))
-            .await;
-            Err(ExceptionCode::IllegalFunction)
-        }
-        Request::MaskWriteRegister(_, _, _) => {
-            log.invoke(format!(
-                "MaskWriteRegister request received for slave ID {}. Unsupported function.",
-                slave,
-            ))
-            .await;
-            Err(ExceptionCode::IllegalFunction)
-        }
-        Request::ReadWriteMultipleRegisters(read_addr, cnt, write_addr, values) => {
+        RequestPdu::ReadWriteMultipleRegisters {
+            read_address,
+            read_quantity,
+            write_address,
+            registers,
+        } => {
+            let (read_addr, cnt, write_addr) = (read_address.0, read_quantity.0, write_address.0);
+            let values: Vec<u16> = registers.iter().map(|v| v.0).collect();
             log.invoke(format!(
                 "ReadWriteMultipleRegisrters request received for slave ID {}, read address {}, count {}, write address {}, and values {:?}.",
                 slave, read_addr, cnt, write_addr, values
@@ -420,22 +423,21 @@ where
                         ))
                         .await;
                     }
-                    Ok(Response::ReadWriteMultipleRegisters(v))
+                    Ok(ResponsePdu::ReadWriteMultipleRegisters {
+                        registers: v.into_iter().map(RegisterValue).collect(),
+                    })
                 }
             }
         }
-        Request::ReadDeviceIdentification(_, _) => {
+        // MB-R-059: everything the server does not implement — report-server-id,
+        // mask-write-register, diagnostics, comm-event, file record, FIFO queue,
+        // read-device-identification (MEI), and any custom code — is one refusal, so a
+        // function code the frame layer learns to decode later cannot silently acquire a
+        // different answer here. MB-R-066 still requires the received line.
+        other => {
             log.invoke(format!(
-                "ReadDeviceIdentification request received for slave ID {}. Unsupported function.",
-                slave,
-            ))
-            .await;
-            Err(ExceptionCode::IllegalFunction)
-        }
-        Request::Custom(func, _) => {
-            log.invoke(format!(
-                "Custom function {} request received for slave ID {}. Unsupported function.",
-                func, slave,
+                "{} request received for slave ID {slave}. Unsupported function.",
+                other.function(),
             ))
             .await;
             Err(ExceptionCode::IllegalFunction)
@@ -471,25 +473,33 @@ where
     }
 }
 
-impl<T, L> tokio_modbus::server::Service for Server<T, L>
+impl<T, L> Service for Server<T, L>
 where
     T: KeyParams,
     L: LogFn + Clone,
 {
-    type Request = SlaveRequest<'static>;
-    type Exception = ExceptionCode;
-    type Response = Response;
-    type Future = Pin<Box<dyn Future<Output = Result<Response, ExceptionCode>> + Send>>;
+    // Taken by `&self` and awaited inside the connection's own task, so the handler suspends
+    // normally on the store's lock and the log sink rather than blocking a worker thread. The
+    // connection itself is not part of the answer: every request is served from the shared
+    // store, whichever link carried it (MB-R-057).
+    async fn on_request(
+        &self,
+        _conn: &Connection,
+        unit: UnitId,
+        request: RequestPdu,
+    ) -> Result<ResponsePdu, ExceptionCode> {
+        handle_request(unit, request, &self.memory, &self.log, self.verbose).await
+    }
 
-    // `tokio_modbus`'s `process()` loop (TCP and RTU alike) already `.await`s this future from
-    // inside its own per-connection tokio task, so there is no need to bridge into async here —
-    // returning the future directly lets it suspend normally instead of blocking a worker thread.
-    fn call(&self, request: Self::Request) -> Self::Future {
-        let SlaveRequest { slave, request } = request;
-        let memory = self.memory.clone();
-        let log = self.log.clone();
-        let verbose = self.verbose;
-        Box::pin(async move { handle_request(slave, request, &memory, &log, verbose).await })
+    // A framing or I/O failure on the wire never reaches `on_request`. TCP reports it (the
+    // former `on_process_error` callback); RTU stays quiet on per-request outcomes, and
+    // `verbose` is exactly that distinction (MB-R-067).
+    async fn on_error(&self, _conn: &Connection, error: &rust_modbus::Error) {
+        if self.verbose {
+            self.log
+                .invoke(format!("Server processing failed. [{error}]"))
+                .await;
+        }
     }
 }
 
@@ -499,6 +509,10 @@ mod tests {
     use crate::SlaveKey;
     use ferrowl_codec::Kind as RegKind;
     use ferrowl_store::CellKind as MemKind;
+    use rust_modbus::{
+        Address, Client as RmClient, DiagnosticSubFunction, FrameTransport, Mask, MeiRequest,
+        ReadDeviceIdCode, Server as ModbusServer, Tcp,
+    };
     use std::sync::Mutex;
 
     /// Build a memory map for slave `1`, holding registers `[0,4)`, seeded with `seed` at addr 0,
@@ -506,7 +520,7 @@ mod tests {
     fn seeded_memory(seed: &[u16]) -> Arc<RwLock<Memory<Key<SlaveKey>>>> {
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: RegKind::HoldingRegister,
             },
         };
@@ -536,29 +550,35 @@ mod tests {
         (log, buf)
     }
 
-    // Regression: `Server::call` used to bridge into async via `block_in_place` +
+    // Regression: the service used to bridge into async via `block_in_place` +
     // `Handle::block_on` purely to lock `memory`, which panics ("can call blocking only when
     // running on the multi-threaded runtime") on the default current-thread flavor below. Now
-    // that the lock is synchronous (`parking_lot`) and `call` returns a real future that
-    // `tokio_modbus`'s `process()` loop just `.await`s, this must succeed on a current-thread
-    // runtime with no dedicated worker threads to bridge onto.
+    // that the lock is synchronous (`parking_lot`) and `on_request` is an ordinary async fn the
+    // connection task just `.await`s, this must succeed on a current-thread runtime with no
+    // dedicated worker threads to bridge onto.
     #[tokio::test]
     /// MB-R-057 — the server answers an inbound request directly from the shared store.
     async fn ut_server_call_works_on_current_thread_runtime() {
-        use tokio_modbus::server::Service;
-
         let mem = seeded_memory(&[10, 20]);
         let (log, _) = recording_log();
         let server = Server::new(mem, log, true);
 
-        let resp = server
-            .call(SlaveRequest {
-                slave: 1,
-                request: Request::ReadHoldingRegisters(0, 2),
-            })
+        // Served over an in-memory duplex link, which is the same code path a socket takes:
+        // the accept loop is the only thing a real listener adds.
+        let (server_end, client_end) = tokio::io::duplex(256);
+        let modbus = ModbusServer::new(server);
+        let handle = modbus.handle();
+        let serving = tokio::spawn(modbus.serve_link(FrameTransport::<_, Tcp>::new(server_end)));
+
+        let mut client: RmClient<_, Tcp> = RmClient::new(FrameTransport::new(client_end));
+        let registers = client
+            .read_holding_registers(UnitId(1), Address(0), Quantity(2))
             .await
             .unwrap();
-        assert!(matches!(resp, Response::ReadHoldingRegisters(v) if v == vec![10, 20]));
+        assert_eq!(registers, vec![RegisterValue(10), RegisterValue(20)]);
+
+        handle.shutdown().await;
+        let _ = serving.await;
     }
 
     #[tokio::test]
@@ -566,11 +586,21 @@ mod tests {
     async fn ut_handle_read_holding_returns_seeded_values() {
         let mem = seeded_memory(&[10, 20]);
         let (log, _) = recording_log();
-        let resp =
-            handle_request::<SlaveKey, _>(1, Request::ReadHoldingRegisters(0, 2), &mem, &log, true)
-                .await
-                .unwrap();
-        assert!(matches!(resp, Response::ReadHoldingRegisters(v) if v == vec![10, 20]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(0),
+                quantity: Quantity(2),
+            },
+            &mem,
+            &log,
+            true,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(resp, ResponsePdu::ReadHoldingRegisters { registers: v } if v == vec![RegisterValue(10), RegisterValue(20)])
+        );
     }
 
     #[tokio::test]
@@ -580,8 +610,11 @@ mod tests {
         let (log, _) = recording_log();
         // Slave 2 has no registered ranges, so the lookup fails.
         let err = handle_request::<SlaveKey, _>(
-            2,
-            Request::ReadHoldingRegisters(0, 2),
+            UnitId(2),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(0),
+                quantity: Quantity(2),
+            },
             &mem,
             &log,
             false,
@@ -596,19 +629,33 @@ mod tests {
     async fn ut_handle_write_single_register_persists() {
         let mem = seeded_memory(&[]);
         let (log, _) = recording_log();
-        handle_request::<SlaveKey, _>(1, Request::WriteSingleRegister(1, 99), &mem, &log, false)
-            .await
-            .unwrap();
-        let resp = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadHoldingRegisters(1, 1),
+        handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::WriteSingleRegister {
+                address: Address(1),
+                value: RegisterValue(99),
+            },
             &mem,
             &log,
             false,
         )
         .await
         .unwrap();
-        assert!(matches!(resp, Response::ReadHoldingRegisters(v) if v == vec![99]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(1),
+                quantity: Quantity(1),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(resp, ResponsePdu::ReadHoldingRegisters { registers: v } if v == vec![RegisterValue(99)])
+        );
     }
 
     #[tokio::test]
@@ -618,9 +665,18 @@ mod tests {
 
         // verbose = true: a "received" line plus a "successful" line.
         let (log, buf) = recording_log();
-        handle_request::<SlaveKey, _>(1, Request::ReadHoldingRegisters(0, 2), &mem, &log, true)
-            .await
-            .unwrap();
+        handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(0),
+                quantity: Quantity(2),
+            },
+            &mem,
+            &log,
+            true,
+        )
+        .await
+        .unwrap();
         let verbose = buf.lock().unwrap().clone();
         assert_eq!(verbose.len(), 2);
         assert!(verbose[0].contains("received"));
@@ -628,9 +684,18 @@ mod tests {
 
         // verbose = false: only the "received" line.
         let (log, buf) = recording_log();
-        handle_request::<SlaveKey, _>(1, Request::ReadHoldingRegisters(0, 2), &mem, &log, false)
-            .await
-            .unwrap();
+        handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(0),
+                quantity: Quantity(2),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
         let quiet = buf.lock().unwrap().clone();
         assert_eq!(quiet.len(), 1);
         assert!(quiet[0].contains("received"));
@@ -645,7 +710,10 @@ mod tests {
         seed: &[u16],
     ) -> Arc<RwLock<Memory<Key<SlaveKey>>>> {
         let key = Key {
-            id: SlaveKey { slave_id: 1, kind },
+            id: SlaveKey {
+                slave_id: UnitId(1),
+                kind,
+            },
         };
         let mut mem = Memory::<Key<SlaveKey>>::default();
         mem.add_ranges(key.clone(), &MemKind::ReadWrite(ty), &[Range::new(0, len)]);
@@ -666,8 +734,11 @@ mod tests {
         let coils = vec![true, false, true, true, false];
 
         let resp = handle_request::<SlaveKey, _>(
-            1,
-            Request::WriteMultipleCoils(1, coils.clone().into()),
+            UnitId(1),
+            RequestPdu::WriteMultipleCoils {
+                address: Address(1),
+                coils: coils.clone(),
+            },
             &mem,
             &log,
             false,
@@ -676,12 +747,27 @@ mod tests {
         .unwrap();
         // Regression: the write range length must equal values.len(), not 1. Before the fix
         // `Memory::write` rejected any multi-coil write (range.length() != values.len()).
-        assert!(matches!(resp, Response::WriteMultipleCoils(1, 5)));
+        assert!(matches!(
+            resp,
+            ResponsePdu::WriteMultipleCoils {
+                address: Address(1),
+                quantity: Quantity(5)
+            }
+        ));
 
-        let read = handle_request::<SlaveKey, _>(1, Request::ReadCoils(1, 5), &mem, &log, false)
-            .await
-            .unwrap();
-        assert!(matches!(read, Response::ReadCoils(v) if v == coils));
+        let read = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadCoils {
+                address: Address(1),
+                quantity: Quantity(5),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(read, ResponsePdu::ReadCoils { coils: v } if v == coils));
     }
 
     #[tokio::test]
@@ -691,8 +777,11 @@ mod tests {
         let (log, _) = recording_log();
         // addr 6 + 5 coils overruns the registered [0, 8) region.
         let err = handle_request::<SlaveKey, _>(
-            1,
-            Request::WriteMultipleCoils(6, vec![true; 5].into()),
+            UnitId(1),
+            RequestPdu::WriteMultipleCoils {
+                address: Address(6),
+                coils: vec![true; 5],
+            },
             &mem,
             &log,
             false,
@@ -709,10 +798,21 @@ mod tests {
     async fn ut_read_coils_returns_seeded_bits() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[1, 0, 1, 0]);
         let (log, _) = recording_log();
-        let resp = handle_request::<SlaveKey, _>(1, Request::ReadCoils(0, 4), &mem, &log, false)
-            .await
-            .unwrap();
-        assert!(matches!(resp, Response::ReadCoils(v) if v == vec![true, false, true, false]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadCoils {
+                address: Address(0),
+                quantity: Quantity(4),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(resp, ResponsePdu::ReadCoils { coils: v } if v == vec![true, false, true, false])
+        );
     }
 
     #[tokio::test]
@@ -720,9 +820,18 @@ mod tests {
     async fn ut_read_coils_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
-        let err = handle_request::<SlaveKey, _>(1, Request::ReadCoils(10, 2), &mem, &log, false)
-            .await
-            .unwrap_err();
+        let err = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadCoils {
+                address: Address(10),
+                quantity: Quantity(2),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalDataAddress);
     }
 
@@ -731,11 +840,21 @@ mod tests {
     async fn ut_read_discrete_inputs_returns_seeded_bits() {
         let mem = seeded(RegKind::DiscreteInput, CellType::Coil, 3, &[0, 1, 1]);
         let (log, _) = recording_log();
-        let resp =
-            handle_request::<SlaveKey, _>(1, Request::ReadDiscreteInputs(0, 3), &mem, &log, false)
-                .await
-                .unwrap();
-        assert!(matches!(resp, Response::ReadDiscreteInputs(v) if v == vec![false, true, true]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadDiscreteInputs {
+                address: Address(0),
+                quantity: Quantity(3),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(resp, ResponsePdu::ReadDiscreteInputs { inputs: v } if v == vec![false, true, true])
+        );
     }
 
     #[tokio::test]
@@ -743,10 +862,18 @@ mod tests {
     async fn ut_read_discrete_inputs_unknown_slave_is_illegal_data_address() {
         let mem = seeded(RegKind::DiscreteInput, CellType::Coil, 3, &[]);
         let (log, _) = recording_log();
-        let err =
-            handle_request::<SlaveKey, _>(2, Request::ReadDiscreteInputs(0, 3), &mem, &log, false)
-                .await
-                .unwrap_err();
+        let err = handle_request::<SlaveKey, _>(
+            UnitId(2),
+            RequestPdu::ReadDiscreteInputs {
+                address: Address(0),
+                quantity: Quantity(3),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalDataAddress);
     }
 
@@ -757,11 +884,21 @@ mod tests {
     async fn ut_read_input_registers_returns_seeded_values() {
         let mem = seeded(RegKind::InputRegister, CellType::Register, 3, &[7, 8, 9]);
         let (log, _) = recording_log();
-        let resp =
-            handle_request::<SlaveKey, _>(1, Request::ReadInputRegisters(0, 3), &mem, &log, false)
-                .await
-                .unwrap();
-        assert!(matches!(resp, Response::ReadInputRegisters(v) if v == vec![7, 8, 9]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadInputRegisters {
+                address: Address(0),
+                quantity: Quantity(3),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(resp, ResponsePdu::ReadInputRegisters { registers: v } if v == vec![RegisterValue(7), RegisterValue(8), RegisterValue(9)])
+        );
     }
 
     #[tokio::test]
@@ -769,10 +906,18 @@ mod tests {
     async fn ut_read_input_registers_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::InputRegister, CellType::Register, 3, &[]);
         let (log, _) = recording_log();
-        let err =
-            handle_request::<SlaveKey, _>(1, Request::ReadInputRegisters(2, 5), &mem, &log, false)
-                .await
-                .unwrap_err();
+        let err = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadInputRegisters {
+                address: Address(2),
+                quantity: Quantity(5),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalDataAddress);
     }
 
@@ -782,8 +927,11 @@ mod tests {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
         let err = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadHoldingRegisters(3, 4),
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(3),
+                quantity: Quantity(4),
+            },
             &mem,
             &log,
             false,
@@ -800,15 +948,38 @@ mod tests {
     async fn ut_write_single_coil_persists() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
-        let resp =
-            handle_request::<SlaveKey, _>(1, Request::WriteSingleCoil(2, true), &mem, &log, false)
-                .await
-                .unwrap();
-        assert!(matches!(resp, Response::WriteSingleCoil(2, true)));
-        let read = handle_request::<SlaveKey, _>(1, Request::ReadCoils(2, 1), &mem, &log, false)
-            .await
-            .unwrap();
-        assert!(matches!(read, Response::ReadCoils(v) if v == vec![true]));
+        let resp = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::WriteSingleCoil {
+                address: Address(2),
+                value: true,
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            resp,
+            ResponsePdu::WriteSingleCoil {
+                address: Address(2),
+                value: true
+            }
+        ));
+        let read = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadCoils {
+                address: Address(2),
+                quantity: Quantity(1),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(read, ResponsePdu::ReadCoils { coils: v } if v == vec![true]));
     }
 
     #[tokio::test]
@@ -816,10 +987,18 @@ mod tests {
     async fn ut_write_single_coil_out_of_range_is_illegal_data_address() {
         let mem = seeded(RegKind::Coil, CellType::Coil, 4, &[]);
         let (log, _) = recording_log();
-        let err =
-            handle_request::<SlaveKey, _>(1, Request::WriteSingleCoil(9, true), &mem, &log, false)
-                .await
-                .unwrap_err();
+        let err = handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::WriteSingleCoil {
+                address: Address(9),
+                value: true,
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalDataAddress);
     }
 
@@ -829,8 +1008,11 @@ mod tests {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
         let err = handle_request::<SlaveKey, _>(
-            1,
-            Request::WriteSingleRegister(99, 1),
+            UnitId(1),
+            RequestPdu::WriteSingleRegister {
+                address: Address(99),
+                value: RegisterValue(1),
+            },
             &mem,
             &log,
             false,
@@ -848,25 +1030,39 @@ mod tests {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 8, &[]);
         let (log, _) = recording_log();
         let resp = handle_request::<SlaveKey, _>(
-            1,
-            Request::WriteMultipleRegisters(1, vec![11, 22, 33].into()),
+            UnitId(1),
+            RequestPdu::WriteMultipleRegisters {
+                address: Address(1),
+                registers: vec![11, 22, 33].into_iter().map(RegisterValue).collect(),
+            },
             &mem,
             &log,
             false,
         )
         .await
         .unwrap();
-        assert!(matches!(resp, Response::WriteMultipleRegisters(1, 3)));
+        assert!(matches!(
+            resp,
+            ResponsePdu::WriteMultipleRegisters {
+                address: Address(1),
+                quantity: Quantity(3)
+            }
+        ));
         let read = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadHoldingRegisters(1, 3),
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(1),
+                quantity: Quantity(3),
+            },
             &mem,
             &log,
             false,
         )
         .await
         .unwrap();
-        assert!(matches!(read, Response::ReadHoldingRegisters(v) if v == vec![11, 22, 33]));
+        assert!(
+            matches!(read, ResponsePdu::ReadHoldingRegisters { registers: v } if v == vec![RegisterValue(11), RegisterValue(22), RegisterValue(33)])
+        );
     }
 
     #[tokio::test]
@@ -875,8 +1071,11 @@ mod tests {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
         let err = handle_request::<SlaveKey, _>(
-            1,
-            Request::WriteMultipleRegisters(3, vec![1, 2, 3].into()),
+            UnitId(1),
+            RequestPdu::WriteMultipleRegisters {
+                address: Address(3),
+                registers: vec![1, 2, 3].into_iter().map(RegisterValue).collect(),
+            },
             &mem,
             &log,
             false,
@@ -900,25 +1099,37 @@ mod tests {
         let (log, _) = recording_log();
         // Read [0,2), write [2,4) = [77, 88].
         let resp = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadWriteMultipleRegisters(0, 2, 2, vec![77, 88].into()),
+            UnitId(1),
+            RequestPdu::ReadWriteMultipleRegisters {
+                read_address: Address(0),
+                read_quantity: Quantity(2),
+                write_address: Address(2),
+                registers: vec![77, 88].into_iter().map(RegisterValue).collect(),
+            },
             &mem,
             &log,
             false,
         )
         .await
         .unwrap();
-        assert!(matches!(resp, Response::ReadWriteMultipleRegisters(v) if v == vec![5, 6]));
+        assert!(
+            matches!(resp, ResponsePdu::ReadWriteMultipleRegisters { registers: v } if v == vec![RegisterValue(5), RegisterValue(6)])
+        );
         let read = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadHoldingRegisters(2, 2),
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(2),
+                quantity: Quantity(2),
+            },
             &mem,
             &log,
             false,
         )
         .await
         .unwrap();
-        assert!(matches!(read, Response::ReadHoldingRegisters(v) if v == vec![77, 88]));
+        assert!(
+            matches!(read, ResponsePdu::ReadHoldingRegisters { registers: v } if v == vec![RegisterValue(77), RegisterValue(88)])
+        );
     }
 
     #[tokio::test]
@@ -932,8 +1143,13 @@ mod tests {
         );
         let (log, _) = recording_log();
         let err = handle_request::<SlaveKey, _>(
-            1,
-            Request::ReadWriteMultipleRegisters(0, 2, 10, vec![1, 2].into()),
+            UnitId(1),
+            RequestPdu::ReadWriteMultipleRegisters {
+                read_address: Address(0),
+                read_quantity: Quantity(2),
+                write_address: Address(10),
+                registers: vec![1, 2].into_iter().map(RegisterValue).collect(),
+            },
             &mem,
             &log,
             false,
@@ -951,7 +1167,7 @@ mod tests {
         for &slave in &[3u8, 9u8] {
             let key = Key {
                 id: SlaveKey {
-                    slave_id: slave,
+                    slave_id: UnitId(slave),
                     kind: RegKind::HoldingRegister,
                 },
             };
@@ -974,15 +1190,20 @@ mod tests {
         // Both slaves are answered from their own declared regions.
         for &slave in &[3u8, 9u8] {
             let resp = handle_request::<SlaveKey, _>(
-                slave,
-                Request::ReadHoldingRegisters(0, 2),
+                UnitId(slave),
+                RequestPdu::ReadHoldingRegisters {
+                    address: Address(0),
+                    quantity: Quantity(2),
+                },
                 &mem,
                 &log,
                 false,
             )
             .await
             .unwrap();
-            assert!(matches!(resp, Response::ReadHoldingRegisters(v) if v[0] == slave as u16));
+            assert!(
+                matches!(resp, ResponsePdu::ReadHoldingRegisters { registers: v } if v[0] == RegisterValue(slave as u16))
+            );
         }
     }
 
@@ -998,9 +1219,18 @@ mod tests {
 
         // A supported request logs "request received".
         let (log, buf) = recording_log();
-        handle_request::<SlaveKey, _>(1, Request::ReadHoldingRegisters(0, 2), &mem, &log, false)
-            .await
-            .unwrap();
+        handle_request::<SlaveKey, _>(
+            UnitId(1),
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(0),
+                quantity: Quantity(2),
+            },
+            &mem,
+            &log,
+            false,
+        )
+        .await
+        .unwrap();
         assert!(
             buf.lock()
                 .unwrap()
@@ -1010,9 +1240,10 @@ mod tests {
 
         // A rejected function code still logs "request received" before the IllegalFunction reply.
         let (log, buf) = recording_log();
-        let err = handle_request::<SlaveKey, _>(1, Request::ReportServerId, &mem, &log, false)
-            .await
-            .unwrap_err();
+        let err =
+            handle_request::<SlaveKey, _>(UnitId(1), RequestPdu::ReportServerId, &mem, &log, false)
+                .await
+                .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalFunction);
         assert!(
             buf.lock()
@@ -1029,9 +1260,10 @@ mod tests {
     async fn ut_report_server_id_is_illegal_function() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
-        let err = handle_request::<SlaveKey, _>(1, Request::ReportServerId, &mem, &log, false)
-            .await
-            .unwrap_err();
+        let err =
+            handle_request::<SlaveKey, _>(UnitId(1), RequestPdu::ReportServerId, &mem, &log, false)
+                .await
+                .unwrap_err();
         assert_eq!(err, ExceptionCode::IllegalFunction);
     }
 
@@ -1044,7 +1276,7 @@ mod tests {
             ($mem:expr, $req:expr) => {{
                 let mem = $mem;
                 let (log, buf) = recording_log();
-                handle_request::<SlaveKey, _>(1, $req, &mem, &log, true)
+                handle_request::<SlaveKey, _>(UnitId(1), $req, &mem, &log, true)
                     .await
                     .unwrap();
                 assert!(
@@ -1055,31 +1287,52 @@ mod tests {
         }
         ok!(
             seeded(RegKind::Coil, CellType::Coil, 8, &[1, 0, 1, 0, 1, 0, 1, 0]),
-            Request::ReadCoils(0, 4)
+            RequestPdu::ReadCoils {
+                address: Address(0),
+                quantity: Quantity(4)
+            }
         );
         ok!(
             seeded(RegKind::Coil, CellType::Coil, 8, &[]),
-            Request::WriteSingleCoil(0, true)
+            RequestPdu::WriteSingleCoil {
+                address: Address(0),
+                value: true
+            }
         );
         ok!(
             seeded(RegKind::Coil, CellType::Coil, 8, &[]),
-            Request::WriteMultipleCoils(0, vec![true, false, true].into())
+            RequestPdu::WriteMultipleCoils {
+                address: Address(0),
+                coils: vec![true, false, true]
+            }
         );
         ok!(
             seeded(RegKind::DiscreteInput, CellType::Coil, 4, &[1, 1, 1, 1]),
-            Request::ReadDiscreteInputs(0, 4)
+            RequestPdu::ReadDiscreteInputs {
+                address: Address(0),
+                quantity: Quantity(4)
+            }
         );
         ok!(
             seeded(RegKind::InputRegister, CellType::Register, 4, &[1, 2, 3, 4]),
-            Request::ReadInputRegisters(0, 4)
+            RequestPdu::ReadInputRegisters {
+                address: Address(0),
+                quantity: Quantity(4)
+            }
         );
         ok!(
             seeded(RegKind::HoldingRegister, CellType::Register, 8, &[]),
-            Request::WriteSingleRegister(0, 9)
+            RequestPdu::WriteSingleRegister {
+                address: Address(0),
+                value: RegisterValue(9)
+            }
         );
         ok!(
             seeded(RegKind::HoldingRegister, CellType::Register, 8, &[]),
-            Request::WriteMultipleRegisters(0, vec![1, 2, 3].into())
+            RequestPdu::WriteMultipleRegisters {
+                address: Address(0),
+                registers: vec![1, 2, 3].into_iter().map(RegisterValue).collect()
+            }
         );
         ok!(
             seeded(
@@ -1088,7 +1341,12 @@ mod tests {
                 8,
                 &[5, 6, 7, 8]
             ),
-            Request::ReadWriteMultipleRegisters(0, 2, 2, vec![7, 8].into())
+            RequestPdu::ReadWriteMultipleRegisters {
+                read_address: Address(0),
+                read_quantity: Quantity(2),
+                write_address: Address(2),
+                registers: vec![7, 8].into_iter().map(RegisterValue).collect()
+            }
         );
     }
 
@@ -1099,7 +1357,7 @@ mod tests {
             ($mem:expr, $req:expr) => {{
                 let mem = $mem;
                 let (log, buf) = recording_log();
-                let _ = handle_request::<SlaveKey, _>(1, $req, &mem, &log, true).await;
+                let _ = handle_request::<SlaveKey, _>(UnitId(1), $req, &mem, &log, true).await;
                 assert!(
                     buf.lock().unwrap().iter().any(|l| l.contains("failed")),
                     "missing failure log line"
@@ -1108,35 +1366,59 @@ mod tests {
         }
         fail!(
             seeded(RegKind::Coil, CellType::Coil, 4, &[]),
-            Request::ReadCoils(10, 2)
+            RequestPdu::ReadCoils {
+                address: Address(10),
+                quantity: Quantity(2)
+            }
         );
         fail!(
             seeded(RegKind::Coil, CellType::Coil, 4, &[]),
-            Request::WriteSingleCoil(9, true)
+            RequestPdu::WriteSingleCoil {
+                address: Address(9),
+                value: true
+            }
         );
         fail!(
             seeded(RegKind::Coil, CellType::Coil, 4, &[]),
-            Request::WriteMultipleCoils(6, vec![true; 5].into())
+            RequestPdu::WriteMultipleCoils {
+                address: Address(6),
+                coils: vec![true; 5]
+            }
         );
         fail!(
             seeded(RegKind::DiscreteInput, CellType::Coil, 4, &[]),
-            Request::ReadDiscreteInputs(10, 2)
+            RequestPdu::ReadDiscreteInputs {
+                address: Address(10),
+                quantity: Quantity(2)
+            }
         );
         fail!(
             seeded(RegKind::InputRegister, CellType::Register, 4, &[]),
-            Request::ReadInputRegisters(10, 2)
+            RequestPdu::ReadInputRegisters {
+                address: Address(10),
+                quantity: Quantity(2)
+            }
         );
         fail!(
             seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]),
-            Request::ReadHoldingRegisters(10, 2)
+            RequestPdu::ReadHoldingRegisters {
+                address: Address(10),
+                quantity: Quantity(2)
+            }
         );
         fail!(
             seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]),
-            Request::WriteSingleRegister(99, 1)
+            RequestPdu::WriteSingleRegister {
+                address: Address(99),
+                value: RegisterValue(1)
+            }
         );
         fail!(
             seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]),
-            Request::WriteMultipleRegisters(3, vec![1, 2, 3].into())
+            RequestPdu::WriteMultipleRegisters {
+                address: Address(3),
+                registers: vec![1, 2, 3].into_iter().map(RegisterValue).collect()
+            }
         );
         // Write address out of range -> writable check fails (verbose failure branch).
         fail!(
@@ -1146,21 +1428,48 @@ mod tests {
                 4,
                 &[1, 2, 3, 4]
             ),
-            Request::ReadWriteMultipleRegisters(0, 2, 10, vec![1, 2].into())
+            RequestPdu::ReadWriteMultipleRegisters {
+                read_address: Address(0),
+                read_quantity: Quantity(2),
+                write_address: Address(10),
+                registers: vec![1, 2].into_iter().map(RegisterValue).collect()
+            }
         );
     }
 
     #[tokio::test]
-    /// MB-R-059 — mask-write-register, read-device-identification, and custom function codes are rejected with `IllegalFunction`.
+    /// MB-R-059 — every function code outside the nine the server implements is rejected with
+    /// `IllegalFunction`, whatever the frame layer is able to decode.
     async fn ut_unsupported_function_codes_are_illegal() {
         let mem = seeded(RegKind::HoldingRegister, CellType::Register, 4, &[]);
         let (log, _) = recording_log();
         for req in [
-            Request::MaskWriteRegister(0, 0, 0),
-            Request::ReadDeviceIdentification(tokio_modbus::prelude::ReadCode::Basic, 0),
-            Request::Custom(0x65, vec![].into()),
+            RequestPdu::MaskWriteRegister {
+                address: Address(0),
+                and_mask: Mask(0),
+                or_mask: Mask(0),
+            },
+            RequestPdu::EncapsulatedInterfaceTransport(MeiRequest::ReadDeviceIdentification {
+                read_device_id_code: ReadDeviceIdCode::Basic,
+                object_id: 0,
+            }),
+            RequestPdu::ReportServerId,
+            RequestPdu::ReadExceptionStatus,
+            RequestPdu::GetCommEventCounter,
+            RequestPdu::GetCommEventLog,
+            RequestPdu::Diagnostics {
+                sub_function: DiagnosticSubFunction::ReturnQueryData,
+                data: vec![0x1234],
+            },
+            RequestPdu::ReadFifoQueue {
+                address: Address(0),
+            },
+            RequestPdu::Custom {
+                code: 0x65,
+                data: vec![],
+            },
         ] {
-            let err = handle_request::<SlaveKey, _>(1, req, &mem, &log, false)
+            let err = handle_request::<SlaveKey, _>(UnitId(1), req, &mem, &log, false)
                 .await
                 .unwrap_err();
             assert_eq!(err, ExceptionCode::IllegalFunction);

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -510,8 +510,9 @@ mod tests {
     use ferrowl_codec::Kind as RegKind;
     use ferrowl_store::CellKind as MemKind;
     use rust_modbus::{
-        Address, Client as RmClient, DiagnosticSubFunction, FrameTransport, Mask, MeiRequest,
-        ReadDeviceIdCode, Server as ModbusServer, Tcp,
+        Address, Client as RmClient, DiagnosticSubFunction, FileNumber, FileRecordRead,
+        FileRecordWrite, FrameTransport, Mask, MeiRequest, ReadDeviceIdCode, RecordLength,
+        RecordNumber, Rtu, Server as ModbusServer, Tcp,
     };
     use std::sync::Mutex;
 
@@ -571,6 +572,76 @@ mod tests {
         let serving = tokio::spawn(modbus.serve_link(FrameTransport::<_, Tcp>::new(server_end)));
 
         let mut client: RmClient<_, Tcp> = RmClient::new(FrameTransport::new(client_end));
+        let registers = client
+            .read_holding_registers(UnitId(1), Address(0), Quantity(2))
+            .await
+            .unwrap();
+        assert_eq!(registers, vec![RegisterValue(10), RegisterValue(20)]);
+
+        handle.shutdown().await;
+        let _ = serving.await;
+    }
+
+    #[tokio::test]
+    /// MB-R-103 — an RTU server applies a request addressed to slave id 0 to the store exactly as
+    /// it would any other, and emits no response frame for it.
+    async fn ut_rtu_broadcast_request_is_applied_and_unanswered() {
+        // Both the broadcast address and slave 1 have declared regions: the broadcast write
+        // lands in slave 0's, and the follow-up read of slave 1 is what proves no stray
+        // broadcast response was left sitting in the stream ahead of it.
+        let mut mem = Memory::<Key<SlaveKey>>::default();
+        for slave in [UnitId(0), UnitId(1)] {
+            let key = Key {
+                id: SlaveKey {
+                    slave_id: slave,
+                    kind: RegKind::HoldingRegister,
+                },
+            };
+            mem.add_ranges(
+                key.clone(),
+                &MemKind::ReadWrite(CellType::Register),
+                &[Range::new(0, 4)],
+            );
+            mem.write(key, &CellType::Register, &Range::new(0, 2), &[10, 20])
+                .unwrap();
+        }
+        let mem = Arc::new(RwLock::new(mem));
+        let (log, _) = recording_log();
+        let server = Server::new(mem.clone(), log, true);
+
+        let (server_end, client_end) = tokio::io::duplex(256);
+        let modbus = ModbusServer::new(server);
+        let handle = modbus.handle();
+        let serving = tokio::spawn(modbus.serve_link(FrameTransport::<_, Rtu>::new(server_end)));
+
+        let mut client: RmClient<_, Rtu> = RmClient::new(FrameTransport::new(client_end));
+        // Returns as soon as the frame is written — nothing is awaited, because nothing answers.
+        client
+            .write_single_register(UnitId(0), Address(1), RegisterValue(0x1234))
+            .await
+            .unwrap();
+
+        // The store took the write all the same.
+        let key = Key {
+            id: SlaveKey {
+                slave_id: UnitId(0),
+                kind: RegKind::HoldingRegister,
+            },
+        };
+        let mut applied = Vec::new();
+        for _ in 0..50 {
+            applied = mem
+                .read()
+                .read(key.clone(), &CellType::Register, &Range::new(0, 2))
+                .unwrap();
+            if applied == vec![10, 0x1234] {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(applied, vec![10, 0x1234]);
+
+        // The next exchange lines up, so the broadcast put no frame on the wire.
         let registers = client
             .read_holding_registers(UnitId(1), Address(0), Quantity(2))
             .await
@@ -1460,6 +1531,20 @@ mod tests {
             RequestPdu::Diagnostics {
                 sub_function: DiagnosticSubFunction::ReturnQueryData,
                 data: vec![0x1234],
+            },
+            RequestPdu::ReadFileRecord {
+                records: vec![FileRecordRead {
+                    file_number: FileNumber(1),
+                    record_number: RecordNumber(0),
+                    record_length: RecordLength(1),
+                }],
+            },
+            RequestPdu::WriteFileRecord {
+                records: vec![FileRecordWrite {
+                    file_number: FileNumber(1),
+                    record_number: RecordNumber(0),
+                    values: vec![RegisterValue(1)],
+                }],
             },
             RequestPdu::ReadFifoQueue {
                 address: Address(0),

--- a/ferrowl-modbus/src/tcp/client.rs
+++ b/ferrowl-modbus/src/tcp/client.rs
@@ -4,6 +4,7 @@ use crate::{Command, Error, Key, KeyParams, LogFn, Operation, TcpError};
 
 use ferrowl_store::Memory;
 use parking_lot::RwLock as MemLock;
+use rust_modbus::{Client as ModbusClient, TcpConfig, connect_tcp};
 use tokio::task::JoinHandle;
 
 use std::net::SocketAddr;
@@ -76,9 +77,9 @@ impl<T: KeyParams> ClientBuilder<T> {
 }
 
 /// A connected Modbus TCP client. Connection setup is TCP-specific; the read/command loop is
-/// shared via the internal `ClientCore`.
+/// shared via the internal `ClientCore`, over a socket carrying Modbus TCP framing.
 pub struct Client {
-    pub(crate) core: ClientCore,
+    pub(crate) core: ClientCore<tokio::net::TcpStream, rust_modbus::Tcp>,
 }
 
 impl Client {
@@ -90,12 +91,14 @@ impl Client {
             .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
         match tokio::time::timeout(
             std::time::Duration::from_millis(config.timeout_ms as u64),
-            tokio_modbus::client::tcp::connect(addr),
+            connect_tcp(addr, TcpConfig::default()),
         )
         .await
         {
-            Ok(Ok(context)) => Ok(Self {
-                core: ClientCore { context },
+            Ok(Ok(transport)) => Ok(Self {
+                core: ClientCore {
+                    client: ModbusClient::<_, _>::new(transport),
+                },
             }),
             Ok(Err(e)) => Err(TcpError::Error(e).into()),
             Err(e) => Err(TcpError::Timeout(e).into()),

--- a/ferrowl-modbus/src/tcp/server.rs
+++ b/ferrowl-modbus/src/tcp/server.rs
@@ -8,12 +8,11 @@ use ferrowl_store::Memory;
 
 // External
 use parking_lot::RwLock as MemLock;
+use rust_modbus::{Server as ModbusServer, TcpListener};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tokio_modbus::server::tcp::{Server as TcpServer, accept_tcp_connection};
 
 /// Builds and spawns a Modbus TCP server task answering requests from the
 /// shared `memory`.
@@ -54,32 +53,11 @@ where
         .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
     match TcpListener::bind(addr).await {
         Ok(listener) => {
-            let server = TcpServer::new(listener);
-            let memory = memory.clone();
-            let log = log.clone();
+            // One service instance answers every accepted connection, so all of them share the
+            // one store (MB-R-070). TCP servers log per-request outcomes (verbose = true).
+            let server = ModbusServer::new(Server::new(memory, log, true));
             Ok(tokio::task::spawn(async move {
-                // TCP servers log per-request outcomes (verbose = true).
-                let new_request_handler =
-                    |_socket_addr| Ok(Some(Server::new(memory.clone(), log.clone(), true)));
-                let on_connected = |stream, socket_addr| async move {
-                    accept_tcp_connection(stream, socket_addr, new_request_handler)
-                };
-                let on_process_log = log.clone();
-                // `on_process_error` is a sync callback (not awaited by `tokio_modbus`), so the
-                // log line is emitted on a detached task instead of blocking a worker thread to
-                // await it inline.
-                let on_process_error = move |err| {
-                    let on_process_log = on_process_log.clone();
-                    tokio::task::spawn(async move {
-                        on_process_log
-                            .invoke(format!("Server processing failed. [{}]", err))
-                            .await;
-                    });
-                };
-                server
-                    .serve(&on_connected, on_process_error)
-                    .await
-                    .map_err(Error::Server)
+                server.serve(listener).await.map_err(Error::Server)
             }))
         }
         Err(e) => Err(Error::Server(e)),

--- a/ferrowl-modbus/tests/rtu_serial.rs
+++ b/ferrowl-modbus/tests/rtu_serial.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ferrowl_modbus::rtu;
-use ferrowl_modbus::{Command, Error, FunctionCode, Key, Operation, SerialError, SlaveKey};
+use ferrowl_modbus::{Command, Error, FunctionCode, Key, Operation, SerialError, SlaveKey, UnitId};
 use ferrowl_store::{Memory, Range};
 use parking_lot::RwLock as MemLock;
 use tokio::sync::{RwLock, mpsc};
@@ -59,7 +59,7 @@ async fn rtu_server_open_failure_fails_start() {
 /// reconnect disabled it ends the client task with the error.
 async fn rtu_client_open_failure_reconnect_false_dies() {
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 2),
     }]));

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use ferrowl_codec::Kind as RegKind;
 use ferrowl_modbus::tcp;
-use ferrowl_modbus::{Command, FunctionCode, Key, Operation, SlaveKey};
+use ferrowl_modbus::{Address, Command, FunctionCode, Key, Operation, SlaveKey, UnitId, Word};
 use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
 use parking_lot::Mutex;
 use parking_lot::RwLock as MemLock;
@@ -20,7 +20,10 @@ use tokio::time::sleep;
 type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
 
 fn key(kind: RegKind) -> Key<SlaveKey> {
-    Key::new(SlaveKey { slave_id: 1, kind })
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
 }
 
 /// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
@@ -169,22 +172,22 @@ async fn tcp_client_polls_server_and_executes_commands() {
     // Operations cover every read function code the client supports.
     let operations = Arc::new(RwLock::new(vec![
         Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadCoils,
             range: Range::new(0, 4),
         },
         Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadDiscreteInputs,
             range: Range::new(0, 4),
         },
         Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadInputRegisters,
             range: Range::new(0, 4),
         },
         Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadHoldingRegisters,
             range: Range::new(0, 4),
         },
@@ -240,16 +243,30 @@ async fn tcp_client_polls_server_and_executes_commands() {
     }
 
     // Exercise every write command against the server.
-    tx.send(Command::WriteSingleRegister(1, 0, 99))
+    tx.send(Command::WriteSingleRegister(
+        UnitId(1),
+        Address(0),
+        Word(99),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteMultipleRegister(
+        UnitId(1),
+        Address(1),
+        vec![5, 6].into_iter().map(Word).collect(),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteSingleCoil(UnitId(1), Address(5), true))
         .await
         .unwrap();
-    tx.send(Command::WriteMultipleRegister(1, 1, vec![5, 6]))
-        .await
-        .unwrap();
-    tx.send(Command::WriteSingleCoil(1, 5, true)).await.unwrap();
-    tx.send(Command::WriteMultipleCoils(1, 6, vec![true, false]))
-        .await
-        .unwrap();
+    tx.send(Command::WriteMultipleCoils(
+        UnitId(1),
+        Address(6),
+        vec![true, false],
+    ))
+    .await
+    .unwrap();
     sleep(Duration::from_millis(600)).await;
 
     {
@@ -294,7 +311,7 @@ async fn tcp_client_handles_server_rejections() {
         .expect("server failed to start");
 
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 2),
     }]));
@@ -312,16 +329,26 @@ async fn tcp_client_handles_server_rejections() {
     sleep(Duration::from_millis(800)).await;
 
     // Writes the server rejects -> the "invalid" command branches.
-    tx.send(Command::WriteSingleRegister(1, 0, 1))
+    tx.send(Command::WriteSingleRegister(UnitId(1), Address(0), Word(1)))
         .await
         .unwrap();
-    tx.send(Command::WriteMultipleRegister(1, 0, vec![1, 2]))
+    tx.send(Command::WriteMultipleRegister(
+        UnitId(1),
+        Address(0),
+        vec![1, 2].into_iter().map(Word).collect(),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteSingleCoil(UnitId(1), Address(0), true))
         .await
         .unwrap();
-    tx.send(Command::WriteSingleCoil(1, 0, true)).await.unwrap();
-    tx.send(Command::WriteMultipleCoils(1, 0, vec![true]))
-        .await
-        .unwrap();
+    tx.send(Command::WriteMultipleCoils(
+        UnitId(1),
+        Address(0),
+        vec![true],
+    ))
+    .await
+    .unwrap();
     sleep(Duration::from_millis(600)).await;
 
     tx.send(Command::Terminate).await.unwrap();
@@ -372,7 +399,7 @@ async fn tcp_server_serves_concurrent_clients() {
     // Two independent clients connect at the same time and both read from the one server.
     let ops = || {
         Arc::new(RwLock::new(vec![Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadHoldingRegisters,
             range: Range::new(0, 4),
         }]))
@@ -442,7 +469,7 @@ async fn tcp_client_reconnect_false_dies_on_refused_connect() {
     // instead of retrying forever.
     let port = free_port();
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 2),
     }]));
@@ -474,7 +501,7 @@ async fn tcp_client_reconnect_true_connects_once_a_listener_appears() {
     let cli_mem = client_mem();
 
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -566,7 +593,7 @@ async fn tcp_client_operation_list_mutated_at_runtime() {
 
     // Start with a single operation reading the holding registers.
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -596,7 +623,7 @@ async fn tcp_client_operation_list_mutated_at_runtime() {
 
     // Add an input-register operation at runtime — no reconnect.
     operations.write().await.push(Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadInputRegisters,
         range: Range::new(0, 4),
     });
@@ -636,7 +663,7 @@ async fn tcp_client_rereads_config_on_reconnect() {
 
     let shared_cfg = Arc::new(RwLock::new(config(bad_port)));
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -678,7 +705,7 @@ async fn tcp_client_backoff_resets_after_successful_run() {
     let cli_mem = client_mem();
 
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -749,7 +776,7 @@ async fn tcp_client_addresses_operation_slave_id() {
     // Server memory declared only under slave id 7. A request for any other slave finds no region.
     let k7 = || {
         Key::new(SlaveKey {
-            slave_id: 7,
+            slave_id: UnitId(7),
             kind: RegKind::HoldingRegister,
         })
     };
@@ -783,7 +810,7 @@ async fn tcp_client_addresses_operation_slave_id() {
     let cli_mem: Mem = Arc::new(MemLock::new(cm));
 
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 7,
+        slave_id: UnitId(7),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -830,7 +857,7 @@ async fn tcp_client_delays_before_first_poll() {
         ..config(port)
     };
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));
@@ -894,7 +921,7 @@ async fn tcp_client_read_times_out_when_server_silent() {
         ..config_no_reconnect(port)
     };
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 2),
     }]));
@@ -927,7 +954,7 @@ async fn tcp_client_success_resets_retry_counter() {
         .expect("server failed to start");
 
     let operations = Arc::new(RwLock::new(vec![Operation {
-        slave_id: 1,
+        slave_id: UnitId(1),
         fn_code: FunctionCode::ReadHoldingRegisters,
         range: Range::new(0, 4),
     }]));

--- a/ferrowl/Cargo.toml
+++ b/ferrowl/Cargo.toml
@@ -34,7 +34,15 @@ crossterm = { workspace = true }
 ratatui = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time", "rt", "signal"] }
+# `rt-multi-thread` is named here rather than inherited: the binary builds a multi-threaded
+# runtime itself, and it used to arrive only as a transitive feature of the Modbus library.
+tokio = { workspace = true, features = [
+    "sync",
+    "time",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+] }
 derive_builder = { workspace = true }
 parking_lot = { workspace = true }
 futures-util = { workspace = true }

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -209,6 +209,7 @@ impl<T: KeyParams> Instance<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ferrowl_modbus::UnitId;
 
     use std::sync::Arc;
 
@@ -247,7 +248,7 @@ mod tests {
 
     fn tcp_client_instance() -> Instance<SlaveKey> {
         let operations = Arc::new(RwLock::new(vec![Operation {
-            slave_id: 1,
+            slave_id: UnitId(1),
             fn_code: FunctionCode::ReadHoldingRegisters,
             range: Range::new(0, 2),
         }]));

--- a/ferrowl/src/lua.rs
+++ b/ferrowl/src/lua.rs
@@ -319,13 +319,14 @@ mod tests {
     use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Access, Format, Kind, RegisterBuilder};
     use ferrowl_modbus::SlaveKey;
+    use ferrowl_modbus::UnitId;
     use ferrowl_store::{CellKind as MemKind, CellType, Memory};
     use parking_lot::RwLock as MemLock;
     use tokio::sync::RwLock;
 
     fn holding(addr: u16) -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(addr))
@@ -344,7 +345,7 @@ mod tests {
         let mut memory: Memory<Key<SlaveKey>> = Memory::default();
         let key = Key {
             id: SlaveKey {
-                slave_id: 1u8,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -375,7 +376,7 @@ mod tests {
         registers.insert(
             "calc".to_string(),
             RegisterBuilder::default()
-                .slave_id(1u8)
+                .slave_id(UnitId(1))
                 .access(Access::ReadWrite)
                 .kind(Kind::HoldingRegister)
                 .address(ferrowl_codec::Address::Virtual)
@@ -456,7 +457,7 @@ mod tests {
             .read(
                 Key {
                     id: SlaveKey {
-                        slave_id: 1,
+                        slave_id: UnitId(1),
                         kind: Kind::HoldingRegister,
                     },
                 },
@@ -546,7 +547,7 @@ mod tests {
                 .read(
                     Key {
                         id: SlaveKey {
-                            slave_id: 1,
+                            slave_id: UnitId(1),
                             kind: Kind::HoldingRegister,
                         },
                     },
@@ -669,7 +670,7 @@ mod tests {
         registers.insert(
             "calc".to_string(),
             RegisterBuilder::default()
-                .slave_id(1u8)
+                .slave_id(UnitId(1))
                 .access(Access::ReadWrite)
                 .kind(Kind::HoldingRegister)
                 .address(ferrowl_codec::Address::Virtual)
@@ -700,7 +701,7 @@ mod tests {
         registers.insert(
             "calc".to_string(),
             RegisterBuilder::default()
-                .slave_id(1u8)
+                .slave_id(UnitId(1))
                 .access(Access::ReadWrite)
                 .kind(Kind::HoldingRegister)
                 .address(ferrowl_codec::Address::Virtual)
@@ -863,7 +864,7 @@ mod tests {
             .read(
                 Key {
                     id: SlaveKey {
-                        slave_id: 1,
+                        slave_id: UnitId(1),
                         kind: Kind::HoldingRegister,
                     },
                 },

--- a/ferrowl/src/lua/value_conv.rs
+++ b/ferrowl/src/lua/value_conv.rs
@@ -138,6 +138,7 @@ mod tests {
     use super::*;
     use ferrowl_codec::format::{Alignment, BitField, Endian, Resolution, Width, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn int_fmt(kind: fn((Endian, WordOrder, Resolution, BitField)) -> Format) -> Format {
         kind((
@@ -219,7 +220,7 @@ mod tests {
     /// nil fails.
     fn ut_virtual_value_from_type() {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Virtual)

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use ferrowl_codec::{Access, Address, Kind, Register};
-use ferrowl_modbus::{FunctionCode, Key, Operation, SlaveKey, Transport as NetConfig};
+use ferrowl_modbus::{FunctionCode, Key, Operation, SlaveKey, Transport as NetConfig, UnitId};
 use ferrowl_store::{CellKind as MemKind, CellType, Range};
 use tokio::sync::RwLock;
 
@@ -65,7 +65,7 @@ fn fn_code_key(fc: FunctionCode) -> u8 {
 /// Readable register spans grouped by `(slave, function-code key)`, each value carrying the
 /// function code and a list of `(start, end)` spans. Used for both operation and memory planning.
 type ReadableSpanGroups =
-    std::collections::BTreeMap<(u8, u8), (FunctionCode, Kind, Vec<(usize, usize)>)>;
+    std::collections::BTreeMap<(UnitId, u8), (FunctionCode, Kind, Vec<(usize, usize)>)>;
 
 fn group_readable_spans(
     registers: &[(String, String, Register, Vec<NamedValue>)],
@@ -314,6 +314,7 @@ pub(crate) fn build_instance(
 mod tests {
     use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Format, Kind, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
     use ferrowl_modbus::{Key, SlaveKey};
     use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
 
@@ -330,7 +331,7 @@ mod tests {
         Vec<crate::config::device::NamedValue>,
     ) {
         let register = RegisterBuilder::default()
-            .slave_id(slave)
+            .slave_id(UnitId(slave))
             .access(access)
             .kind(kind)
             .address(Address::Fixed(addr))
@@ -600,7 +601,7 @@ mod tests {
         let mut memory: Memory<Key<SlaveKey>> = Memory::default();
         let key = Key {
             id: SlaveKey {
-                slave_id: 1u8,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -611,7 +612,7 @@ mod tests {
         );
 
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -7,6 +7,7 @@ use ferrowl_codec::{
     Address, Format, Kind, Register, RegisterBuilder,
     format::{BitField, Endian, Resolution, Width, WordOrder},
 };
+use ferrowl_modbus::UnitId;
 use ferrowl_store::{CellType, Range};
 use ferrowl_ui::traits::ToLabel;
 use serde::{Deserialize, Serialize};
@@ -295,7 +296,7 @@ impl RegisterDef {
 
     pub fn register(&self) -> Register {
         RegisterBuilder::default()
-            .slave_id(self.slave_id)
+            .slave_id(UnitId(self.slave_id))
             .access(self.access.into())
             .kind(self.kind())
             .address(self.address())

--- a/ferrowl/src/module/modbus/dialog/input/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/input/mod.rs
@@ -12,6 +12,7 @@ use ferrowl_codec::format::{
     WordOrder as RegisterWordOrder,
 };
 use ferrowl_codec::{Address, Kind, Register, RegisterBuilder, encode};
+use ferrowl_modbus::UnitId;
 use ferrowl_ui::{
     state::{ButtonState, InputFieldState, SelectionState},
     traits::SetFocus,
@@ -335,7 +336,7 @@ impl EditInputDialog {
             .map_err(|_| "Slave ID must be 0–255.".to_string())?;
 
         let register = RegisterBuilder::default()
-            .slave_id(slave_id)
+            .slave_id(UnitId(slave_id))
             .access(self.access.state.get_value().0.clone())
             .kind(self.kind.state.get_value().0)
             .address(address)
@@ -530,6 +531,7 @@ mod apply_tests {
         Resolution, Width, WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn reg(
         kind: Kind,
@@ -539,7 +541,7 @@ mod apply_tests {
         format: RegisterFormat,
     ) -> Register {
         RegisterBuilder::default()
-            .slave_id(slave)
+            .slave_id(UnitId(slave))
             .access(access)
             .kind(kind)
             .address(address)
@@ -568,7 +570,7 @@ mod apply_tests {
 
         assert_eq!(edited.name, "temp");
         assert_eq!(edited.description, "a sensor");
-        assert_eq!(*edited.register.slave_id(), 7);
+        assert_eq!(*edited.register.slave_id(), UnitId(7));
         assert_eq!(*edited.register.kind(), Kind::HoldingRegister);
         assert_eq!(*edited.register.access(), Access::ReadWrite);
         assert_eq!(*edited.register.address(), Address::Fixed(100));
@@ -705,11 +707,12 @@ mod focus_tests {
         WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
     use ferrowl_ui::traits::HandleEvents;
 
     fn numeric_dialog() -> EditInputDialog {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))
@@ -727,7 +730,7 @@ mod focus_tests {
 
     fn coil_dialog() -> EditInputDialog {
         let register: Register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::Coil)
             .address(Address::Fixed(0))
@@ -811,7 +814,7 @@ mod focus_tests {
         );
 
         let single = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))

--- a/ferrowl/src/module/modbus/dialog/input/render.rs
+++ b/ferrowl/src/module/modbus/dialog/input/render.rs
@@ -318,6 +318,7 @@ mod render_tests {
         BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
@@ -359,7 +360,7 @@ mod render_tests {
     #[test]
     fn ut_render_edit_dialog_shows_edit_title_and_delete_button() {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))

--- a/ferrowl/src/module/modbus/dialog/selection/mod.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/mod.rs
@@ -14,6 +14,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use derive_builder::Builder;
 use ferrowl_codec::format::{BitField, Format as RegisterFormat, Resolution, Width};
 use ferrowl_codec::{Address, Register, RegisterBuilder};
+use ferrowl_modbus::UnitId;
 use ferrowl_ui::{
     state::{ButtonState, InputFieldState, SelectionState},
     traits::HandleEvents,
@@ -344,7 +345,7 @@ impl EditSelectionDialog<NamedValue> {
             .map_err(|_| "Slave ID must be 0–255.".to_string())?;
 
         let register = RegisterBuilder::default()
-            .slave_id(slave_id)
+            .slave_id(UnitId(slave_id))
             .access(self.access.state.get_value().0.clone())
             .kind(self.kind.state.get_value().0)
             .address(address)
@@ -514,10 +515,11 @@ mod apply_tests {
         WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn reg(kind: Kind, address: Address, format: RegisterFormat) -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(kind)
             .address(address)
@@ -641,10 +643,11 @@ mod focus_tests {
         WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn dialog_with_values() -> EditSelectionDialog<NamedValue> {
         let original: Register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))
@@ -698,11 +701,12 @@ mod default_and_conversion_tests {
         BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
     use ferrowl_ui::traits::HandleEvents;
 
     fn u16_register() -> Register {
         RegisterBuilder::default()
-            .slave_id(3u8)
+            .slave_id(UnitId(3))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(7))

--- a/ferrowl/src/module/modbus/dialog/selection/render.rs
+++ b/ferrowl/src/module/modbus/dialog/selection/render.rs
@@ -346,6 +346,7 @@ mod render_tests {
         BitField, Endian, Format, Resolution, WordOrder as RegisterWordOrder,
     };
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
@@ -385,7 +386,7 @@ mod render_tests {
     #[test]
     fn ut_render_edit_dialog_shows_edit_title_and_delete_button() {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ferrowl_codec::{Address, Kind, Register};
-use ferrowl_modbus::{Key, Operation, SlaveKey};
+use ferrowl_modbus::{Key, Operation, SlaveKey, UnitId};
 use ferrowl_store::{CellKind as MemKind, Memory, Range};
 use parking_lot::RwLock as MemLock;
 use tokio::sync::RwLock;
@@ -114,7 +114,7 @@ impl ModbusModule {
             if let Some(range) = def.mem_range() {
                 let key = Key {
                     id: SlaveKey {
-                        slave_id: def.slave_id,
+                        slave_id: UnitId(def.slave_id),
                         kind: def.register().kind().clone(),
                     },
                 };
@@ -128,7 +128,7 @@ impl ModbusModule {
                 {
                     let write_key = Key {
                         id: SlaveKey {
-                            slave_id: def.slave_id,
+                            slave_id: UnitId(def.slave_id),
                             kind: def.register().kind().clone(),
                         },
                     };
@@ -412,6 +412,7 @@ impl ModbusModule {
 #[cfg(test)]
 mod tests {
     use ferrowl_codec::Kind;
+    use ferrowl_modbus::UnitId;
 
     #[test]
     /// MB-R-087 — effective timing uses the device config's values when set, otherwise the built-in defaults.
@@ -568,7 +569,7 @@ mod tests {
         let module = ModbusModule::new(&spec, &device);
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -601,7 +602,7 @@ mod tests {
         let mut module = ModbusModule::new(&spec, &device);
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -753,7 +754,7 @@ mod tests {
             .read(
                 Key {
                     id: SlaveKey {
-                        slave_id: 1,
+                        slave_id: UnitId(1),
                         kind: Kind::HoldingRegister,
                     },
                 },

--- a/ferrowl/src/module/modbus/registers.rs
+++ b/ferrowl/src/module/modbus/registers.rs
@@ -2,7 +2,7 @@
 //! bindings and live table values.
 
 use ferrowl_codec::{Access, Address, Kind, Register};
-use ferrowl_modbus::{Command, Key, SlaveKey};
+use ferrowl_modbus::{Address as WireAddress, Command, Key, SlaveKey, UnitId, Word};
 use ferrowl_store::{CellKind as MemKind, CellType, Range};
 
 use crate::config::device::{
@@ -51,7 +51,12 @@ pub(crate) fn register_mem_binding(register: &Register) -> Option<(MemKind, Key<
 }
 
 /// Build the appropriate write command for a client, based on the register kind/width.
-pub(crate) fn write_command(register: &Register, slave: u8, addr: u16, raw: &[u16]) -> Command {
+pub(crate) fn write_command(
+    register: &Register,
+    slave: UnitId,
+    addr: WireAddress,
+    raw: &[u16],
+) -> Command {
     match register.kind() {
         Kind::Coil | Kind::DiscreteInput => {
             if raw.len() == 1 {
@@ -62,9 +67,9 @@ pub(crate) fn write_command(register: &Register, slave: u8, addr: u16, raw: &[u1
         }
         Kind::HoldingRegister | Kind::InputRegister => {
             if raw.len() == 1 {
-                Command::WriteSingleRegister(slave, addr, raw[0])
+                Command::WriteSingleRegister(slave, addr, Word(raw[0]))
             } else {
-                Command::WriteMultipleRegister(slave, addr, raw.to_vec())
+                Command::WriteMultipleRegister(slave, addr, raw.iter().copied().map(Word).collect())
             }
         }
     }
@@ -75,7 +80,7 @@ pub(crate) fn write_command(register: &Register, slave: u8, addr: u16, raw: &[u1
 pub(crate) fn sync_register_def(def: &mut RegisterDef, register: &Register) {
     use ferrowl_codec::Format;
 
-    def.slave_id = *register.slave_id();
+    def.slave_id = register.slave_id().0;
     def.access = match register.access() {
         Access::ReadOnly => AccessCfg::ReadOnly,
         Access::WriteOnly => AccessCfg::WriteOnly,
@@ -162,10 +167,11 @@ mod tests {
     use crate::config::script::ScriptDef;
     use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
     use ferrowl_codec::{Address, Format, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn reg(kind: Kind, address: Address) -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(kind)
             .address(address)
@@ -184,21 +190,21 @@ mod tests {
     fn ut_write_command_selects_by_kind_and_width() {
         let coil = reg(Kind::Coil, Address::Fixed(0));
         assert!(matches!(
-            write_command(&coil, 1, 0, &[1]),
-            Command::WriteSingleCoil(1, 0, true)
+            write_command(&coil, UnitId(1), WireAddress(0), &[1]),
+            Command::WriteSingleCoil(UnitId(1), WireAddress(0), true)
         ));
         assert!(matches!(
-            write_command(&coil, 1, 0, &[0, 1]),
-            Command::WriteMultipleCoils(1, 0, _)
+            write_command(&coil, UnitId(1), WireAddress(0), &[0, 1]),
+            Command::WriteMultipleCoils(UnitId(1), WireAddress(0), _)
         ));
         let hr = reg(Kind::HoldingRegister, Address::Fixed(0));
         assert!(matches!(
-            write_command(&hr, 1, 5, &[7]),
-            Command::WriteSingleRegister(1, 5, 7)
+            write_command(&hr, UnitId(1), WireAddress(5), &[7]),
+            Command::WriteSingleRegister(UnitId(1), WireAddress(5), Word(7))
         ));
         assert!(matches!(
-            write_command(&hr, 1, 5, &[7, 8]),
-            Command::WriteMultipleRegister(1, 5, _)
+            write_command(&hr, UnitId(1), WireAddress(5), &[7, 8]),
+            Command::WriteMultipleRegister(UnitId(1), WireAddress(5), _)
         ));
     }
 
@@ -280,7 +286,7 @@ mod tests {
             default: None,
         };
         let register = RegisterBuilder::default()
-            .slave_id(9u8)
+            .slave_id(UnitId(9))
             .access(Access::WriteOnly)
             .kind(Kind::Coil)
             .address(Address::Virtual)

--- a/ferrowl/src/module/modbus/table.rs
+++ b/ferrowl/src/module/modbus/table.rs
@@ -290,10 +290,11 @@ mod tests {
     use super::*;
     use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn definition() -> Definition {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))
@@ -334,7 +335,7 @@ mod tests {
 
     fn named(name: &str, slave: u8) -> Definition {
         let register = RegisterBuilder::default()
-            .slave_id(slave)
+            .slave_id(UnitId(slave))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -1031,6 +1031,7 @@ mod tests {
     use crossterm::event::{KeyCode, KeyModifiers};
     use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, RegisterBuilder, Value};
+    use ferrowl_modbus::UnitId;
     use ferrowl_modbus::{Key, SlaveKey};
     use ferrowl_store::{CellKind, Memory, Range};
     use ferrowl_ui::EventResult;
@@ -1077,7 +1078,7 @@ mod tests {
 
     fn fixed_def() -> Definition {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(0))
@@ -1094,7 +1095,7 @@ mod tests {
 
     fn virtual_def() -> Definition {
         let register = RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Virtual)
@@ -1116,7 +1117,7 @@ mod tests {
         let mut memory = Memory::<Key<SlaveKey>>::default();
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -1184,7 +1185,7 @@ mod tests {
         let mut memory = Memory::<Key<SlaveKey>>::default();
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -2,7 +2,7 @@
 //! reconfiguration, and writing register values.
 
 use ferrowl_codec::{Access, Address, Kind};
-use ferrowl_modbus::{Key, SlaveKey};
+use ferrowl_modbus::{Address as WireAddress, Key, SlaveKey};
 use ferrowl_store::Range;
 use ferrowl_ui::widgets::Header;
 
@@ -373,7 +373,7 @@ impl ModbusModuleView {
                         .unwrap_or_default();
                     register.merge_write(&old, &raw)
                 };
-                let command = write_command(&register, slave, addr, &merged);
+                let command = write_command(&register, slave, WireAddress(addr), &merged);
                 let result = self.module.send_command(command).await;
                 match result {
                     Ok(()) => {
@@ -402,6 +402,7 @@ mod tests {
     use crate::module::modbus::dialog::EditedRegister;
     use ferrowl_codec::format::{BitField, Endian, Format, Resolution, WordOrder};
     use ferrowl_codec::{Access, Address, Kind, Register, RegisterBuilder};
+    use ferrowl_modbus::UnitId;
 
     fn spec(role: Role) -> ModuleSpec {
         ModuleSpec {
@@ -424,7 +425,7 @@ mod tests {
 
     fn holding(addr: u16) -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Fixed(addr))
@@ -440,7 +441,7 @@ mod tests {
 
     fn virtual_reg() -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(Address::Virtual)
@@ -541,7 +542,7 @@ mod tests {
 
         let key = Key {
             id: SlaveKey {
-                slave_id: 1,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };

--- a/ferrowl/src/registry.rs
+++ b/ferrowl/src/registry.rs
@@ -177,6 +177,7 @@ fn _assert_host_types_send_sync() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ferrowl_modbus::UnitId;
 
     struct StubHost {
         kind: &'static str,
@@ -308,7 +309,7 @@ mod tests {
 
     fn holding(addr: u16) -> Register {
         RegisterBuilder::default()
-            .slave_id(1u8)
+            .slave_id(UnitId(1))
             .access(Access::ReadWrite)
             .kind(Kind::HoldingRegister)
             .address(ferrowl_codec::Address::Fixed(addr))
@@ -328,7 +329,7 @@ mod tests {
         let mut memory: Memory<Key<SlaveKey>> = Memory::default();
         let key = Key {
             id: SlaveKey {
-                slave_id: 1u8,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };
@@ -378,7 +379,7 @@ mod tests {
 
         let key = Key {
             id: SlaveKey {
-                slave_id: 1u8,
+                slave_id: UnitId(1),
                 kind: Kind::HoldingRegister,
             },
         };

--- a/ferrowl/src/session/e2e_tests.rs
+++ b/ferrowl/src/session/e2e_tests.rs
@@ -14,7 +14,7 @@ use parking_lot::RwLock;
 use ferrowl_codec::format::{BitField, Endian, Resolution, WordOrder};
 use ferrowl_codec::{Access, Format, Kind, Register, RegisterBuilder};
 use ferrowl_lua::module::{ModuleDirectory, ModuleHost, ValueType};
-use ferrowl_modbus::{Key, SlaveKey};
+use ferrowl_modbus::{Key, SlaveKey, UnitId};
 use ferrowl_ocpp::V1_6;
 use ferrowl_store::{CellKind as MemKind, Memory, Range};
 
@@ -68,7 +68,7 @@ fn wait_for(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
 
 fn holding(addr: u16) -> Register {
     RegisterBuilder::default()
-        .slave_id(1u8)
+        .slave_id(UnitId(1))
         .access(Access::ReadWrite)
         .kind(Kind::HoldingRegister)
         .address(ferrowl_codec::Address::Fixed(addr))
@@ -85,7 +85,7 @@ fn holding(addr: u16) -> Register {
 fn modbus_memory_key() -> Key<SlaveKey> {
     Key {
         id: SlaveKey {
-            slave_id: 1u8,
+            slave_id: UnitId(1),
             kind: Kind::HoldingRegister,
         },
     }


### PR DESCRIPTION
## Why

`tokio-modbus` bound Ferrowl to a per-connection slave context, a bare `u8` slave
id, and a serial layer whose defaults are the serial library's rather than
Modbus's. `rust-modbus` addresses each request with a `UnitId` of its own, names
every framing explicitly, and models broadcast as a first-class concept — so the
behavior Ferrowl needs is stated by the library rather than worked around in it.

## How it was resolved

- `ferrowl-modbus`'s client and server cores are rebuilt on `Client<S, F>` and
  `Server<S>` + the `Service` trait, generic over stream and framing. The TCP and
  RTU transports now differ only in how they establish the connection
  (`connect_tcp` / `open_serial::<Rtu>`); the run loop and request handler are
  shared, exactly as before.
- The client's per-request slave id replaces the connection-level slave context,
  which is why the RTU `slave` config field is now inert (edge case 5.3).
- `UnitId` is adopted throughout `ferrowl-codec`, `ferrowl-modbus` and `ferrowl`
  rather than aliased back to `u8`. `serde(transparent)` keeps saved session and
  device configs parsing unchanged, and `Display` keeps every log line
  byte-identical.
- The server's request match ends in a single exhaustive arm, so a function code
  outside the nine Ferrowl implements is rejected by construction rather than by
  an enumerated list that a library update could silently outgrow.
- `ferrowl` names tokio's `rt-multi-thread` feature explicitly; it used to arrive
  transitively through the Modbus library.
- The dependency is pinned by `git` + full `rev`, the same way `rust-ocpp` is.

## Requirements

New: **MB-R-101**, **MB-R-102**, **MB-R-103** (RTU broadcast: reads refused
locally, writes fire-and-forget, server applies and stays silent).

Changed: **MB-R-002** (slave id defaults to 1, not 0 — 0 is the RTU broadcast
address), **MB-R-059** (exhaustive function-code rejection), **MB-R-072** (unset
serial parameters take the Modbus default 8E1, not 8N1).

Also updated: `api-contract.md` §1.2 and the register-field table, three
`edge-cases.md` rows, edge case 5.3, and the `ARCHITECTURE.md` crate table.

## Verification

- `cargo test --workspace` — all suites pass, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Headless live run: a TCP server and a TCP client from `configs/evse.toml` on an
  ephemeral port for 6 s. The client connects, polls `[0,1) → [1,2) → [2,3)` in
  round-robin and wraps, the server answers each from the store, and the process
  exits 0. Log wording is unchanged from tokio-modbus.

Closes #153
