### PR TITLE
Fix the build after the dependency upgrade (syn 3, validator 0.21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +861,7 @@ dependencies = [
  "ferrowl-lua",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -879,7 +885,7 @@ dependencies = [
 name = "ferrowl-ocpp"
 version = "0.5.0"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "futures-util",
  "parking_lot",
  "rcgen",
@@ -945,7 +951,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "ratatui",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1776,7 +1782,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2264,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "rust-modbus"
 version = "0.1.0"
-source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=2c7b22cc629e409003dacf9ab1a0966211f857e0#2c7b22cc629e409003dacf9ab1a0966211f857e0"
+source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=025c73ad29c4d4667b7a385b203e422270ff7c2f#025c73ad29c4d4667b7a385b203e422270ff7c2f"
 dependencies = [
  "crc",
  "serde",
@@ -2277,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "rust-ocpp"
 version = "3.0.4"
-source = "git+https://github.com/TumbleOwlee/rust-ocpp?rev=d9d8364e7d802dacfd8a4bfc479ce89a3210dece#d9d8364e7d802dacfd8a4bfc479ce89a3210dece"
+source = "git+https://github.com/TumbleOwlee/rust-ocpp?rev=1343bbbac095ed4f41709bda6ed0a3e5cf443190#1343bbbac095ed4f41709bda6ed0a3e5cf443190"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -2719,7 +2725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
@@ -3082,12 +3088,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+checksum = "c3d68c6633c483df6780cc5277a417c7c2d1bceee2649d06c8ab6b0fd2dd3c81"
 dependencies = [
  "idna",
- "once_cell",
  "regex",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,50 +41,50 @@ unsafe_code = "forbid"
 # Every external dependency lives here so two crates cannot drift onto different versions of the
 # same one. Members add features on top; they never restate a version.
 [workspace.dependencies]
-anyhow = "1.0.100"
-async-trait = "0.1.89"
-base64 = "0.22.1"
-clap = { version = "4.5.54", features = ["derive"] }
+anyhow = "1.0.104"
+async-trait = "0.1.91"
+base64 = "0.23.0"
+clap = { version = "4.6.5", features = ["derive"] }
 convert_case = "0.11.0"
 crossterm = "0.29.0"
 derive_builder = "0.20.2"
-futures-util = "0.3.31"
-getset = "0.1.6"
+futures-util = "0.3.33"
+getset = "0.1.7"
 itertools = "0.15.0"
 mlua = { version = "0.12.0", features = ["anyhow", "lua54", "vendored"] }
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 parking_lot = "0.12"
-proc-macro2 = "1.0.106"
-quote = "1.0.45"
-ratatui = { version = "0.30.0", features = [
+proc-macro2 = "1.0.107"
+quote = "1.0.47"
+ratatui = { version = "0.30.2", features = [
     "all-widgets",
     "unstable-widget-ref",
 ] }
 rcgen = "0.14.8"
 # Pinned by rev, not branch: `cargo update` must not silently move us to whatever the fork's
 # `main` points at. Bump the rev deliberately when pulling in upstream changes.
-rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "2c7b22cc629e409003dacf9ab1a0966211f857e0", default-features = false }
-rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "d9d8364e7d802dacfd8a4bfc479ce89a3210dece", default-features = false }
+rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "025c73ad29c4d4667b7a385b203e422270ff7c2f", default-features = false }
+rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "1343bbbac095ed4f41709bda6ed0a3e5cf443190", default-features = false }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",
     "tls12",
 ] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-syn = "2.0.117"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+syn = "3.0.3"
 thiserror = "2.0"
-tokio = "1.49.0"
+tokio = "1.53.1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 tokio-tungstenite = { version = "0.30", default-features = false, features = [
     "connect",
     "handshake",
     "rustls-tls-webpki-roots",
 ] }
-toml = "1.1.3"
+toml = "1.1.4"
 uuid = { version = "1", features = ["v4"] }
-validator = "0.20.0"
-webpki-roots = "1.0.8"
+validator = "0.21.0"
+webpki-roots = "1.0.9"
 
 # Speed up repeated release builds during development.
 [profile.release]

--- a/ferrowl-ui-derive/src/focus.rs
+++ b/ferrowl-ui-derive/src/focus.rs
@@ -331,11 +331,12 @@ pub fn expand_focusable(mut input: syn::DeriveInput) -> syn::Result<TokenStream>
     let focus_ty = input.ident.to_string().to_case(Case::Pascal) + "Focus";
     let focus_field = Field {
         attrs: Vec::new(),
-        mutability: syn::FieldMutability::None,
+        modifiers: Default::default(),
         vis: Visibility::Inherited,
         ident: Some(Ident::new("focus", Span::call_site())),
         colon_token: Some(Default::default()),
         ty: syn::parse_str::<Type>(&focus_ty)?,
+        default: None,
     };
     let view_focused_attrs = if uses_builder {
         vec![syn::parse_quote!(#[builder(default)])]
@@ -344,11 +345,12 @@ pub fn expand_focusable(mut input: syn::DeriveInput) -> syn::Result<TokenStream>
     };
     let view_focused_field = Field {
         attrs: view_focused_attrs,
-        mutability: syn::FieldMutability::None,
+        modifiers: Default::default(),
         vis: Visibility::Inherited,
         ident: Some(Ident::new("view_focused", Span::call_site())),
         colon_token: Some(Default::default()),
         ty: syn::parse_str::<Type>("bool")?,
+        default: None,
     };
 
     named.named.push(focus_field);


### PR DESCRIPTION
## Background

Upgrading the workspace dependencies broke the build in two independent
places. Both are consequences of the upgrade itself; no behavior changes.

## What broke

**syn 2 → 3.** syn 3 removed `Field.mutability` and added `modifiers` and
`default`, breaking the two synthesized `Field` literals in the `#[focusable]`
derive:

    error[E0433]: cannot find `FieldMutability` in `syn`
    error[E0560]: struct `syn::Field` has no field named `mutability`

**validator 0.20 → 0.21.** This pulled two incompatible copies of the
`Validate` trait into the graph — 116 errors of the form:

    the trait bound `AuthorizeRequest: Validate` is not satisfied
       ::: validator-0.21.0/src/traits.rs:9  this is the expected trait
       ::: validator-0.20.0/src/traits.rs:9  this is the found trait

`rust-ocpp` at the pinned rev `d9d8364` still declared validator 0.20, so the
`ocpp_validate_arm!` expansions called 0.21's trait on structs deriving 0.20's.

## How it was resolved

`focus.rs` constructs the two synthesized fields against the syn 3 shape:
`modifiers: Default::default()` plus `default: None`, replacing
`mutability: syn::FieldMutability::None`. `FieldModifiers` is
`#[non_exhaustive]`, so `Default::default()` is the only forward-safe
construction.

For validator, the fork had **already** bumped to 0.21 in `1343bbb` — ferrowl
was simply pinned to a stale rev. Moving the pin is the fix; holding validator
back at 0.20 would have kept the whole workspace off the upgrade to work around
a problem that was already solved upstream. The lock now resolves a single
validator 0.21.0 rather than a duplicate pair.

Both fork pins were one commit ahead and zero behind, so both move:

| Dependency | From | To | Effect |
|---|---|---|---|
| `rust-ocpp` | `d9d8364` | `1343bbb` | carries the validator 0.21 bump |
| `rust-modbus` | `2c7b22cc` | `025c73ad` | test coverage only, no build effect |

All 22 crates.io bumps in the upgrade are preserved — nothing was reverted or
held back.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 44 suites ok, 0 failures

No requirement IDs: this is a build fix and a dependency bump with identical
observable semantics, so there is no spec diff.
