### PR TITLE
feat(modbus): optional TLS for Modbus/TCP client and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "rust-modbus"
 version = "0.1.0"
-source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=d876221261b8eeb9445e59ca3bdf3243a38a219e#d876221261b8eeb9445e59ca3bdf3243a38a219e"
+source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=b72a7e643bf656a232dc906862ba4af82cae74a7#b72a7e643bf656a232dc906862ba4af82cae74a7"
 dependencies = [
  "crc",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "itertools 0.15.0",
  "parking_lot",
  "rcgen",
+ "ring",
  "rust-modbus",
  "rustls-pki-types",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,11 +874,14 @@ dependencies = [
  "ferrowl-store",
  "itertools 0.15.0",
  "parking_lot",
+ "rcgen",
  "rust-modbus",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1712,6 +1715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,9 +2282,13 @@ version = "0.1.0"
 source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=d876221261b8eeb9445e59ca3bdf3243a38a219e#d876221261b8eeb9445e59ca3bdf3243a38a219e"
 dependencies = [
  "crc",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-rustls",
  "tokio-serial",
  "winnow",
 ]
@@ -2377,6 +2390,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2453,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "std",
     "tls12",
 ] }
+rustls-pki-types = { version = "1.15", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 syn = "3.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ rcgen = "0.14.8"
 # `main` points at. Bump the rev deliberately when pulling in upstream changes.
 rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "b72a7e643bf656a232dc906862ba4af82cae74a7", default-features = false }
 rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "1343bbbac095ed4f41709bda6ed0a3e5cf443190", default-features = false }
+# Already pulled in transitively by rustls's "ring" feature below; named directly so
+# ferrowl-modbus can hash a rejected TLS peer certificate (MB-R-111) without pinning its
+# own, possibly-divergent, copy.
+ring = "0.17"
 rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ ratatui = { version = "0.30.2", features = [
 rcgen = "0.14.8"
 # Pinned by rev, not branch: `cargo update` must not silently move us to whatever the fork's
 # `main` points at. Bump the rev deliberately when pulling in upstream changes.
-rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "d876221261b8eeb9445e59ca3bdf3243a38a219e", default-features = false }
+rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "b72a7e643bf656a232dc906862ba4af82cae74a7", default-features = false }
 rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "1343bbbac095ed4f41709bda6ed0a3e5cf443190", default-features = false }
 rustls = { version = "0.23", default-features = false, features = [
     "ring",

--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -85,6 +85,7 @@ Fields of the TCP transport config, shared by the client and server roles.
 | `delay_ms` | usize | `0` | ≥ 0 | wait before the first operation after connect |
 | `interval_ms` | usize | `0` | ≥ 0 (0 ⇒ ~1 ms tick) | interval between successive operations |
 | `reconnect` | bool | `true` | — | client-only: auto-reconnect with backoff. Ignored by the server. |
+| `tls` | optional `ModbusTlsConfig` | unset | client+server | see requirements.md MB-R-104ff |
 
 When these fields are absent from a serialized config, `reconnect` defaults to
 `true`; the remaining fields have no serde defaults and must be present.

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -80,13 +80,23 @@ mistaken for an oversight and silently "fixed".
 | RTU request addressed to slave id 0 | applied to the store, answered with silence — a store failure that would otherwise be an `IllegalDataAddress` exception is invisible to the sender (MB-R-103) |
 | Malformed frame / framing error on the wire | rejected by the protocol layer before it reaches the request handler; the TCP server logs a processing failure and drops the connection, and the accept loop keeps running |
 | TCP client disconnects mid-request | the connection's serve task ends; the accept loop and the store are unaffected |
-| RTU serial port disappears mid-serve | the serve loop ends and the server task ends with an error. There is **no** RTU server reconnect (see §5.4) |
+| RTU serial port disappears mid-serve | the serve loop ends and the server task ends with an error. There is **no** RTU server reconnect (see §6.4) |
 
 ---
 
-## 5. Known limitations — intentional constraints
+## 5. TLS boundaries
 
-### 5.1 No max-registers-per-request bound at the protocol layer
+| Condition | Behavior |
+|---|---|
+| `self_signed` set together with explicit `cert_file`/`key_file` | the explicit files win; no error, self-generation is skipped |
+| `tls` set in an RTU device config | ignored — the RTU `Config` has no `tls` field (MB-R-112), so the key is unreachable rather than rejected |
+| A `cert_file`/`key_file`/`ca_file`/`client_cert_file`/`client_key_file`/`client_ca_file` path that is malformed PEM or unreadable | server or client start fails with a TLS configuration error, the same tier as MB-R-107/MB-R-108 |
+
+---
+
+## 6. Known limitations — intentional constraints
+
+### 6.1 No max-registers-per-request bound at the protocol layer
 
 Neither the client core nor the server core enforces the Modbus per-request limits
 (125 registers / 2000 bits). The **only** enforcement is in the application-level
@@ -103,7 +113,7 @@ Consequences:
 - A write command is never split: a register wider than the limit would be sent as
   a single write. Unreachable in practice — the widest format is 8 registers.
 
-### 5.2 The RTU `Config` cannot be flattened into a `clap` command
+### 6.2 The RTU `Config` cannot be flattened into a `clap` command
 
 The RTU connection config doubles as a `clap` argument group, but its short flags
 collide: `-s` is claimed by both `slave` and `stop_bits`, and `-d` by both
@@ -114,7 +124,7 @@ The config is therefore only ever reached through its serde path (session and
 device config files, and the `--module` key/value form), which is unaffected. No
 Modbus RTU flag is exposed as a top-level CLI flag.
 
-### 5.3 The RTU `slave` config field is inert
+### 6.3 The RTU `slave` config field is inert
 
 The RTU config carries a `slave` field (default 1). It is read by no code path:
 the client carries a slave id on every individual request, taken from the
@@ -125,22 +135,22 @@ observable effect on a running module.
 An RTU **server** ignores the field entirely: it answers for whichever slave ids
 have declared memory regions, not for a single configured one.
 
-### 5.4 No server-side reconnect
+### 6.4 No server-side reconnect
 
 `reconnect` is client-only. A server whose listener or serial port fails ends its
 task; it does not retry the bind or the port open. Restarting it is the operator's
 (or the module lifecycle's) job.
 
-### 5.5 Unbounded TCP server connections
+### 6.5 Unbounded TCP server connections
 
 A TCP server spawns one task per accepted connection with no cap on the number of
 concurrent connections and no idle timeout.
 
-### 5.6 Only TCP and RTU
+### 6.6 Only TCP and RTU
 
 There is no Modbus ASCII, no Modbus-over-UDP, and no RTU-over-TCP gateway mode.
 
-### 5.7 Display resolution is one-way
+### 6.7 Display resolution is one-way
 
 `resolution` scales a value for *display only*. Encoding does not divide by it, so
 value input is in raw, unscaled units. Entering `10` on a register with
@@ -148,7 +158,7 @@ value input is in raw, unscaled units. Entering `10` on a register with
 consistent — display always scales, input never does — but it means the string you
 type is not the string you read back.
 
-### 5.8 Declaration failures are silent
+### 6.8 Declaration failures are silent
 
 Declaring a memory region reports success or failure, but the module-construction
 and runtime register-edit paths ignore that result. A declaration that is rejected
@@ -160,7 +170,7 @@ gap already declared as a read-only cell. The overlap is (existing `Read` cell,
 requested `ReadWrite` region), which is not one of the widening combinations, so
 the declaration is rejected and dropped.
 
-### 5.9 Client writes are fire-and-forget
+### 6.9 Client writes are fire-and-forget
 
 A client-side write is dispatched to the client task's command channel and the
 caller is told "sent" as soon as it is queued. The Modbus response (including an
@@ -169,7 +179,7 @@ caller, and the store is not updated from it. The polled value is what eventuall
 reflects the truth — except for write-only registers, whose written value is
 mirrored into the store locally because it is not otherwise observable.
 
-### 5.10 The register's `access` does not gate store access
+### 6.10 The register's `access` does not gate store access
 
 A register's `access` (`ReadOnly` / `WriteOnly` / `ReadWrite`) does **not**
 determine the direction of its backing memory cells; the register's *kind* does

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -252,3 +252,21 @@ behavior, stated limitations).
 **MB-R-094** — Stopping a client shall first request graceful termination and only abort the task if it has not finished within the grace period; a stopped instance shall be restartable.
 
 **MB-R-098** — When a Modbus module view stops its running instance as part of a `:restart` or `:reload` command, a failure of that stop — other than the instance not currently being running, which is the expected no-op — shall be reported in the module message log at Error level rather than silently discarded. A failed start on `:restart` is already surfaced.
+
+**MB-R-104** — The Modbus TCP connection config shall carry an optional `tls` field of type `ModbusTlsConfig`, unset by default. When unset, the endpoint shall use plain TCP. When set, the client shall connect over TLS and the server shall listen over TLS, for that endpoint, instead of plain TCP.
+
+**MB-R-105** — `ModbusTlsConfig` shall carry exactly nine fields: `ca_file`, `cert_file`, `key_file`, `client_cert_file`, `client_key_file`, `client_ca_file` (each an optional string, unset by default), and `require_client_cert`, `self_signed`, `insecure_skip_verify` (each a bool, defaulting to `false`).
+
+**MB-R-106** — With `tls` set, a server shall resolve its presented certificate as: the PEM files at `cert_file`/`key_file` when both are set (explicit files always win); otherwise an ephemeral self-signed certificate when `self_signed` is set; otherwise an ephemeral self-signed certificate with the fallback logged, when none of `cert_file`, `key_file`, `self_signed` is set.
+
+**MB-R-107** — `cert_file` or `key_file` set alone (not both) shall fail the server's start with a TLS configuration error, rather than silently falling through to a self-signed certificate.
+
+**MB-R-108** — With `tls` set on a server and `require_client_cert` set, a connection presenting no client certificate, or one not signed by the CA in `client_ca_file`, shall fail the TLS handshake and never reach the request handler. `require_client_cert` set without `client_ca_file` shall fail the server's start with a TLS configuration error. With `require_client_cert` unset, `client_ca_file` shall be ignored and no client certificate requested.
+
+**MB-R-109** — With `tls` set on a client, the server certificate shall be verified against the native root store plus the extra trust anchor at `ca_file` when set — unless `insecure_skip_verify` is set, in which case any server certificate shall be accepted unauthenticated and `ca_file` shall be ignored rather than combined with it.
+
+**MB-R-110** — With `tls` set on a client, `client_cert_file` and `client_key_file` set together shall present that certificate/key pair as the client's TLS identity for mutual TLS; either set alone shall present no client certificate.
+
+**MB-R-111** — A TLS handshake failure shall be distinguished from a connection-refused/transport error and from a request timeout. On the client it shall be treated as a failed connection attempt, subject to the reconnect rules (MB-R-050–MB-R-055). On the server it shall end only that one connection attempt, without affecting the accept loop or other connections, and shall log the failure at Error level with the peer's socket address plus (where the handshake progressed far enough to expose one) its offered certificate identity, and the error description — never silently dropped.
+
+**MB-R-112** — The RTU connection config shall carry no `tls` field; TLS applies to the TCP transport only.

--- a/docs/specs/non-functional-requirements.md
+++ b/docs/specs/non-functional-requirements.md
@@ -30,7 +30,7 @@ IDs are stable and append-only (`NF-R-nnn`). See [`README.md`](./README.md).
 
 ## Security posture
 
-**NF-R-030** — OCPP shall support TLS (including mutual TLS) and HTTP Basic Auth. Modbus has no transport security, matching the protocol's own lack of one.
+**NF-R-030** — OCPP shall support TLS (including mutual TLS) and HTTP Basic Auth. Modbus/TCP shall optionally support TLS, including mutual TLS, via an opt-in `tls` config field (MB-R-104–MB-R-111). Modbus RTU has no transport security, matching the protocol's own lack of one.
 
 **NF-R-031** — Lua sim scripts shall run in a restricted sandbox: only the pure-computation standard libraries (`string`, `table`, `math`, `utf8`, `coroutine`) are reachable; `io`, `os`, `package`, `debug`, FFI, and the base dynamic-code loaders (`load`, `loadfile`, `dofile`, `require`) are not. A script therefore has no access to the host filesystem, shell, environment, or dynamic code loading. (Specified in [`scripting/`](./scripting/).) There is no CPU-time or memory ceiling — a separate, known limitation.
 

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -24,6 +24,7 @@ clap = { workspace = true }
 rustls-pki-types = { workspace = true }
 tokio-rustls = { workspace = true }
 rcgen = { workspace = true }
+ring = { workspace = true }
 
 [dev-dependencies]
 # Async test harness for the `handle_request` server logic (the crate's own tokio dep is

--- a/ferrowl-modbus/Cargo.toml
+++ b/ferrowl-modbus/Cargo.toml
@@ -19,8 +19,11 @@ itertools = { workspace = true }
 serde = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-rust-modbus = { workspace = true, features = ["std", "rtu", "serde"] }
+rust-modbus = { workspace = true, features = ["std", "rtu", "serde", "tls"] }
 clap = { workspace = true }
+rustls-pki-types = { workspace = true }
+tokio-rustls = { workspace = true }
+rcgen = { workspace = true }
 
 [dev-dependencies]
 # Async test harness for the `handle_request` server logic (the crate's own tokio dep is

--- a/ferrowl-modbus/src/rtu/mod.rs
+++ b/ferrowl-modbus/src/rtu/mod.rs
@@ -11,7 +11,7 @@ pub use server::ServerBuilder;
 
 /// Modbus RTU serial settings; doubles as the clap argument group for RTU
 /// mode.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, Args)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Args)]
 pub struct Config {
     /// The device path to use for communication.
     pub path: String,
@@ -84,5 +84,16 @@ mod tests {
         let json = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0,"reconnect":false}"#;
         let cfg: Config = serde_json::from_str(json).unwrap();
         assert!(!cfg.reconnect);
+    }
+
+    #[test]
+    /// MB-R-112 — the RTU config carries no `tls` field: an extra `"tls"` key is
+    /// silently ignored on deserialize, proving TLS is unreachable on RTU.
+    fn ut_rtu_config_ignores_unknown_tls_key() {
+        let without_tls = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0}"#;
+        let with_tls = r#"{"path":"/dev/ttyUSB0","baud_rate":115200,"slave":1,"parity":null,"data_bits":null,"stop_bits":null,"timeout_ms":3000,"delay_ms":0,"interval_ms":0,"tls":{"self_signed":true}}"#;
+        let cfg_without: Config = serde_json::from_str(without_tls).unwrap();
+        let cfg_with: Config = serde_json::from_str(with_tls).unwrap();
+        assert_eq!(cfg_without, cfg_with);
     }
 }

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -518,8 +518,8 @@ where
                 peer_cert: Some(cert),
             } => {
                 format!(
-                    "{source}; the client presented a certificate ({} byte(s)) that was rejected",
-                    cert.len()
+                    "{source}; the client presented a certificate (fingerprint {}) that was rejected",
+                    sha256_fingerprint(cert)
                 )
             }
             rust_modbus::Error::TlsHandshake {
@@ -532,6 +532,22 @@ where
             .invoke(format!("TLS handshake with {peer} failed: {detail}."))
             .await;
     }
+}
+
+/// A SHA-256 fingerprint of a certificate's raw DER bytes, colon-separated hex
+/// (the conventional certificate-fingerprint display) — the crate exposes only the
+/// raw DER, no parsed subject, so a fingerprint is the strongest identity a log line
+/// can carry without adding an x509 parser dependency. A byte length is not: two
+/// distinct certificates of the same length are indistinguishable by length alone
+/// (MB-R-111).
+fn sha256_fingerprint(cert: &rustls_pki_types::CertificateDer<'_>) -> String {
+    let digest = ring::digest::digest(&ring::digest::SHA256, cert.as_ref());
+    digest
+        .as_ref()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
 }
 
 #[cfg(test)]
@@ -602,7 +618,15 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("127.0.0.1:5502"), "line: {}", lines[0]);
         assert!(lines[0].contains("bad certificate"), "line: {}", lines[0]);
-        assert!(lines[0].contains('4'), "line: {}", lines[0]); // cert byte count
+        // SHA-256 of [1, 2, 3, 4], colon-separated hex (computed from the SHA-256
+        // standard, not from this crate's own output).
+        assert!(
+            lines[0].contains(
+                "9f:64:a7:47:e1:b9:7f:13:1f:ab:b6:b4:47:29:6c:9b:6f:02:01:e7:9f:b3:c5:35:6e:6c:77:e8:9b:6a:80:6a"
+            ),
+            "line: {}",
+            lines[0]
+        );
     }
 
     // Regression: the service used to bridge into async via `block_in_place` +

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -501,6 +501,37 @@ where
                 .await;
         }
     }
+
+    // No `Connection` names the peer here — the handshake never got far enough to be
+    // accepted (MB-R-111, server logging half). `Error::TlsHandshake.peer_cert` only
+    // carries the raw offered DER, never a parsed subject, so the certificate's byte
+    // length is the most specific identity this can report without adding an x509
+    // parser dependency.
+    async fn on_tls_handshake_failed(
+        &self,
+        peer: std::net::SocketAddr,
+        error: &rust_modbus::Error,
+    ) {
+        let detail = match error {
+            rust_modbus::Error::TlsHandshake {
+                source,
+                peer_cert: Some(cert),
+            } => {
+                format!(
+                    "{source}; the client presented a certificate ({} byte(s)) that was rejected",
+                    cert.len()
+                )
+            }
+            rust_modbus::Error::TlsHandshake {
+                source,
+                peer_cert: None,
+            } => source.to_string(),
+            other => other.to_string(),
+        };
+        self.log
+            .invoke(format!("TLS handshake with {peer} failed: {detail}."))
+            .await;
+    }
 }
 
 #[cfg(test)]
@@ -549,6 +580,29 @@ mod tests {
             }
         };
         (log, buf)
+    }
+
+    #[tokio::test]
+    /// MB-R-111 (server logging half) — a TLS handshake failure logs the peer address
+    /// and the underlying failure, including the rejected client certificate's size
+    /// when one was offered (the crate only exposes the raw DER, no parsed subject).
+    async fn ut_on_tls_handshake_failed_logs_peer_and_error() {
+        let mem = seeded_memory(&[]);
+        let (log, buf) = recording_log();
+        let server = Server::new(mem, log, true);
+
+        let peer: std::net::SocketAddr = "127.0.0.1:5502".parse().unwrap();
+        let error = rust_modbus::Error::TlsHandshake {
+            source: tokio_rustls::rustls::Error::General("bad certificate".to_string()),
+            peer_cert: Some(rustls_pki_types::CertificateDer::from(vec![1, 2, 3, 4])),
+        };
+        server.on_tls_handshake_failed(peer, &error).await;
+
+        let lines = buf.lock().unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("127.0.0.1:5502"), "line: {}", lines[0]);
+        assert!(lines[0].contains("bad certificate"), "line: {}", lines[0]);
+        assert!(lines[0].contains('4'), "line: {}", lines[0]); // cert byte count
     }
 
     // Regression: the service used to bridge into async via `block_in_place` +

--- a/ferrowl-modbus/src/tcp/client.rs
+++ b/ferrowl-modbus/src/tcp/client.rs
@@ -1,14 +1,22 @@
 use crate::client_core::{ClientCore, ConnectAttempt};
 use crate::tcp::Config;
+use crate::tcp::tls::{map_tls_err, read_pem};
 use crate::{Command, Error, Key, KeyParams, LogFn, Operation, TcpError};
 
 use ferrowl_store::Memory;
 use parking_lot::RwLock as MemLock;
-use rust_modbus::{Client as ModbusClient, TcpConfig, connect_tcp};
+use rust_modbus::{
+    Client as ModbusClient, ClientIdentity, FrameTransport, RootStore, ServerCertVerification,
+    TcpConfig, TlsClientConfig, connect_tcp, connect_tls, load_pem_cert_chain,
+    load_pem_private_key,
+};
 use tokio::task::JoinHandle;
 
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Receiver;
 
@@ -76,32 +84,199 @@ impl<T: KeyParams> ClientBuilder<T> {
     }
 }
 
+/// A client-side socket that is either plain TCP or TLS-terminated TCP (MB-R-104).
+pub(crate) enum ClientStream {
+    Plain(tokio::net::TcpStream),
+    Tls(Box<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>),
+}
+
+impl AsyncRead for ClientStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ClientStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_flush(cx),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
+/// Build the `rust_modbus` client TLS config from ours: native roots plus `ca_file`
+/// if set, unless `insecure_skip_verify` is set (in which case `ca_file` is ignored
+/// and no server certificate is checked at all) — MB-R-109. A client identity is
+/// presented only when both `client_cert_file` and `client_key_file` are set;
+/// either alone presents nothing — MB-R-110.
+fn build_client_tls_config(cfg: &crate::tcp::ModbusTlsConfig) -> Result<TlsClientConfig, TcpError> {
+    let server_cert = if cfg.insecure_skip_verify {
+        ServerCertVerification::DangerousDisableVerification
+    } else {
+        let mut roots = RootStore::native();
+        if let Some(path) = &cfg.ca_file {
+            roots.add_pem(&read_pem(path)?).map_err(map_tls_err)?;
+        }
+        ServerCertVerification::Verify(roots)
+    };
+    let client_identity = match (&cfg.client_cert_file, &cfg.client_key_file) {
+        (Some(cert), Some(key)) => Some(ClientIdentity {
+            cert_chain: load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?,
+            key: load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?,
+        }),
+        _ => None,
+    };
+    Ok(TlsClientConfig {
+        server_cert,
+        client_identity,
+    })
+}
+
 /// A connected Modbus TCP client. Connection setup is TCP-specific; the read/command loop is
 /// shared via the internal `ClientCore`, over a socket carrying Modbus TCP framing.
 pub struct Client {
-    pub(crate) core: ClientCore<tokio::net::TcpStream, rust_modbus::Tcp>,
+    pub(crate) core: ClientCore<ClientStream, rust_modbus::Tcp>,
 }
 
 impl Client {
     /// Opens a TCP connection to `config.ip:config.port`, bounded by the
-    /// configured timeout.
+    /// configured timeout. Plain TCP unless `config.tls` is set (MB-R-104), in which
+    /// case the same timeout bounds the TCP connect and the TLS handshake together.
     pub async fn connect(config: &Config) -> Result<Self, Error> {
         let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
             .parse()
             .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
+        let tls_config = config
+            .tls
+            .as_ref()
+            .map(build_client_tls_config)
+            .transpose()?;
+        let attempt = async {
+            match tls_config {
+                None => connect_tcp(addr, TcpConfig::default())
+                    .await
+                    .map(|t| ClientStream::Plain(t.into_inner())),
+                Some(tls) => connect_tls(addr, TcpConfig::default(), tls)
+                    .await
+                    .map(|t| ClientStream::Tls(Box::new(t.into_inner()))),
+            }
+        };
         match tokio::time::timeout(
             std::time::Duration::from_millis(config.timeout_ms as u64),
-            connect_tcp(addr, TcpConfig::default()),
+            attempt,
         )
         .await
         {
-            Ok(Ok(transport)) => Ok(Self {
+            Ok(Ok(stream)) => Ok(Self {
                 core: ClientCore {
-                    client: ModbusClient::<_, _>::new(transport),
+                    client: ModbusClient::<_, _>::new(FrameTransport::new(stream)),
                 },
             }),
             Ok(Err(e)) => Err(TcpError::Error(e).into()),
             Err(e) => Err(TcpError::Timeout(e).into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_client_tls_config;
+    use crate::tcp::ModbusTlsConfig;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn write_pem(label: &str, pem: &str) -> String {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-modbus-client-tls-ut-{}-{label}-{n}.pem",
+            std::process::id()
+        ));
+        std::fs::write(&path, pem).expect("write test pem");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn cert_and_key_pem() -> (String, String) {
+        let key = rcgen::KeyPair::generate().expect("keypair generation failed");
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .expect("cert params")
+            .self_signed(&key)
+            .expect("self-signed cert");
+        (cert.pem(), key.serialize_pem())
+    }
+
+    /// MB-R-110 — a client identity is presented only when both `client_cert_file` and
+    /// `client_key_file` are set.
+    #[test]
+    fn ut_build_client_tls_config_identity_only_when_both_files_set() {
+        let (cert_pem, key_pem) = cert_and_key_pem();
+        let cert_file = write_pem("cert", &cert_pem);
+        let key_file = write_pem("key", &key_pem);
+
+        let both = build_client_tls_config(&ModbusTlsConfig {
+            client_cert_file: Some(cert_file.clone()),
+            client_key_file: Some(key_file.clone()),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(both.client_identity.is_some());
+
+        let cert_only = build_client_tls_config(&ModbusTlsConfig {
+            client_cert_file: Some(cert_file),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(cert_only.client_identity.is_none());
+
+        let key_only = build_client_tls_config(&ModbusTlsConfig {
+            client_key_file: Some(key_file),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(key_only.client_identity.is_none());
+
+        let neither = build_client_tls_config(&ModbusTlsConfig::default()).expect("builds");
+        assert!(neither.client_identity.is_none());
+    }
+
+    /// MB-R-109 — `insecure_skip_verify` disables server certificate verification and
+    /// ignores `ca_file`, rather than combining the two.
+    #[test]
+    fn ut_build_client_tls_config_insecure_skip_verify_ignores_ca_file() {
+        use rust_modbus::ServerCertVerification;
+
+        let cfg = ModbusTlsConfig {
+            ca_file: Some("/no/such/ca.pem".to_string()),
+            insecure_skip_verify: true,
+            ..Default::default()
+        };
+        let built = build_client_tls_config(&cfg).expect("builds despite unreadable ca_file");
+        assert!(matches!(
+            built.server_cert,
+            ServerCertVerification::DangerousDisableVerification
+        ));
     }
 }

--- a/ferrowl-modbus/src/tcp/mod.rs
+++ b/ferrowl-modbus/src/tcp/mod.rs
@@ -2,12 +2,14 @@
 
 mod client;
 mod server;
+mod tls;
 
 use clap::Args;
 use serde::{Deserialize, Serialize};
 
 pub use client::{Client, ClientBuilder};
 pub use server::ServerBuilder;
+pub use tls::ModbusTlsConfig;
 
 /// Modbus TCP connection settings; doubles as the clap argument group for
 /// TCP mode.
@@ -38,8 +40,68 @@ pub struct Config {
     #[serde(default = "default_reconnect")]
     #[arg(long, default_value_t = true)]
     pub reconnect: bool,
+
+    /// TLS material for this endpoint. Unset (the default) keeps the endpoint on
+    /// plain TCP (MB-R-104).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[arg(skip)]
+    pub tls: Option<ModbusTlsConfig>,
 }
 
 fn default_reconnect() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    /// MB-R-104 — a `tcp::Config` with no `tls` key deserializes with `tls: None`.
+    #[test]
+    fn ut_tcp_config_tls_absent_deserializes_to_none() {
+        let json = r#"{
+            "ip": "127.0.0.1",
+            "port": 502,
+            "timeout_ms": 3000,
+            "delay_ms": 0,
+            "interval_ms": 0
+        }"#;
+        let cfg: Config = serde_json::from_str(json).expect("deserializes");
+        assert_eq!(cfg.tls, None);
+    }
+
+    /// MB-R-104, MB-R-105 — a `tcp::Config` with a full `tls` object deserializes
+    /// into the matching `Some(ModbusTlsConfig { .. })`.
+    #[test]
+    fn ut_tcp_config_tls_present_deserializes() {
+        let json = r#"{
+            "ip": "127.0.0.1",
+            "port": 502,
+            "timeout_ms": 3000,
+            "delay_ms": 0,
+            "interval_ms": 0,
+            "tls": {
+                "ca_file": "ca.pem",
+                "cert_file": "cert.pem",
+                "key_file": "key.pem",
+                "client_cert_file": "client.pem",
+                "client_key_file": "client-key.pem",
+                "client_ca_file": "client-ca.pem",
+                "require_client_cert": true,
+                "self_signed": false,
+                "insecure_skip_verify": true
+            }
+        }"#;
+        let cfg: Config = serde_json::from_str(json).expect("deserializes");
+        let tls = cfg.tls.expect("tls present");
+        assert_eq!(tls.ca_file.as_deref(), Some("ca.pem"));
+        assert_eq!(tls.cert_file.as_deref(), Some("cert.pem"));
+        assert_eq!(tls.key_file.as_deref(), Some("key.pem"));
+        assert_eq!(tls.client_cert_file.as_deref(), Some("client.pem"));
+        assert_eq!(tls.client_key_file.as_deref(), Some("client-key.pem"));
+        assert_eq!(tls.client_ca_file.as_deref(), Some("client-ca.pem"));
+        assert!(tls.require_client_cert);
+        assert!(!tls.self_signed);
+        assert!(tls.insecure_skip_verify);
+    }
 }

--- a/ferrowl-modbus/src/tcp/server.rs
+++ b/ferrowl-modbus/src/tcp/server.rs
@@ -1,6 +1,7 @@
 // Crate
 use crate::server_core::Server;
 use crate::tcp::Config;
+use crate::tcp::tls::{map_tls_err, read_pem};
 use crate::{Error, Key, KeyParams, LogFn, TcpError};
 
 // Workspace
@@ -8,7 +9,10 @@ use ferrowl_store::Memory;
 
 // External
 use parking_lot::RwLock as MemLock;
-use rust_modbus::{Server as ModbusServer, TcpListener};
+use rust_modbus::{
+    ClientCertPolicy, RootStore, Server as ModbusServer, TcpListener, TlsListener, TlsServerConfig,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -37,8 +41,99 @@ impl<T: KeyParams> ServerBuilder<T> {
     }
 }
 
+/// Resolve the server's presented certificate per MB-R-106/107, and whether an
+/// ephemeral self-signed certificate was used *without* being explicitly
+/// requested (the caller logs that case). Explicit `cert_file`/`key_file` always
+/// win over `self_signed` when both are set (edge-cases.md "TLS boundaries").
+fn resolve_server_identity(
+    cfg: &crate::tcp::ModbusTlsConfig,
+    bind_host: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>, bool), TcpError> {
+    match (&cfg.cert_file, &cfg.key_file) {
+        (Some(cert), Some(key)) => {
+            let chain = rust_modbus::load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?;
+            // A PEM document with no certificate blocks at all (garbage input) parses
+            // successfully to an empty chain rather than erroring; catch that here so it
+            // fails at the same TLS-configuration-error tier as every other malformed-PEM
+            // case (edge-cases.md "TLS boundaries"), rather than surfacing later, at TLS
+            // listener bind time, as a bare `Error::Server(Error::TlsHandshake)`.
+            if chain.is_empty() {
+                return Err(TcpError::Configuration(format!(
+                    "{cert} contains no certificate"
+                )));
+            }
+            let k = rust_modbus::load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?;
+            Ok((chain, k, false))
+        }
+        (None, None) => {
+            let (chain, k) = generate_self_signed(bind_host)?;
+            Ok((chain, k, !cfg.self_signed))
+        }
+        _ => Err(TcpError::Configuration(
+            "cert_file and key_file must both be set, or neither (MB-R-107)".into(),
+        )),
+    }
+}
+
+/// An ephemeral self-signed certificate/key pair, generated fresh in memory and
+/// never written to disk (MB-R-106 fallback). `host` and `"localhost"` (when
+/// different) are carried as SAN entries, mirroring
+/// `ferrowl-ocpp/src/security.rs::generate_self_signed`.
+fn generate_self_signed(
+    host: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), TcpError> {
+    let mut names = vec![host.to_string()];
+    if host != "localhost" {
+        names.push("localhost".to_string());
+    }
+    let mut params = rcgen::CertificateParams::new(names)
+        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "ferrowl Modbus");
+    let key_pair = rcgen::KeyPair::generate()
+        .map_err(|e| TcpError::Configuration(format!("self-signed key generation failed: {e}")))?;
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
+    let cert_der = cert.der().clone();
+    let key_der = PrivateKeyDer::try_from(key_pair.serialize_der())
+        .map_err(|e| TcpError::Configuration(format!("self-signed key encoding failed: {e}")))?;
+    Ok((vec![cert_der], key_der))
+}
+
+/// Build the full `rust_modbus` server TLS config, and whether the self-signed
+/// fallback was used without being requested (the caller logs that case).
+fn build_server_tls_config(
+    cfg: &crate::tcp::ModbusTlsConfig,
+    bind_host: &str,
+) -> Result<(TlsServerConfig, bool), TcpError> {
+    let (cert_chain, key, used_fallback) = resolve_server_identity(cfg, bind_host)?;
+    let client_certs = if cfg.require_client_cert {
+        let ca = cfg.client_ca_file.as_ref().ok_or_else(|| {
+            TcpError::Configuration(
+                "require_client_cert is set but no client_ca_file was configured (MB-R-108)".into(),
+            )
+        })?;
+        let mut roots = RootStore::empty();
+        roots.add_pem(&read_pem(ca)?).map_err(map_tls_err)?;
+        ClientCertPolicy::Require(roots)
+    } else {
+        ClientCertPolicy::None
+    };
+    Ok((
+        TlsServerConfig {
+            cert_chain,
+            key,
+            client_certs,
+        },
+        used_fallback,
+    ))
+}
+
 /// Bind the configured TCP address and spawn the accept loop; each accepted connection answers from
-/// the shared `memory` via a [`Server`] (verbose logging on).
+/// the shared `memory` via a [`Server`] (verbose logging on). Plain TCP unless `config.tls` is set
+/// (MB-R-104), in which case the listener terminates TLS on each accepted connection.
 async fn run<T, L>(
     config: &Config,
     memory: Arc<MemLock<Memory<Key<T>>>>,
@@ -51,15 +146,36 @@ where
     let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
         .parse()
         .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
-    match TcpListener::bind(addr).await {
-        Ok(listener) => {
-            // One service instance answers every accepted connection, so all of them share the
-            // one store (MB-R-070). TCP servers log per-request outcomes (verbose = true).
-            let server = ModbusServer::new(Server::new(memory, log, true));
-            Ok(tokio::task::spawn(async move {
+    // One service instance answers every accepted connection, so all of them share the
+    // one store (MB-R-070). TCP servers log per-request outcomes (verbose = true).
+    let server = ModbusServer::new(Server::new(memory, log.clone(), true));
+    match &config.tls {
+        None => match TcpListener::bind(addr).await {
+            Ok(listener) => Ok(tokio::task::spawn(async move {
                 server.serve(listener).await.map_err(Error::Server)
-            }))
+            })),
+            Err(e) => Err(Error::Server(e)),
+        },
+        Some(tls) => {
+            let (tls_config, used_fallback) =
+                build_server_tls_config(tls, &config.ip).map_err(Error::Tcp)?;
+            if used_fallback {
+                log.invoke(
+                    "No cert_file/key_file/self_signed configured for this TLS \
+                     server; falling back to an ephemeral self-signed certificate."
+                        .to_string(),
+                )
+                .await;
+            }
+            match TlsListener::bind(addr, tls_config).await {
+                Ok(listener) => Ok(tokio::task::spawn(async move {
+                    server
+                        .serve_tls::<rust_modbus::Tcp>(listener)
+                        .await
+                        .map_err(Error::Server)
+                })),
+                Err(e) => Err(Error::Server(e)),
+            }
         }
-        Err(e) => Err(Error::Server(e)),
     }
 }

--- a/ferrowl-modbus/src/tcp/tls.rs
+++ b/ferrowl-modbus/src/tcp/tls.rs
@@ -1,0 +1,69 @@
+//! Modbus/TCP TLS configuration (MB-R-104 .. MB-R-112).
+
+use serde::{Deserialize, Serialize};
+
+use crate::TcpError;
+
+/// TLS material for a Modbus/TCP endpoint, client or server (MB-R-105).
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct ModbusTlsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ca_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cert_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_cert_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_key_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_ca_file: Option<String>,
+    #[serde(default)]
+    pub require_client_cert: bool,
+    #[serde(default)]
+    pub self_signed: bool,
+    #[serde(default)]
+    pub insecure_skip_verify: bool,
+}
+
+/// Read a PEM file's raw bytes, mapping a missing/unreadable file to the TLS
+/// configuration-error tier (MB-R-107/108, edge-cases.md "malformed PEM").
+///
+/// Unused until s2 (client.rs) and s3 (server.rs) wire it into their connect/serve
+/// paths; allowed dead here rather than deferred, since both consume it without
+/// otherwise touching this file.
+#[allow(dead_code)]
+pub(crate) fn read_pem(path: &str) -> Result<Vec<u8>, TcpError> {
+    std::fs::read(path).map_err(|e| TcpError::Configuration(format!("failed to read {path}: {e}")))
+}
+
+/// Map any `rust_modbus` failure encountered while assembling TLS material (a bad
+/// PEM, an untrusted root, ...) onto the same configuration-error tier.
+///
+/// Unused until s2/s3 wire it in — see `read_pem` above.
+#[allow(dead_code)]
+pub(crate) fn map_tls_err(e: rust_modbus::Error) -> TcpError {
+    TcpError::Configuration(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModbusTlsConfig;
+
+    /// MB-R-105 — `ModbusTlsConfig` carries exactly nine fields, six optional
+    /// strings unset and three bools false, by default.
+    #[test]
+    fn ut_modbus_tls_config_defaults() {
+        let cfg = ModbusTlsConfig::default();
+        assert_eq!(cfg.ca_file, None);
+        assert_eq!(cfg.cert_file, None);
+        assert_eq!(cfg.key_file, None);
+        assert_eq!(cfg.client_cert_file, None);
+        assert_eq!(cfg.client_key_file, None);
+        assert_eq!(cfg.client_ca_file, None);
+        assert!(!cfg.require_client_cert);
+        assert!(!cfg.self_signed);
+        assert!(!cfg.insecure_skip_verify);
+    }
+}

--- a/ferrowl-modbus/src/tcp/tls.rs
+++ b/ferrowl-modbus/src/tcp/tls.rs
@@ -29,20 +29,12 @@ pub struct ModbusTlsConfig {
 
 /// Read a PEM file's raw bytes, mapping a missing/unreadable file to the TLS
 /// configuration-error tier (MB-R-107/108, edge-cases.md "malformed PEM").
-///
-/// Unused until s2 (client.rs) and s3 (server.rs) wire it into their connect/serve
-/// paths; allowed dead here rather than deferred, since both consume it without
-/// otherwise touching this file.
-#[allow(dead_code)]
 pub(crate) fn read_pem(path: &str) -> Result<Vec<u8>, TcpError> {
     std::fs::read(path).map_err(|e| TcpError::Configuration(format!("failed to read {path}: {e}")))
 }
 
 /// Map any `rust_modbus` failure encountered while assembling TLS material (a bad
 /// PEM, an untrusted root, ...) onto the same configuration-error tier.
-///
-/// Unused until s2/s3 wire it in — see `read_pem` above.
-#[allow(dead_code)]
 pub(crate) fn map_tls_err(e: rust_modbus::Error) -> TcpError {
     TcpError::Configuration(e.to_string())
 }

--- a/ferrowl-modbus/tests/tcp_loopback.rs
+++ b/ferrowl-modbus/tests/tcp_loopback.rs
@@ -62,6 +62,7 @@ fn config(port: u16) -> tcp::Config {
         delay_ms: 0,
         interval_ms: 0,
         reconnect: true,
+        tls: None,
     }
 }
 

--- a/ferrowl-modbus/tests/tcp_tls_client.rs
+++ b/ferrowl-modbus/tests/tcp_tls_client.rs
@@ -1,0 +1,345 @@
+//! Client-side Modbus/TCP TLS tests (MB-R-109, MB-R-110, MB-R-111 client half).
+//!
+//! Drives `ferrowl_modbus::tcp::Client::connect` against a bare `rust_modbus`
+//! TLS/TCP listener (not `ferrowl_modbus`'s own server — that's s3's job), so
+//! this stage needs no coordination with s3.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use ferrowl_modbus::tcp;
+use rcgen::{CertificateParams, Issuer, KeyPair};
+use rust_modbus::{
+    ClientCertPolicy, RootStore, ServerCertVerification, TcpConfig, TlsClientConfig, TlsListener,
+    TlsServerConfig, connect_tls,
+};
+use tokio::io::AsyncReadExt;
+
+/// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn write_pem(label: &str, pem: &str) -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "ferrowl-modbus-tls-test-{}-{label}-{n}.pem",
+        std::process::id()
+    ));
+    std::fs::write(&path, pem).expect("failed to write test PEM file");
+    path.to_string_lossy().into_owned()
+}
+
+/// A self-signed cert/key pair, PEM-encoded, CN `127.0.0.1`.
+fn self_signed_pem() -> (String, String) {
+    let key = KeyPair::generate().expect("keypair generation failed");
+    let cert = CertificateParams::new(vec!["127.0.0.1".to_owned()])
+        .expect("cert params")
+        .self_signed(&key)
+        .expect("self-signed cert");
+    (cert.pem(), key.serialize_pem())
+}
+
+/// A self-signed CA plus one client cert/key pair it signs, all PEM-encoded.
+fn ca_and_signed_client_pem() -> (String, String, String) {
+    let ca_key = KeyPair::generate().expect("ca keypair generation failed");
+    let ca_params = CertificateParams::new(vec!["ferrowl-test-ca".to_owned()]).expect("ca params");
+    let ca_cert = ca_params.self_signed(&ca_key).expect("self-signed ca cert");
+    let issuer = Issuer::from_params(&ca_params, &ca_key);
+
+    let client_key = KeyPair::generate().expect("client keypair generation failed");
+    let client_cert = CertificateParams::new(vec!["ferrowl-test-client".to_owned()])
+        .expect("client params")
+        .signed_by(&client_key, &issuer)
+        .expect("ca-signed client cert");
+
+    (ca_cert.pem(), client_cert.pem(), client_key.serialize_pem())
+}
+
+fn config(port: u16, tls: tcp::ModbusTlsConfig) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: Some(tls),
+    }
+}
+
+#[tokio::test]
+/// MB-R-109 — `insecure_skip_verify` accepts a server certificate unauthenticated,
+/// with no `ca_file` needed.
+async fn tls_client_connects_to_plain_rust_modbus_tls_server() {
+    let (cert_pem, key_pem) = self_signed_pem();
+    let cert_chain = rust_modbus::load_pem_cert_chain(cert_pem.as_bytes()).unwrap();
+    let key = rust_modbus::load_pem_private_key(key_pem.as_bytes()).unwrap();
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+    let listener = TlsListener::bind(
+        addr,
+        TlsServerConfig {
+            cert_chain,
+            key,
+            client_certs: ClientCertPolicy::None,
+        },
+    )
+    .await
+    .unwrap();
+    let bound = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let _ = listener.accept().await;
+    });
+
+    let cfg = config(
+        bound.port(),
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    let client = tcp::Client::connect(&cfg).await;
+    assert!(
+        client.is_ok(),
+        "expected connect to succeed: {}",
+        client.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-109 — a client trusts a server certificate presented via `ca_file`, and
+/// rejects the same certificate with neither `ca_file` nor `insecure_skip_verify` set.
+async fn tls_client_verifies_against_ca_file() {
+    let (cert_pem, key_pem) = self_signed_pem();
+    let cert_file = write_pem("server-cert2", &cert_pem);
+    let cert_chain = rust_modbus::load_pem_cert_chain(cert_pem.as_bytes()).unwrap();
+    let key = rust_modbus::load_pem_private_key(key_pem.as_bytes()).unwrap();
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+    let listener = TlsListener::bind(
+        addr,
+        TlsServerConfig {
+            cert_chain,
+            key,
+            client_certs: ClientCertPolicy::None,
+        },
+    )
+    .await
+    .unwrap();
+    let bound = listener.local_addr().unwrap();
+    let listener = std::sync::Arc::new(listener);
+
+    let accept_listener = listener.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            if accept_listener.accept().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Trusted via ca_file.
+    let trusted_cfg = config(
+        bound.port(),
+        tcp::ModbusTlsConfig {
+            ca_file: Some(cert_file),
+            ..Default::default()
+        },
+    );
+    let trusted = tcp::Client::connect(&trusted_cfg).await;
+    assert!(
+        trusted.is_ok(),
+        "expected trusted connect: {}",
+        trusted.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+
+    // Untrusted: neither ca_file nor insecure_skip_verify set.
+    let untrusted_cfg = config(bound.port(), tcp::ModbusTlsConfig::default());
+    let untrusted = tcp::Client::connect(&untrusted_cfg).await;
+    assert!(
+        untrusted.is_err(),
+        "expected untrusted connect to fail verification"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-110 — a client presents its identity only when both `client_cert_file` and
+/// `client_key_file` are set; either alone presents nothing, and a server requiring
+/// a client certificate then rejects the handshake.
+async fn tls_client_presents_identity_only_when_both_files_set() {
+    let (server_cert_pem, server_key_pem) = self_signed_pem();
+    let server_cert_file = write_pem("mtls-server-cert", &server_cert_pem);
+    let server_cert_chain = rust_modbus::load_pem_cert_chain(server_cert_pem.as_bytes()).unwrap();
+    let server_key = rust_modbus::load_pem_private_key(server_key_pem.as_bytes()).unwrap();
+
+    let (ca_pem, client_cert_pem, client_key_pem) = ca_and_signed_client_pem();
+    let client_cert_file = write_pem("mtls-client-cert", &client_cert_pem);
+    let client_key_file = write_pem("mtls-client-key", &client_key_pem);
+
+    let mut roots = RootStore::empty();
+    roots.add_pem(ca_pem.as_bytes()).unwrap();
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+    let listener = TlsListener::bind(
+        addr,
+        TlsServerConfig {
+            cert_chain: server_cert_chain,
+            key: server_key,
+            client_certs: ClientCertPolicy::Require(roots),
+        },
+    )
+    .await
+    .unwrap();
+    let bound = listener.local_addr().unwrap();
+    let listener = std::sync::Arc::new(listener);
+
+    let accept_listener = listener.clone();
+    let server = tokio::spawn(async move {
+        loop {
+            if accept_listener.accept().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Both set: identity presented, handshake succeeds.
+    let both_cfg = config(
+        bound.port(),
+        tcp::ModbusTlsConfig {
+            ca_file: Some(server_cert_file.clone()),
+            client_cert_file: Some(client_cert_file.clone()),
+            client_key_file: Some(client_key_file.clone()),
+            ..Default::default()
+        },
+    );
+    let both = tcp::Client::connect(&both_cfg).await;
+    assert!(
+        both.is_ok(),
+        "expected mTLS connect to succeed: {}",
+        both.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+
+    // Only cert set, or only key set: MB-R-110 says either alone presents *no* client
+    // identity — proved directly against `build_client_tls_config`'s unit tests in
+    // `tcp/client.rs`. What that "no identity presented" consequence looks like on the
+    // wire, against this same `Require`-policy server, is probed below with a raw
+    // `rust_modbus::connect_tls` (identity: None mirrors both "cert only" and "key
+    // only", since `build_client_tls_config` maps both to `None` identically).
+    //
+    // TLS 1.3 quirk (confirmed empirically, not assumed): the *client's* handshake
+    // future resolves successfully even when the server will reject the connection for
+    // a missing/invalid client certificate — client-side completion doesn't wait for
+    // the server's verdict on the client's certificate message. The rejection is only
+    // observable on the wire afterwards, as the server closing the connection before
+    // sending any application data. So this test asserts on that: the first read
+    // returns EOF/an error, rather than asserting `connect()` itself errors.
+    let mut server_trust = RootStore::empty();
+    server_trust.add_pem(server_cert_pem.as_bytes()).unwrap();
+    let no_identity_tls = TlsClientConfig {
+        server_cert: ServerCertVerification::Verify(server_trust),
+        client_identity: None,
+    };
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{}", bound.port()).parse().unwrap();
+    let transport = connect_tls(addr, TcpConfig::default(), no_identity_tls)
+        .await
+        .expect("client-side TLS 1.3 handshake completes even though the server will reject");
+    let mut stream = transport.into_inner();
+    let mut buf = [0u8; 1];
+    let read = tokio::time::timeout(std::time::Duration::from_millis(500), stream.read(&mut buf))
+        .await
+        .expect("server should close the connection promptly, not hang");
+    // A reset/IO error (the `Err` arm) is an equally valid rejection signal, alongside
+    // an outright EOF.
+    if let Ok(n) = read {
+        assert_eq!(
+            n, 0,
+            "expected EOF (server closed after rejecting no identity)"
+        );
+    }
+
+    drop((client_cert_file, client_key_file));
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-111 (client half) — a TLS handshake failure, a refused connection, and a
+/// timed-out connection attempt are three distinct outcomes.
+async fn tls_handshake_failure_is_distinct_from_refused_and_timeout() {
+    // (a) TLS configured against a plain (non-TLS) listener: handshake failure.
+    let plain_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let plain_addr = plain_listener.local_addr().unwrap();
+    let plain_server = tokio::spawn(async move {
+        loop {
+            if plain_listener.accept().await.is_err() {
+                break;
+            }
+        }
+    });
+    let handshake_cfg = config(
+        plain_addr.port(),
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    let handshake_result = tcp::Client::connect(&handshake_cfg).await;
+    assert!(
+        handshake_result.is_err(),
+        "expected TLS handshake against a plain listener to fail"
+    );
+    plain_server.abort();
+
+    // (b) Nothing listening: connection refused.
+    let refused_port = free_port();
+    let refused_cfg = config(
+        refused_port,
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    let refused_result = tcp::Client::connect(&refused_cfg).await;
+    assert!(
+        refused_result.is_err(),
+        "expected connect to a closed port to fail"
+    );
+
+    // (c) A TLS server that accepts the TCP connection but never completes the
+    // handshake: a very short client timeout should time out, not hang.
+    let stalling_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let stalling_addr = stalling_listener.local_addr().unwrap();
+    let stalling_server = tokio::spawn(async move {
+        let (socket, _) = stalling_listener.accept().await.unwrap();
+        // Accept the TCP connection, then simply hold it open without ever speaking
+        // TLS, forcing the client's handshake to stall until it hits its timeout.
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        drop(socket);
+    });
+    let mut timeout_cfg = config(
+        stalling_addr.port(),
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    timeout_cfg.timeout_ms = 50;
+    let timeout_result = tcp::Client::connect(&timeout_cfg).await;
+    assert!(
+        timeout_result.is_err(),
+        "expected a stalled handshake to time out"
+    );
+    stalling_server.abort();
+}

--- a/ferrowl-modbus/tests/tcp_tls_server.rs
+++ b/ferrowl-modbus/tests/tcp_tls_server.rs
@@ -472,6 +472,41 @@ async fn require_client_cert_rejection_is_logged() {
 }
 
 #[tokio::test]
+/// MB-R-108 — with `require_client_cert` unset (false), a configured `client_ca_file`
+/// is ignored: a client presenting no certificate at all is still accepted.
+async fn client_ca_file_is_ignored_when_require_client_cert_is_unset() {
+    let (server_cert_pem, server_key_pem) = self_signed_pem();
+    let server_cert_file = write_pem("no-require-server-cert", &server_cert_pem);
+    let server_key_file = write_pem("no-require-server-key", &server_key_pem);
+
+    let (ca_pem, ..) = ca_and_signed_client_pem();
+    let ca_file = write_pem("no-require-ca", &ca_pem);
+
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            cert_file: Some(server_cert_file),
+            key_file: Some(server_key_file),
+            client_ca_file: Some(ca_file),
+            // require_client_cert left at its default (false).
+            ..Default::default()
+        },
+    )));
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(sink())
+        .await
+        .expect("server should start: a client_ca_file without require_client_cert is valid");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    raw_connect(addr, Some(&server_cert_pem), None)
+        .await
+        .expect("a client presenting no certificate should be accepted");
+
+    server.abort();
+}
+
+#[tokio::test]
 /// MB-R-108 — `require_client_cert` without a `client_ca_file` fails the server's
 /// start with a TLS configuration error, before any bind is attempted.
 async fn require_client_cert_without_ca_fails_server_start() {

--- a/ferrowl-modbus/tests/tcp_tls_server.rs
+++ b/ferrowl-modbus/tests/tcp_tls_server.rs
@@ -1,0 +1,427 @@
+//! Server-side Modbus/TCP TLS tests (MB-R-106, MB-R-107, MB-R-108, MB-R-111 server
+//! connection-scoping half).
+//!
+//! Drives `ferrowl_modbus::tcp::ServerBuilder` (the real server) with `rust_modbus`'s
+//! own TLS client primitives directly (never `ferrowl_modbus::tcp::Client` — that's
+//! s2's own surface), so this stage needs nothing s2 produces.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use ferrowl_codec::Kind as RegKind;
+use ferrowl_modbus::tcp;
+use ferrowl_modbus::{Key, SlaveKey, UnitId};
+use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::Mutex;
+use parking_lot::RwLock as MemLock;
+use rcgen::{CertificateParams, Issuer, KeyPair};
+use rust_modbus::{
+    ClientIdentity, RootStore, ServerCertVerification, TcpConfig, TlsClientConfig, connect_tls,
+};
+use tokio::sync::RwLock;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKey> {
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
+}
+
+fn memory() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    Arc::new(MemLock::new(mem))
+}
+
+/// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+/// A log sink that records every line, so a test can assert on what the server logged.
+fn capturing() -> (impl ferrowl_modbus::LogFn + Clone, Arc<Mutex<Vec<String>>>) {
+    let log = Arc::new(Mutex::new(Vec::<String>::new()));
+    let sink = log.clone();
+    let f = move |s: String| {
+        let sink = sink.clone();
+        async move {
+            sink.lock().push(s);
+        }
+    };
+    (f, log)
+}
+
+/// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn write_pem(label: &str, pem: &str) -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "ferrowl-modbus-tls-server-test-{}-{label}-{n}.pem",
+        std::process::id()
+    ));
+    std::fs::write(&path, pem).expect("failed to write test PEM file");
+    path.to_string_lossy().into_owned()
+}
+
+fn self_signed_pem() -> (String, String) {
+    let key = KeyPair::generate().expect("keypair generation failed");
+    let cert = CertificateParams::new(vec!["127.0.0.1".to_owned()])
+        .expect("cert params")
+        .self_signed(&key)
+        .expect("self-signed cert");
+    (cert.pem(), key.serialize_pem())
+}
+
+/// A self-signed CA plus one client cert/key pair it signs, all PEM-encoded.
+fn ca_and_signed_client_pem() -> (String, String, String) {
+    let ca_key = KeyPair::generate().expect("ca keypair generation failed");
+    let ca_params = CertificateParams::new(vec!["ferrowl-test-ca".to_owned()]).expect("ca params");
+    let ca_cert = ca_params.self_signed(&ca_key).expect("self-signed ca cert");
+    let issuer = Issuer::from_params(&ca_params, &ca_key);
+
+    let client_key = KeyPair::generate().expect("client keypair generation failed");
+    let client_cert = CertificateParams::new(vec!["ferrowl-test-client".to_owned()])
+        .expect("client params")
+        .signed_by(&client_key, &issuer)
+        .expect("ca-signed client cert");
+
+    (ca_cert.pem(), client_cert.pem(), client_key.serialize_pem())
+}
+
+fn config(port: u16, tls: tcp::ModbusTlsConfig) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: Some(tls),
+    }
+}
+
+/// Connect a bare `rust_modbus` TLS client against `addr`, trusting `trust_pem` (or
+/// skipping verification if `None`), optionally presenting `identity`.
+async fn raw_connect(
+    addr: std::net::SocketAddr,
+    trust_pem: Option<&str>,
+    identity: Option<ClientIdentity>,
+) -> rust_modbus::Result<()> {
+    let server_cert = match trust_pem {
+        Some(pem) => {
+            let mut roots = RootStore::empty();
+            roots.add_pem(pem.as_bytes())?;
+            ServerCertVerification::Verify(roots)
+        }
+        None => ServerCertVerification::DangerousDisableVerification,
+    };
+    let tls = TlsClientConfig {
+        server_cert,
+        client_identity: identity,
+    };
+    connect_tls(addr, TcpConfig::default(), tls).await?;
+    Ok(())
+}
+
+#[tokio::test]
+/// MB-R-106 — with none of `cert_file`/`key_file`/`self_signed` set, the server falls
+/// back to an ephemeral self-signed certificate, and logs that fallback.
+async fn self_signed_fallback_is_used_and_logged() {
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(port, tcp::ModbusTlsConfig::default())));
+    let (log, captured) = capturing();
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(log)
+        .await
+        .expect("server should start with the self-signed fallback");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    raw_connect(addr, None, None)
+        .await
+        .expect("client should connect to the fallback cert with verification disabled");
+
+    assert!(
+        captured
+            .lock()
+            .iter()
+            .any(|line| line.contains("self-signed")),
+        "expected a fallback log line, got: {:?}",
+        captured.lock()
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-106 — an explicit `self_signed: true` uses a self-signed certificate without
+/// logging the "no configuration" fallback line.
+async fn explicit_self_signed_is_used_without_fallback_log() {
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        },
+    )));
+    let (log, captured) = capturing();
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(log)
+        .await
+        .expect("server should start with an explicit self-signed cert");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    raw_connect(addr, None, None)
+        .await
+        .expect("client should connect with verification disabled");
+
+    assert!(
+        !captured
+            .lock()
+            .iter()
+            .any(|line| line.contains("self-signed")),
+        "expected no fallback log line when self_signed was explicitly requested, got: {:?}",
+        captured.lock()
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-106, edge-cases.md — `cert_file`/`key_file` win over `self_signed` when both
+/// are set: no fallback log, and the presented certificate is the explicit one.
+async fn explicit_files_win_over_self_signed() {
+    let (cert_pem, key_pem) = self_signed_pem();
+    let cert_file = write_pem("explicit-cert", &cert_pem);
+    let key_file = write_pem("explicit-key", &key_pem);
+
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            cert_file: Some(cert_file),
+            key_file: Some(key_file),
+            self_signed: true,
+            ..Default::default()
+        },
+    )));
+    let (log, captured) = capturing();
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(log)
+        .await
+        .expect("server should start from the explicit files");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    raw_connect(addr, Some(&cert_pem), None)
+        .await
+        .expect("client trusting the explicit cert specifically should connect");
+
+    assert!(
+        !captured
+            .lock()
+            .iter()
+            .any(|line| line.contains("self-signed")),
+        "expected no fallback log line when explicit files were set, got: {:?}",
+        captured.lock()
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-107 — `cert_file` or `key_file` set alone (not both) fails the server's start
+/// with a TLS configuration error, before any bind is attempted.
+async fn lone_cert_or_key_file_fails_server_start() {
+    let (cert_pem, _key_pem) = self_signed_pem();
+    let cert_file = write_pem("lone-cert", &cert_pem);
+
+    let cert_only = Arc::new(RwLock::new(config(
+        free_port(),
+        tcp::ModbusTlsConfig {
+            cert_file: Some(cert_file),
+            ..Default::default()
+        },
+    )));
+    let result = tcp::ServerBuilder::new(cert_only, memory())
+        .spawn(sink())
+        .await;
+    assert!(matches!(
+        result,
+        Err(ferrowl_modbus::Error::Tcp(
+            ferrowl_modbus::TcpError::Configuration(_)
+        ))
+    ));
+
+    let (_cert_pem2, key_pem2) = self_signed_pem();
+    let key_file = write_pem("lone-key", &key_pem2);
+    let key_only = Arc::new(RwLock::new(config(
+        free_port(),
+        tcp::ModbusTlsConfig {
+            key_file: Some(key_file),
+            ..Default::default()
+        },
+    )));
+    let result = tcp::ServerBuilder::new(key_only, memory())
+        .spawn(sink())
+        .await;
+    assert!(matches!(
+        result,
+        Err(ferrowl_modbus::Error::Tcp(
+            ferrowl_modbus::TcpError::Configuration(_)
+        ))
+    ));
+}
+
+#[tokio::test]
+/// MB-R-108, MB-R-111 (server connection-scoping half) — `require_client_cert`
+/// accepts a client signed by the configured CA, rejects one presenting none or one
+/// signed by an unrelated CA, and the accept loop survives every rejection.
+async fn require_client_cert_enforced() {
+    let (server_cert_pem, server_key_pem) = self_signed_pem();
+    let server_cert_file = write_pem("mtls-server-cert", &server_cert_pem);
+    let server_key_file = write_pem("mtls-server-key", &server_key_pem);
+
+    let (ca_pem, client_cert_pem, client_key_pem) = ca_and_signed_client_pem();
+    let ca_file = write_pem("mtls-ca", &ca_pem);
+
+    let (other_ca_pem, other_cert_pem, other_key_pem) = ca_and_signed_client_pem();
+    let _ = other_ca_pem;
+
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            cert_file: Some(server_cert_file.clone()),
+            key_file: Some(server_key_file),
+            require_client_cert: true,
+            client_ca_file: Some(ca_file),
+            ..Default::default()
+        },
+    )));
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(sink())
+        .await
+        .expect("mTLS server should start");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+    // Signed by the trusted CA: accepted.
+    let client_cert_chain = rust_modbus::load_pem_cert_chain(client_cert_pem.as_bytes()).unwrap();
+    let client_key = rust_modbus::load_pem_private_key(client_key_pem.as_bytes()).unwrap();
+    raw_connect(
+        addr,
+        Some(&server_cert_pem),
+        Some(ClientIdentity {
+            cert_chain: client_cert_chain,
+            key: client_key,
+        }),
+    )
+    .await
+    .expect("a client signed by the trusted CA should connect");
+
+    // No client certificate presented at all: the handshake either fails outright,
+    // or (TLS 1.3 client-side completion quirk — see s2's client tests) appears to
+    // succeed to the client while the server has already rejected it; either way the
+    // connection carries no usable session, so this only proves the accept loop
+    // survives, checked below by a subsequent good connection.
+    let _ = raw_connect(addr, Some(&server_cert_pem), None).await;
+
+    // Signed by an unrelated CA: rejected the same way.
+    let other_cert_chain = rust_modbus::load_pem_cert_chain(other_cert_pem.as_bytes()).unwrap();
+    let other_key = rust_modbus::load_pem_private_key(other_key_pem.as_bytes()).unwrap();
+    let _ = raw_connect(
+        addr,
+        Some(&server_cert_pem),
+        Some(ClientIdentity {
+            cert_chain: other_cert_chain,
+            key: other_key,
+        }),
+    )
+    .await;
+
+    // The accept loop survived both rejections: a subsequent well-behaved client
+    // still connects (MB-R-111 server half: one bad handshake never takes down the
+    // accept loop or other connections).
+    let client_cert_chain = rust_modbus::load_pem_cert_chain(client_cert_pem.as_bytes()).unwrap();
+    let client_key = rust_modbus::load_pem_private_key(client_key_pem.as_bytes()).unwrap();
+    raw_connect(
+        addr,
+        Some(&server_cert_pem),
+        Some(ClientIdentity {
+            cert_chain: client_cert_chain,
+            key: client_key,
+        }),
+    )
+    .await
+    .expect("accept loop should still serve a well-behaved client after prior rejections");
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-108 — `require_client_cert` without a `client_ca_file` fails the server's
+/// start with a TLS configuration error, before any bind is attempted.
+async fn require_client_cert_without_ca_fails_server_start() {
+    let (cert_pem, key_pem) = self_signed_pem();
+    let cert_file = write_pem("no-ca-cert", &cert_pem);
+    let key_file = write_pem("no-ca-key", &key_pem);
+
+    let cfg = Arc::new(RwLock::new(config(
+        free_port(),
+        tcp::ModbusTlsConfig {
+            cert_file: Some(cert_file),
+            key_file: Some(key_file),
+            require_client_cert: true,
+            ..Default::default()
+        },
+    )));
+    let result = tcp::ServerBuilder::new(cfg, memory()).spawn(sink()).await;
+    assert!(matches!(
+        result,
+        Err(ferrowl_modbus::Error::Tcp(
+            ferrowl_modbus::TcpError::Configuration(_)
+        ))
+    ));
+}
+
+#[tokio::test]
+/// edge-cases.md "TLS boundaries" — a malformed/unreadable PEM path fails the
+/// server's start with a TLS configuration error, the same tier as MB-R-107/108.
+async fn malformed_pem_fails_server_start() {
+    let bad_cert = write_pem("garbage-cert", "not a pem file at all");
+    let (_cert_pem, key_pem) = self_signed_pem();
+    let key_file = write_pem("garbage-key", &key_pem);
+
+    let cfg = Arc::new(RwLock::new(config(
+        free_port(),
+        tcp::ModbusTlsConfig {
+            cert_file: Some(bad_cert),
+            key_file: Some(key_file),
+            ..Default::default()
+        },
+    )));
+    let result = tcp::ServerBuilder::new(cfg, memory()).spawn(sink()).await;
+    assert!(matches!(
+        result,
+        Err(ferrowl_modbus::Error::Tcp(
+            ferrowl_modbus::TcpError::Configuration(_)
+        ))
+    ));
+}

--- a/ferrowl-modbus/tests/tcp_tls_server.rs
+++ b/ferrowl-modbus/tests/tcp_tls_server.rs
@@ -412,6 +412,66 @@ async fn require_client_cert_rejection_does_not_kill_accept_loop() {
 }
 
 #[tokio::test]
+/// MB-R-111 (server logging half) — a rejected mTLS handshake (no client
+/// certificate presented) is logged with the peer address and a failure reason.
+async fn require_client_cert_rejection_is_logged() {
+    let (server_cert_pem, server_key_pem) = self_signed_pem();
+    let server_cert_file = write_pem("mtls-log-server-cert", &server_cert_pem);
+    let server_key_file = write_pem("mtls-log-server-key", &server_key_pem);
+
+    let (ca_pem, client_cert_pem, client_key_pem) = ca_and_signed_client_pem();
+    let ca_file = write_pem("mtls-log-ca", &ca_pem);
+
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            cert_file: Some(server_cert_file.clone()),
+            key_file: Some(server_key_file),
+            require_client_cert: true,
+            client_ca_file: Some(ca_file),
+            ..Default::default()
+        },
+    )));
+    let (log, captured) = capturing();
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(log)
+        .await
+        .expect("mTLS server should start");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+    // No client certificate presented at all: rejected (see the TLS 1.3 client-side
+    // completion quirk note in `require_client_cert_enforced`).
+    let _ = raw_connect(addr, Some(&server_cert_pem), None).await;
+
+    // Run a well-behaved connection afterward so the rejected handshake's task has
+    // definitely finished (and its log line landed) before we inspect `captured`.
+    let client_cert_chain = rust_modbus::load_pem_cert_chain(client_cert_pem.as_bytes()).unwrap();
+    let client_key = rust_modbus::load_pem_private_key(client_key_pem.as_bytes()).unwrap();
+    raw_connect(
+        addr,
+        Some(&server_cert_pem),
+        Some(ClientIdentity {
+            cert_chain: client_cert_chain,
+            key: client_key,
+        }),
+    )
+    .await
+    .expect("accept loop should still serve a well-behaved client after a prior rejection");
+
+    let lines = captured.lock();
+    assert!(
+        lines.iter().any(|line| line.contains("TLS handshake")
+            && line.contains("127.0.0.1:")
+            && line.contains("failed")),
+        "expected a TLS handshake failure log line naming the peer, got: {lines:?}"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
 /// MB-R-108 — `require_client_cert` without a `client_ca_file` fails the server's
 /// start with a TLS configuration error, before any bind is attempted.
 async fn require_client_cert_without_ca_fails_server_start() {

--- a/ferrowl-modbus/tests/tcp_tls_server.rs
+++ b/ferrowl-modbus/tests/tcp_tls_server.rs
@@ -290,9 +290,8 @@ async fn lone_cert_or_key_file_fails_server_start() {
 }
 
 #[tokio::test]
-/// MB-R-108, MB-R-111 (server connection-scoping half) — `require_client_cert`
-/// accepts a client signed by the configured CA, rejects one presenting none or one
-/// signed by an unrelated CA, and the accept loop survives every rejection.
+/// MB-R-108 — `require_client_cert` accepts a client signed by the configured CA,
+/// and rejects one presenting none or one signed by an unrelated CA.
 async fn require_client_cert_enforced() {
     let (server_cert_pem, server_key_pem) = self_signed_pem();
     let server_cert_file = write_pem("mtls-server-cert", &server_cert_pem);
@@ -339,8 +338,9 @@ async fn require_client_cert_enforced() {
     // No client certificate presented at all: the handshake either fails outright,
     // or (TLS 1.3 client-side completion quirk — see s2's client tests) appears to
     // succeed to the client while the server has already rejected it; either way the
-    // connection carries no usable session, so this only proves the accept loop
-    // survives, checked below by a subsequent good connection.
+    // connection carries no usable session. Survival of the accept loop past this
+    // rejection is asserted separately, in
+    // `require_client_cert_rejection_does_not_kill_accept_loop`.
     let _ = raw_connect(addr, Some(&server_cert_pem), None).await;
 
     // Signed by an unrelated CA: rejected the same way.
@@ -356,9 +356,45 @@ async fn require_client_cert_enforced() {
     )
     .await;
 
-    // The accept loop survived both rejections: a subsequent well-behaved client
-    // still connects (MB-R-111 server half: one bad handshake never takes down the
-    // accept loop or other connections).
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-111 (server connection-scoping half) — a rejected mTLS handshake (missing
+/// or wrong-CA client certificate) never takes down the accept loop: a subsequent
+/// well-behaved client still connects.
+async fn require_client_cert_rejection_does_not_kill_accept_loop() {
+    let (server_cert_pem, server_key_pem) = self_signed_pem();
+    let server_cert_file = write_pem("mtls-server-cert", &server_cert_pem);
+    let server_key_file = write_pem("mtls-server-key", &server_key_pem);
+
+    let (ca_pem, client_cert_pem, client_key_pem) = ca_and_signed_client_pem();
+    let ca_file = write_pem("mtls-ca", &ca_pem);
+
+    let port = free_port();
+    let cfg = Arc::new(RwLock::new(config(
+        port,
+        tcp::ModbusTlsConfig {
+            cert_file: Some(server_cert_file.clone()),
+            key_file: Some(server_key_file),
+            require_client_cert: true,
+            client_ca_file: Some(ca_file),
+            ..Default::default()
+        },
+    )));
+    let server = tcp::ServerBuilder::new(cfg, memory())
+        .spawn(sink())
+        .await
+        .expect("mTLS server should start");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+    // No client certificate presented at all: rejected (see the TLS 1.3 client-side
+    // completion quirk note in `require_client_cert_enforced`).
+    let _ = raw_connect(addr, Some(&server_cert_pem), None).await;
+
+    // The accept loop survived the rejection: a subsequent well-behaved client
+    // still connects.
     let client_cert_chain = rust_modbus::load_pem_cert_chain(client_cert_pem.as_bytes()).unwrap();
     let client_key = rust_modbus::load_pem_private_key(client_key_pem.as_bytes()).unwrap();
     raw_connect(
@@ -370,7 +406,7 @@ async fn require_client_cert_enforced() {
         }),
     )
     .await
-    .expect("accept loop should still serve a well-behaved client after prior rejections");
+    .expect("accept loop should still serve a well-behaved client after a prior rejection");
 
     server.abort();
 }

--- a/ferrowl-ui/src/widgets/mod.rs
+++ b/ferrowl-ui/src/widgets/mod.rs
@@ -205,3 +205,72 @@ where
         StatefulWidget::render(&self.widget, area, buf, state)
     }
 }
+
+/// Render a single `$self.$field: Widget<S, W>` in `$area`. A generic function taking
+/// `&mut Widget<S, W>` hits trait-solver overflow on the blanket `StatefulWidget for &Widget<S,
+/// W>` impl above (ambiguous recursion through `W`), so this boilerplate is a macro instead —
+/// each call site expands with `W` already concrete, sidestepping the overflow entirely.
+#[macro_export]
+macro_rules! render_field {
+    ($self:ident, $field:ident, $area:expr, $buf:expr) => {
+        ::ratatui::widgets::StatefulWidget::render(
+            &$self.$field.widget,
+            $area,
+            $buf,
+            &mut $self.$field.state,
+        )
+    };
+}
+
+/// Render any number of `$self.$field` widgets left-to-right across `$area`, either evenly
+/// split (`field1, field2, ...`) or each sized by its own `Constraint`
+/// (`field1 => Constraint::Length(12), field2 => Constraint::Min(1), ...`).
+#[macro_export]
+macro_rules! render_row {
+    ($self:ident, $area:expr, $buf:expr; $($field:ident),+ $(,)?) => {{
+        let __areas = ::ratatui::layout::Layout::horizontal(::std::vec![
+            ::ratatui::layout::Constraint::Fill(1);
+            [$(::std::stringify!($field)),+].len()
+        ])
+        .split($area);
+        let mut __i = 0;
+        $(
+            $crate::render_field!($self, $field, __areas[__i], $buf);
+            __i += 1;
+        )+
+    }};
+    ($self:ident, $area:expr, $buf:expr; $($field:ident => $constraint:expr),+ $(,)?) => {{
+        let __areas = ::ratatui::layout::Layout::horizontal([$($constraint),+]).split($area);
+        let mut __i = 0;
+        $(
+            $crate::render_field!($self, $field, __areas[__i], $buf);
+            __i += 1;
+        )+
+    }};
+}
+
+/// Render any number of `$self.$field` widgets top-to-bottom across `$area`, either evenly
+/// split or each sized by its own `Constraint` — the vertical counterpart of `render_row!`.
+#[macro_export]
+macro_rules! render_col {
+    ($self:ident, $area:expr, $buf:expr; $($field:ident),+ $(,)?) => {{
+        let __areas = ::ratatui::layout::Layout::vertical(::std::vec![
+            ::ratatui::layout::Constraint::Fill(1);
+            [$(::std::stringify!($field)),+].len()
+        ])
+        .split($area);
+        let mut __i = 0;
+        $(
+            $crate::render_field!($self, $field, __areas[__i], $buf);
+            __i += 1;
+        )+
+    }};
+    ($self:ident, $area:expr, $buf:expr; $($field:ident => $constraint:expr),+ $(,)?) => {{
+        let __areas = ::ratatui::layout::Layout::vertical([$($constraint),+]).split($area);
+        let mut __i = 0;
+        $(
+            $crate::render_field!($self, $field, __areas[__i], $buf);
+            __i += 1;
+        )+
+    }};
+}

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -243,6 +243,7 @@ mod tests {
             delay_ms: 0,
             interval_ms: 0,
             reconnect: true,
+            tls: None,
         }
     }
 

--- a/ferrowl/src/main.rs
+++ b/ferrowl/src/main.rs
@@ -117,6 +117,7 @@ fn demo_modbus_tab(name: String, role: Role) -> Tab {
         delay_ms: None,
         interval_ms: None,
         reconnect: None,
+        tls: None,
         log_file: None,
         read_ranges: Default::default(),
         definitions,

--- a/ferrowl/src/migrate.rs
+++ b/ferrowl/src/migrate.rs
@@ -376,6 +376,7 @@ fn convert(legacy: LegacyConfig) -> (DeviceConfig, Vec<String>) {
         interval_ms: legacy.interval_ms.map(|v| v as usize),
         // The legacy format predates auto-reconnect; `None` falls back to `DEFAULT_RECONNECT`.
         reconnect: None,
+        tls: None,
         log_file: None,
         read_ranges,
         definitions,

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -260,6 +260,8 @@ pub(crate) fn endpoint_to_config(endpoint: &Endpoint, timing: &Timing) -> NetCon
             delay_ms: timing.delay_ms,
             interval_ms: timing.interval_ms,
             reconnect: timing.reconnect,
+            // Threaded end-to-end from device config in stage s5 (MB-R-104 wiring).
+            tls: None,
         }),
         Endpoint::Rtu {
             path,

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -251,7 +251,11 @@ pub struct Timing {
     pub reconnect: bool,
 }
 
-pub(crate) fn endpoint_to_config(endpoint: &Endpoint, timing: &Timing) -> NetConfig {
+pub(crate) fn endpoint_to_config(
+    endpoint: &Endpoint,
+    timing: &Timing,
+    tls: Option<ferrowl_modbus::tcp::ModbusTlsConfig>,
+) -> NetConfig {
     match endpoint {
         Endpoint::Tcp { ip, port } => NetConfig::Tcp(ferrowl_modbus::tcp::Config {
             ip: ip.clone(),
@@ -260,8 +264,7 @@ pub(crate) fn endpoint_to_config(endpoint: &Endpoint, timing: &Timing) -> NetCon
             delay_ms: timing.delay_ms,
             interval_ms: timing.interval_ms,
             reconnect: timing.reconnect,
-            // Threaded end-to-end from device config in stage s5 (MB-R-104 wiring).
-            tls: None,
+            tls,
         }),
         Endpoint::Rtu {
             path,
@@ -649,5 +652,35 @@ mod tests {
             .expect("read should succeed");
         assert_eq!(read, vec![50]);
         assert_eq!(format!("{}", register.decode(&read).unwrap()), "50");
+    }
+
+    /// MB-R-104 — `endpoint_to_config` threads the `tls` value through for a TCP
+    /// endpoint (and never reads it for RTU — MB-R-112).
+    #[test]
+    fn ut_endpoint_to_config_carries_tls_for_tcp_endpoint() {
+        use super::{Timing, endpoint_to_config};
+        use crate::config::Endpoint;
+        use ferrowl_modbus::Transport as NetConfig;
+        use ferrowl_modbus::tcp::ModbusTlsConfig;
+
+        let timing = Timing {
+            timeout_ms: 1000,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let tls = Some(ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        });
+        let endpoint = Endpoint::Tcp {
+            ip: "127.0.0.1".to_string(),
+            port: 502,
+        };
+        let net_config = endpoint_to_config(&endpoint, &timing, tls.clone());
+        match net_config {
+            NetConfig::Tcp(cfg) => assert_eq!(cfg.tls, tls),
+            NetConfig::Rtu(_) => panic!("expected a TCP config"),
+        }
     }
 }

--- a/ferrowl/src/module/modbus/config/device.rs
+++ b/ferrowl/src/module/modbus/config/device.rs
@@ -46,6 +46,11 @@ pub struct DeviceConfig {
     /// servers. See `ModbusModule::resolve_timing`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reconnect: Option<bool>,
+    /// TLS settings for this device's TCP endpoint (MB-R-104). Ignored entirely when
+    /// the module's endpoint is RTU (MB-R-112). `None` (the default) keeps the
+    /// endpoint on plain TCP.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls: Option<ferrowl_modbus::tcp::ModbusTlsConfig>,
     /// Base path for per-module log files (tab name appended as suffix). `None` disables.
     #[serde(skip)]
     pub log_file: Option<String>,
@@ -380,6 +385,7 @@ mod tests {
             delay_ms: None,
             interval_ms: Some(800),
             reconnect: Some(false),
+            tls: None,
             // `log_file` is `#[serde(skip)]` (runtime-only), so it never survives a
             // config roundtrip — leave it None to match the loaded value.
             log_file: None,
@@ -438,6 +444,31 @@ mod tests {
     /// CS-R-004 — a device config round-trips through JSON with no field loss.
     fn ut_device_roundtrip_json() {
         roundtrip(FileType::Json, "json");
+    }
+
+    #[test]
+    /// MB-R-104 — a device config's `tls` block round-trips, and an absent `tls` key
+    /// deserializes to `None`.
+    fn ut_device_config_tls_serde_roundtrip() {
+        use ferrowl_modbus::tcp::ModbusTlsConfig;
+
+        let mut cfg = sample();
+        cfg.tls = Some(ModbusTlsConfig {
+            ca_file: Some("ca.pem".to_string()),
+            cert_file: Some("cert.pem".to_string()),
+            key_file: Some("key.pem".to_string()),
+            require_client_cert: true,
+            ..Default::default()
+        });
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: DeviceConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+
+        let path = std::env::temp_dir().join("ferrowl_device_no_tls.toml");
+        let path = path.to_str().unwrap();
+        std::fs::write(path, "definitions = {}\n").unwrap();
+        let loaded: DeviceConfig = Converter::load(path, FileType::Toml).unwrap();
+        assert_eq!(loaded.tls, None);
     }
 
     /// A device config file saved before `reconnect` existed (no such key at all) must still

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -43,6 +43,7 @@ fn network_log_level(s: &str) -> Level {
     if lower.contains("disconnecting")
         || lower.contains("reconnect disabled")
         || lower.contains("timed out")
+        || lower.contains("tls handshake")
     {
         Level::Error
     } else if lower.contains("disconnected")
@@ -442,6 +443,18 @@ mod tests {
         assert_eq!(timing.delay_ms, 500);
         assert!(!timing.reconnect);
         assert_eq!(timing.interval_ms, DEFAULT_INTERVAL_MS);
+    }
+
+    #[test]
+    /// MB-R-111 (server logging half) — a TLS handshake failure line classifies as
+    /// `Level::Error`, matching the peer/failure-detail format `on_tls_handshake_failed`
+    /// logs (`"TLS handshake with {peer} failed: {detail}."`).
+    fn ut_network_log_level_classifies_tls_handshake_failure_as_error() {
+        use super::network_log_level;
+        use crate::app::Level;
+
+        let line = "TLS handshake with 127.0.0.1:5502 failed: bad certificate.";
+        assert_eq!(network_log_level(line), Level::Error);
     }
 
     fn device_with_defs() -> crate::config::DeviceConfig {

--- a/ferrowl/src/module/modbus/module.rs
+++ b/ferrowl/src/module/modbus/module.rs
@@ -152,7 +152,7 @@ impl ModbusModule {
         let _ = open_sink(&file_sink, device.log_file.as_deref(), &spec.name);
 
         let timing = Self::resolve_timing(device);
-        let net_config = endpoint_to_config(&spec.endpoint, &timing);
+        let net_config = endpoint_to_config(&spec.endpoint, &timing, device.tls.clone());
         let instance = build_instance(spec.role, net_config, operations.clone(), memory.clone());
 
         let mut module = Self {
@@ -381,6 +381,7 @@ impl ModbusModule {
         role: Role,
         timing: Timing,
         read_ranges: ReadRanges,
+        tls: Option<ferrowl_modbus::tcp::ModbusTlsConfig>,
     ) -> Result<(), Error> {
         // Best-effort stop of any running instance; the caller is expected to `start()` afterwards.
         let _ = self.instance.stop().await;
@@ -393,7 +394,7 @@ impl ModbusModule {
                 .add_ranges(key, &mem_kind, std::slice::from_ref(&range));
         }
         self.rebuild_operations().await;
-        let net_config = endpoint_to_config(endpoint, &timing);
+        let net_config = endpoint_to_config(endpoint, &timing, tls);
         self.instance = build_instance(
             role,
             net_config,
@@ -488,6 +489,7 @@ mod tests {
             delay_ms: None,
             interval_ms: Some(500),
             reconnect: None,
+            tls: None,
             log_file: Some(
                 std::env::temp_dir()
                     .join("ferrowl_module_test.log")
@@ -626,6 +628,7 @@ mod tests {
                 Role::Client,
                 timing,
                 ReadRanges::default(),
+                device.tls.clone(),
             )
             .await
             .expect("reconfigure");
@@ -710,6 +713,7 @@ mod tests {
             delay_ms: None,
             interval_ms: Some(50),
             reconnect: None,
+            tls: None,
             log_file: None,
             read_ranges: ReadRanges {
                 holding: Some("0-10".into()),

--- a/ferrowl/src/module/modbus/setup.rs
+++ b/ferrowl/src/module/modbus/setup.rs
@@ -71,6 +71,9 @@ impl SetupView for ModbusSetupView {
             device.reconnect = Some(reconnect);
         }
         device.read_ranges = values.read_ranges.clone();
+        if let Some(tls) = values.tls.clone() {
+            device.tls = tls;
+        }
 
         let spec = ModuleSpec {
             name: values.name,

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -1286,16 +1286,83 @@ mod tests {
     }
 
     #[test]
-    /// UI-R-024 — a TCP setup dialog exposes the TLS section.
-    fn ut_tcp_dialog_shows_tls_section() {
-        let dialog = SetupDialog::create(Timing {
+    /// UI-R-024 — a TCP setup dialog always offers the TLS level selector, but the detail
+    /// section (self-signed/cert/etc.) only appears once a level above Off is actually picked
+    /// — the level selector alone must never imply the rest of the section is showing.
+    fn ut_tcp_dialog_shows_tls_level_selector_but_not_detail_section_at_off() {
+        let mut dialog = SetupDialog::create(Timing {
             timeout_ms: 0,
             delay_ms: 0,
             interval_ms: 0,
             reconnect: true,
         });
         assert_eq!(dialog.transport.state.get_value(), Transport::Tcp);
+        assert_eq!(dialog.tls_level.state.get_value(), TlsLevel::Off);
+        // Level selector itself: always rendered for TCP, regardless of the chosen level.
+        let area = Rect::new(0, 0, 80, 60);
+        let mut buf = Buffer::empty(area);
+        dialog.render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(text.contains("TLS"), "missing TLS level selector:\n{text}");
+        // Detail section: hidden at Off, so the toggle/cert rows aren't allocated or drawn.
+        assert!(!dialog.tls_shown());
+        assert!(
+            !text.contains("Self-Signed"),
+            "self-signed toggle shown at TLS level Off:\n{text}"
+        );
+    }
+
+    #[test]
+    /// UI-R-024 — picking a TLS level above Off reveals the detail section (MB-R-104's fields
+    /// become settable only once the user has actually opted into TLS).
+    fn ut_tls_shown_once_level_selected_above_off() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        assert!(!dialog.tls_shown());
+        dialog.tls_level.state.set_selection(TlsLevel::Tls.index());
         assert!(dialog.tls_shown());
+    }
+
+    #[test]
+    /// UI-R-024 — a server that turns on Self-Signed no longer needs (or shows) the
+    /// cert/key file row; toggling it back off restores the row.
+    fn ut_self_signed_hides_server_cert_row() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        // Default role is Server.
+        dialog.tls_level.state.set_selection(TlsLevel::Tls.index());
+        assert!(dialog.show_cert_row_a());
+        dialog.self_signed.state.set_selection(1); // On
+        assert!(!dialog.show_cert_row_a());
+        dialog.self_signed.state.set_selection(0); // Off
+        assert!(dialog.show_cert_row_a());
+    }
+
+    #[test]
+    /// UI-R-024 — a client that turns on Skip Verify no longer needs (or shows) the CA-file
+    /// row; toggling it back off restores the row.
+    fn ut_skip_verify_hides_ca_file_row() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        dialog.role.state.set_selection(1); // Client
+        dialog.tls_level.state.set_selection(TlsLevel::Tls.index());
+        assert!(dialog.show_cert_row_a());
+        dialog.skip_verify.state.set_selection(1); // On
+        assert!(!dialog.show_cert_row_a());
+        dialog.skip_verify.state.set_selection(0); // Off
+        assert!(dialog.show_cert_row_a());
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -7,7 +7,7 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 use derive_builder::Builder;
 use ferrowl_ui::{
-    Border, COLOR_SCHEME, EventResult,
+    Border, COLOR_SCHEME, EventResult, render_field, render_row,
     state::{
         InputFieldState, InputFieldStateBuilder, SelectionState, SelectionStateBuilder,
         SuggestInputState, SuggestInputStateBuilder,
@@ -24,7 +24,7 @@ use ferrowl_util::convert::FileType;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, HorizontalAlignment, Layout, Margin, Rect},
-    widgets::{Block, Clear, StatefulWidget, Widget as UiWidget},
+    widgets::{Block, Clear, Widget as UiWidget},
 };
 
 use crate::config::device::ReadRanges;
@@ -730,7 +730,7 @@ impl SetupDialog {
 
         let is_new = self.mode == DialogMode::New;
         let is_rtu = self.transport.state.get_value() == Transport::Rtu;
-        // RTU needs three endpoint rows (path/baud, parity/data-bits, stop-bits); TCP one.
+        // RTU needs two endpoint rows (path/baud, parity/data-bits/stop-bits); TCP one.
         let endpoint_rows: u16 = if is_rtu { 2 } else { 1 };
         let show_tls = self.tls_shown();
         let show_cert_row_a = self.show_cert_row_a();
@@ -791,15 +791,10 @@ impl SetupDialog {
         let rows = Layout::vertical(constraints).split(inner);
 
         let mut idx = 0;
-        StatefulWidget::render(&self.name.widget, rows[idx], buf, &mut self.name.state);
+        render_field!(self, name, rows[idx], buf);
         idx += 1;
 
-        StatefulWidget::render(
-            &self.config_path.widget,
-            rows[idx],
-            buf,
-            &mut self.config_path.state,
-        );
+        render_field!(self, config_path, rows[idx], buf);
         idx += 1;
 
         let [transport_area, tls_area, role_area] = Layout::horizontal([
@@ -809,21 +804,11 @@ impl SetupDialog {
         ])
         .areas(rows[idx]);
         idx += 1;
-        StatefulWidget::render(
-            &self.transport.widget,
-            transport_area,
-            buf,
-            &mut self.transport.state,
-        );
+        render_field!(self, transport, transport_area, buf);
         if !is_rtu {
-            StatefulWidget::render(
-                &self.tls_level.widget,
-                tls_area,
-                buf,
-                &mut self.tls_level.state,
-            );
+            render_field!(self, tls_level, tls_area, buf);
         }
-        StatefulWidget::render(&self.role.widget, role_area, buf, &mut self.role.state);
+        render_field!(self, role, role_area, buf);
 
         if show_tls {
             let is_server = self.role.state.get_value() == Role::Server;
@@ -832,55 +817,30 @@ impl SetupDialog {
             } else {
                 self.show_skip_verify()
             };
-            let [side_area] = Layout::horizontal([Constraint::Percentage(100)]).areas(rows[idx]);
+            let side_area = rows[idx];
             if show_side {
                 if is_server {
-                    StatefulWidget::render(
-                        &self.self_signed.widget,
-                        side_area,
-                        buf,
-                        &mut self.self_signed.state,
-                    );
+                    render_field!(self, self_signed, side_area, buf);
                 } else {
-                    StatefulWidget::render(
-                        &self.skip_verify.widget,
-                        side_area,
-                        buf,
-                        &mut self.skip_verify.state,
-                    );
+                    render_field!(self, skip_verify, side_area, buf);
                 }
                 idx += 1;
             }
 
             if show_cert_row_a {
                 if self.show_ca_file() {
-                    StatefulWidget::render(
-                        &self.ca_file.widget,
-                        rows[idx],
-                        buf,
-                        &mut self.ca_file.state,
-                    );
+                    render_field!(self, ca_file, rows[idx], buf);
                 } else {
-                    render_suggest_pair(&mut self.cert_file, &mut self.key_file, rows[idx], buf);
+                    render_row!(self, rows[idx], buf; cert_file, key_file);
                 }
                 idx += 1;
             }
 
             if show_cert_row_b {
                 if self.show_client_cert() {
-                    render_suggest_pair(
-                        &mut self.client_cert_file,
-                        &mut self.client_key_file,
-                        rows[idx],
-                        buf,
-                    );
+                    render_row!(self, rows[idx], buf; client_cert_file, client_key_file);
                 } else {
-                    StatefulWidget::render(
-                        &self.client_ca_file.widget,
-                        rows[idx],
-                        buf,
-                        &mut self.client_ca_file.state,
-                    );
+                    render_field!(self, client_ca_file, rows[idx], buf);
                 }
                 idx += 1;
             }
@@ -891,112 +851,37 @@ impl SetupDialog {
         if is_rtu {
             let [row0, row1] = Layout::vertical([Constraint::Length(3), Constraint::Length(3)])
                 .areas(endpoint_area);
-            let [path_area, baud_area] =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .areas(row0);
-            StatefulWidget::render(&self.path.widget, path_area, buf, &mut self.path.state);
-            StatefulWidget::render(&self.baud.widget, baud_area, buf, &mut self.baud.state);
-            let [parity_area, data_area, stop_area] = Layout::horizontal([
-                Constraint::Percentage(35),
-                Constraint::Percentage(30),
-                Constraint::Percentage(35),
-            ])
-            .areas(row1);
-            StatefulWidget::render(
-                &self.parity.widget,
-                parity_area,
-                buf,
-                &mut self.parity.state,
-            );
-            StatefulWidget::render(
-                &self.data_bits.widget,
-                data_area,
-                buf,
-                &mut self.data_bits.state,
-            );
-            StatefulWidget::render(
-                &self.stop_bits.widget,
-                stop_area,
-                buf,
-                &mut self.stop_bits.state,
+            render_row!(self, row0, buf; path, baud);
+            render_row!(self, row1, buf;
+                parity => Constraint::Percentage(35),
+                data_bits => Constraint::Percentage(30),
+                stop_bits => Constraint::Percentage(35)
             );
         } else {
-            render_pair(&mut self.ip, &mut self.port, endpoint_area, buf);
+            render_row!(self, endpoint_area, buf; ip, port);
         }
 
-        {
-            // Client: timeout | delay | interval | reconnect. Server hides reconnect, so the
-            // remaining three widen to thirds instead of leaving a blank quarter.
-            let is_client = self.role.state.get_value() == Role::Client;
-            let (timeout_area, delay_area, interval_area, reconnect_area) = if is_client {
-                let [t, d, i, r] = Layout::horizontal([
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(25),
-                ])
-                .areas(rows[idx]);
-                (t, d, i, Some(r))
-            } else {
-                let [t, d, i] = Layout::horizontal([
-                    Constraint::Percentage(34),
-                    Constraint::Percentage(33),
-                    Constraint::Percentage(33),
-                ])
-                .areas(rows[idx]);
-                (t, d, i, None)
-            };
-            idx += 1;
-            StatefulWidget::render(
-                &self.timeout.widget,
-                timeout_area,
-                buf,
-                &mut self.timeout.state,
-            );
-            StatefulWidget::render(&self.delay.widget, delay_area, buf, &mut self.delay.state);
-            StatefulWidget::render(
-                &self.interval.widget,
-                interval_area,
-                buf,
-                &mut self.interval.state,
-            );
-            if let Some(reconnect_area) = reconnect_area {
-                StatefulWidget::render(
-                    &self.reconnect.widget,
-                    reconnect_area,
-                    buf,
-                    &mut self.reconnect.state,
-                );
-            }
-
-            render_pair(
-                &mut self.holding_ranges,
-                &mut self.input_ranges,
-                rows[idx],
-                buf,
-            );
-            idx += 1;
-            render_pair(
-                &mut self.coil_ranges,
-                &mut self.discrete_ranges,
-                rows[idx],
-                buf,
-            );
-            idx += 1;
+        // Client: timeout | delay | interval | reconnect. Server hides reconnect, so the
+        // remaining three widen to thirds instead of leaving a blank quarter.
+        if self.role.state.get_value() == Role::Client {
+            render_row!(self, rows[idx], buf; timeout, delay, interval, reconnect);
+        } else {
+            render_row!(self, rows[idx], buf; timeout, delay, interval);
         }
+        idx += 1;
+
+        render_row!(self, rows[idx], buf; holding_ranges, input_ranges);
+        idx += 1;
+        render_row!(self, rows[idx], buf; coil_ranges, discrete_ranges);
+        idx += 1;
 
         let error_area = rows[idx];
         idx += 1;
         if !self.error.state.is_empty() {
-            StatefulWidget::render(&self.error.widget, error_area, buf, &mut self.error.state);
+            render_field!(self, error, error_area, buf);
         }
 
-        StatefulWidget::render(
-            &self.keybinds.widget,
-            rows[idx],
-            buf,
-            &mut self.keybinds.state,
-        );
+        render_field!(self, keybinds, rows[idx], buf);
 
         // Suggestion popups draw last, over everything else in the dialog (and may overflow
         // the dialog box itself), so both must be rendered after all sibling widgets above.
@@ -1029,32 +914,6 @@ impl SetupDialog {
             d.render(vcenter, buf);
         }
     }
-}
-
-/// Render two input fields side by side in `area`.
-fn render_pair(
-    left: &mut Widget<InputFieldState, InputField<String>>,
-    right: &mut Widget<InputFieldState, InputField<String>>,
-    area: Rect,
-    buf: &mut Buffer,
-) {
-    let [left_area, right_area] =
-        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).areas(area);
-    StatefulWidget::render(&left.widget, left_area, buf, &mut left.state);
-    StatefulWidget::render(&right.widget, right_area, buf, &mut right.state);
-}
-
-/// Render two path-suggesting input fields side by side in `area`.
-fn render_suggest_pair(
-    left: &mut Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    right: &mut Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    area: Rect,
-    buf: &mut Buffer,
-) {
-    let [left_area, right_area] =
-        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).areas(area);
-    StatefulWidget::render(&left.widget, left_area, buf, &mut left.state);
-    StatefulWidget::render(&right.widget, right_area, buf, &mut right.state);
 }
 
 /// Select the entry matching `current` (if present) in a numeric choice selection.

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -105,25 +105,11 @@ pub struct SetupDialog {
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<ConfigPath, FsPathProvider>>,
     #[focus]
     pub transport: Widget<SelectionState<Transport>, Selection<Transport>>,
-    #[focus]
-    pub role: Widget<SelectionState<Role>, Selection<Role>>,
-    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
-    pub ip: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
-    pub port: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
-    pub path: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
-    pub baud: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
-    pub parity: Widget<SelectionState<Parity>, Selection<Parity>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
-    pub data_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
-    pub stop_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
     /// TLS level, offered only for TCP (MB-R-112: RTU carries no `tls` field at all).
     #[focus(when = {self.transport.get_value() == Transport::Tcp})]
     pub tls_level: Widget<SelectionState<TlsLevel>, Selection<TlsLevel>>,
+    #[focus]
+    pub role: Widget<SelectionState<Role>, Selection<Role>>,
     /// Server-only "generate an ephemeral self-signed certificate" toggle.
     #[focus(when = {self.show_self_signed()})]
     pub self_signed: Widget<SelectionState<SelfSignedChoice>, Selection<SelfSignedChoice>>,
@@ -152,6 +138,20 @@ pub struct SetupDialog {
     #[focus(when = {self.show_client_ca()})]
     pub client_ca_file:
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    pub ip: Widget<InputFieldState, InputField<String>>,
+    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    pub port: Widget<InputFieldState, InputField<String>>,
+    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    pub path: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    pub baud: Widget<InputFieldState, InputField<String>>,
+    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    pub parity: Widget<SelectionState<Parity>, Selection<Parity>>,
+    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    pub data_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
+    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    pub stop_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
     #[focus]
     pub timeout: Widget<InputFieldState, InputField<String>>,
     #[focus]
@@ -333,13 +333,13 @@ impl SetupDialog {
             ))
             .data_bits(selection(
                 "Data Bits",
-                Some(HorizontalAlignment::Right),
+                Some(HorizontalAlignment::Center),
                 vec![U8Choice(8), U8Choice(7), U8Choice(6), U8Choice(5)],
                 &selection_style,
             ))
             .stop_bits(selection(
                 "Stop Bits",
-                None,
+                Some(HorizontalAlignment::Right),
                 vec![U8Choice(1), U8Choice(2)],
                 &selection_style,
             ))
@@ -489,7 +489,7 @@ impl SetupDialog {
 
     /// The TLS level selection row (any TCP endpoint; never RTU, MB-R-112).
     fn tls_shown(&self) -> bool {
-        self.transport.get_value() == Transport::Tcp
+        self.transport.get_value() == Transport::Tcp && self.tls_level.get_value() != TlsLevel::Off
     }
 
     /// The currently selected TLS level.
@@ -516,6 +516,7 @@ impl SetupDialog {
         self.tls_shown()
             && self.role.get_value() == Role::Client
             && self.tls_level() >= TlsLevel::Tls
+            && self.skip_verify.get_value() == SkipVerifyChoice::Off
     }
 
     /// Server certificate/key inputs (TCP server at TLS level or above).
@@ -523,6 +524,7 @@ impl SetupDialog {
         self.tls_shown()
             && self.role.get_value() == Role::Server
             && self.tls_level() >= TlsLevel::Tls
+            && self.self_signed.get_value() == SelfSignedChoice::Off
     }
 
     /// Client mTLS certificate/key inputs.
@@ -729,7 +731,7 @@ impl SetupDialog {
         let is_new = self.mode == DialogMode::New;
         let is_rtu = self.transport.state.get_value() == Transport::Rtu;
         // RTU needs three endpoint rows (path/baud, parity/data-bits, stop-bits); TCP one.
-        let endpoint_rows: u16 = if is_rtu { 3 } else { 1 };
+        let endpoint_rows: u16 = if is_rtu { 2 } else { 1 };
         let show_tls = self.tls_shown();
         let show_cert_row_a = self.show_cert_row_a();
         let show_cert_row_b = self.show_cert_row_b();
@@ -800,9 +802,12 @@ impl SetupDialog {
         );
         idx += 1;
 
-        let [transport_area, role_area] =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .areas(rows[idx]);
+        let [transport_area, tls_area, role_area] = Layout::horizontal([
+            Constraint::Percentage(if is_rtu { 50 } else { 35 }),
+            Constraint::Percentage(if is_rtu { 0 } else { 30 }),
+            Constraint::Percentage(if is_rtu { 50 } else { 35 }),
+        ])
+        .areas(rows[idx]);
         idx += 1;
         StatefulWidget::render(
             &self.transport.widget,
@@ -810,25 +815,93 @@ impl SetupDialog {
             buf,
             &mut self.transport.state,
         );
+        if !is_rtu {
+            StatefulWidget::render(
+                &self.tls_level.widget,
+                tls_area,
+                buf,
+                &mut self.tls_level.state,
+            );
+        }
         StatefulWidget::render(&self.role.widget, role_area, buf, &mut self.role.state);
+
+        if show_tls {
+            let is_server = self.role.state.get_value() == Role::Server;
+            let show_side = if is_server {
+                self.show_self_signed()
+            } else {
+                self.show_skip_verify()
+            };
+            let [side_area] = Layout::horizontal([Constraint::Percentage(100)]).areas(rows[idx]);
+            if show_side {
+                if is_server {
+                    StatefulWidget::render(
+                        &self.self_signed.widget,
+                        side_area,
+                        buf,
+                        &mut self.self_signed.state,
+                    );
+                } else {
+                    StatefulWidget::render(
+                        &self.skip_verify.widget,
+                        side_area,
+                        buf,
+                        &mut self.skip_verify.state,
+                    );
+                }
+                idx += 1;
+            }
+
+            if show_cert_row_a {
+                if self.show_ca_file() {
+                    StatefulWidget::render(
+                        &self.ca_file.widget,
+                        rows[idx],
+                        buf,
+                        &mut self.ca_file.state,
+                    );
+                } else {
+                    render_suggest_pair(&mut self.cert_file, &mut self.key_file, rows[idx], buf);
+                }
+                idx += 1;
+            }
+
+            if show_cert_row_b {
+                if self.show_client_cert() {
+                    render_suggest_pair(
+                        &mut self.client_cert_file,
+                        &mut self.client_key_file,
+                        rows[idx],
+                        buf,
+                    );
+                } else {
+                    StatefulWidget::render(
+                        &self.client_ca_file.widget,
+                        rows[idx],
+                        buf,
+                        &mut self.client_ca_file.state,
+                    );
+                }
+                idx += 1;
+            }
+        }
 
         let endpoint_area = rows[idx];
         idx += 1;
         if is_rtu {
-            let [row0, row1, row2] = Layout::vertical([
-                Constraint::Length(3),
-                Constraint::Length(3),
-                Constraint::Length(3),
-            ])
-            .areas(endpoint_area);
+            let [row0, row1] = Layout::vertical([Constraint::Length(3), Constraint::Length(3)])
+                .areas(endpoint_area);
             let [path_area, baud_area] =
                 Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .areas(row0);
             StatefulWidget::render(&self.path.widget, path_area, buf, &mut self.path.state);
             StatefulWidget::render(&self.baud.widget, baud_area, buf, &mut self.baud.state);
-            let [parity_area, data_area] =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .areas(row1);
+            let [parity_area, data_area, stop_area] = Layout::horizontal([
+                Constraint::Percentage(35),
+                Constraint::Percentage(30),
+                Constraint::Percentage(35),
+            ])
+            .areas(row1);
             StatefulWidget::render(
                 &self.parity.widget,
                 parity_area,
@@ -841,10 +914,12 @@ impl SetupDialog {
                 buf,
                 &mut self.data_bits.state,
             );
-            let [left, _] =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .areas(row2);
-            StatefulWidget::render(&self.stop_bits.widget, left, buf, &mut self.stop_bits.state);
+            StatefulWidget::render(
+                &self.stop_bits.widget,
+                stop_area,
+                buf,
+                &mut self.stop_bits.state,
+            );
         } else {
             render_pair(&mut self.ip, &mut self.port, endpoint_area, buf);
         }
@@ -907,82 +982,6 @@ impl SetupDialog {
                 rows[idx],
                 buf,
             );
-            idx += 1;
-        }
-
-        if show_tls {
-            let is_server = self.role.state.get_value() == Role::Server;
-            let show_side = if is_server {
-                self.show_self_signed()
-            } else {
-                self.show_skip_verify()
-            };
-            if show_side {
-                let [level_area, side_area] =
-                    Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                        .areas(rows[idx]);
-                StatefulWidget::render(
-                    &self.tls_level.widget,
-                    level_area,
-                    buf,
-                    &mut self.tls_level.state,
-                );
-                if is_server {
-                    StatefulWidget::render(
-                        &self.self_signed.widget,
-                        side_area,
-                        buf,
-                        &mut self.self_signed.state,
-                    );
-                } else {
-                    StatefulWidget::render(
-                        &self.skip_verify.widget,
-                        side_area,
-                        buf,
-                        &mut self.skip_verify.state,
-                    );
-                }
-            } else {
-                StatefulWidget::render(
-                    &self.tls_level.widget,
-                    rows[idx],
-                    buf,
-                    &mut self.tls_level.state,
-                );
-            }
-            idx += 1;
-        }
-
-        if show_cert_row_a {
-            if self.show_ca_file() {
-                StatefulWidget::render(
-                    &self.ca_file.widget,
-                    rows[idx],
-                    buf,
-                    &mut self.ca_file.state,
-                );
-            } else {
-                render_suggest_pair(&mut self.cert_file, &mut self.key_file, rows[idx], buf);
-            }
-            idx += 1;
-        }
-
-        if show_cert_row_b {
-            if self.show_client_cert() {
-                render_suggest_pair(
-                    &mut self.client_cert_file,
-                    &mut self.client_key_file,
-                    rows[idx],
-                    buf,
-                );
-            } else {
-                StatefulWidget::render(
-                    &self.client_ca_file.widget,
-                    rows[idx],
-                    buf,
-                    &mut self.client_ca_file.state,
-                );
-            }
             idx += 1;
         }
 

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -32,11 +32,14 @@ use crate::config::{DeviceConfig, Endpoint, Role};
 use crate::dialog::NonEmpty;
 use crate::dialog::close_confirm::{CloseConfirmDialog, CloseConfirmOutcome, route_close_confirm};
 use crate::dialog::path_suggest::FsPathProvider;
+use ferrowl_modbus::tcp::ModbusTlsConfig;
 
 use super::build::Timing;
 
 mod choices;
 use choices::{DialogMode, Parity, ReconnectChoice, Transport, U8Choice};
+mod tls;
+use tls::{SelfSignedChoice, SkipVerifyChoice, TlsInputs, TlsLevel, validate_tls};
 
 /// The validated per-instance settings.
 pub struct SetupValues {
@@ -52,6 +55,12 @@ pub struct SetupValues {
     pub reconnect: Option<bool>,
     /// Explicit per-function-code read ranges (client only), applied to the device config.
     pub read_ranges: ReadRanges,
+    /// The device config's `tls` setting (MB-R-104). `None` when the TLS section is hidden
+    /// (RTU transport, MB-R-112) — a hidden section must never clobber a device config's
+    /// existing setting. `Some(None)` means shown-and-explicitly-off; `Some(Some(cfg))` means
+    /// shown at a level above Off. Mirrors `reconnect`'s hidden-vs-explicit shape one level
+    /// deeper (the value itself, not just whether to touch it, is optional).
+    pub tls: Option<Option<ModbusTlsConfig>>,
 }
 
 /// The full validated dialog result. `device` is set in New mode: the config path (or
@@ -112,6 +121,37 @@ pub struct SetupDialog {
     pub data_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
     #[focus(when = {self.transport.get_value() == Transport::Rtu})]
     pub stop_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
+    /// TLS level, offered only for TCP (MB-R-112: RTU carries no `tls` field at all).
+    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    pub tls_level: Widget<SelectionState<TlsLevel>, Selection<TlsLevel>>,
+    /// Server-only "generate an ephemeral self-signed certificate" toggle.
+    #[focus(when = {self.show_self_signed()})]
+    pub self_signed: Widget<SelectionState<SelfSignedChoice>, Selection<SelfSignedChoice>>,
+    /// Client-only "accept any server certificate" toggle.
+    #[focus(when = {self.show_skip_verify()})]
+    pub skip_verify: Widget<SelectionState<SkipVerifyChoice>, Selection<SkipVerifyChoice>>,
+    /// Client-only extra trust anchor for a self-signed server certificate.
+    #[focus(when = {self.show_ca_file()})]
+    pub ca_file: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    /// Server-only certificate chain presented to connecting clients.
+    #[focus(when = {self.show_server_cert()})]
+    pub cert_file: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    /// Server-only private key matching `cert_file`.
+    #[focus(when = {self.show_server_cert()})]
+    pub key_file: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    /// Client-only client certificate presented for mutual TLS.
+    #[focus(when = {self.show_client_cert()})]
+    pub client_cert_file:
+        Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    /// Client-only private key matching `client_cert_file`.
+    #[focus(when = {self.show_client_cert()})]
+    pub client_key_file:
+        Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    /// Server-only CA used to verify client certificates (selecting mTLS as server implies
+    /// `require_client_cert = true` in the resolved config).
+    #[focus(when = {self.show_client_ca()})]
+    pub client_ca_file:
+        Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
     #[focus]
     pub timeout: Widget<InputFieldState, InputField<String>>,
     #[focus]
@@ -150,6 +190,7 @@ impl SetupDialog {
         endpoint: &Endpoint,
         timing: Timing,
         ranges: &ReadRanges,
+        tls: Option<&ModbusTlsConfig>,
     ) -> Self {
         let mut dialog = Self::build(name, config_path, DialogMode::Edit, timing, ranges);
         dialog
@@ -179,6 +220,36 @@ impl SetupDialog {
                 select_u8(&mut dialog.data_bits.state, *data_bits);
                 select_u8(&mut dialog.stop_bits.state, *stop_bits);
             }
+        }
+        if let Some(tls) = tls {
+            let level = TlsLevel::from_config(tls, role);
+            dialog.tls_level.state.set_selection(level.index());
+            dialog
+                .self_signed
+                .state
+                .set_selection(if tls.self_signed { 1 } else { 0 });
+            dialog
+                .skip_verify
+                .state
+                .set_selection(if tls.insecure_skip_verify { 1 } else { 0 });
+            set_suggest_input(&mut dialog.ca_file, tls.ca_file.as_deref().unwrap_or(""));
+            set_suggest_input(
+                &mut dialog.cert_file,
+                tls.cert_file.as_deref().unwrap_or(""),
+            );
+            set_suggest_input(&mut dialog.key_file, tls.key_file.as_deref().unwrap_or(""));
+            set_suggest_input(
+                &mut dialog.client_cert_file,
+                tls.client_cert_file.as_deref().unwrap_or(""),
+            );
+            set_suggest_input(
+                &mut dialog.client_key_file,
+                tls.client_key_file.as_deref().unwrap_or(""),
+            );
+            set_suggest_input(
+                &mut dialog.client_ca_file,
+                tls.client_ca_file.as_deref().unwrap_or(""),
+            );
         }
         dialog
     }
@@ -272,6 +343,72 @@ impl SetupDialog {
                 vec![U8Choice(1), U8Choice(2)],
                 &selection_style,
             ))
+            .tls_level(selection(
+                "TLS",
+                None,
+                vec![TlsLevel::Off, TlsLevel::Tls, TlsLevel::MutualTls],
+                &selection_style,
+            ))
+            .self_signed(selection(
+                "Self-Signed",
+                None,
+                vec![SelfSignedChoice::Off, SelfSignedChoice::On],
+                &selection_style,
+            ))
+            .skip_verify(selection(
+                "Skip Verify",
+                None,
+                vec![SkipVerifyChoice::Off, SkipVerifyChoice::On],
+                &selection_style,
+            ))
+            .ca_file(suggest_input(
+                "CA File",
+                None,
+                "ca.pem",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
+            .cert_file(suggest_input(
+                "Cert File",
+                None,
+                "server.crt",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
+            .key_file(suggest_input(
+                "Key File",
+                None,
+                "server.key",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
+            .client_cert_file(suggest_input(
+                "Client Cert",
+                None,
+                "client.crt",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
+            .client_key_file(suggest_input(
+                "Client Key",
+                None,
+                "client.key",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
+            .client_ca_file(suggest_input(
+                "Client CA",
+                None,
+                "client_ca.pem",
+                &input_style,
+                false,
+                FsPathProvider::with_extensions(&["pem", "crt", "key"]),
+            ))
             .timeout(input("Timeout ms", None, "", &input_style, false))
             .delay(input("Delay ms", None, "", &input_style, false))
             .interval(input("Interval ms", None, "", &input_style, false))
@@ -343,6 +480,73 @@ impl SetupDialog {
             }
         }
         dialog
+    }
+
+    // --- TLS-field visibility ------------------------------------------------------------------
+    // Single source of truth consumed by the `#[focus(when)]` gates, the render branches and the
+    // dialog-height computation, so keyboard focus, painting and layout can never disagree about
+    // which fields exist. Mirrors `ferrowl::module::ocpp::setup_dialog`'s own `show_*` methods.
+
+    /// The TLS level selection row (any TCP endpoint; never RTU, MB-R-112).
+    fn tls_shown(&self) -> bool {
+        self.transport.get_value() == Transport::Tcp
+    }
+
+    /// The currently selected TLS level.
+    fn tls_level(&self) -> TlsLevel {
+        self.tls_level.get_value()
+    }
+
+    /// Server-only self-signed toggle (TCP server at TLS level or above).
+    fn show_self_signed(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Server
+            && self.tls_level() >= TlsLevel::Tls
+    }
+
+    /// Client-only skip-verify toggle (TCP client at TLS level or above).
+    fn show_skip_verify(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Client
+            && self.tls_level() >= TlsLevel::Tls
+    }
+
+    /// Client trust-anchor input (TCP client at TLS level or above).
+    fn show_ca_file(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Client
+            && self.tls_level() >= TlsLevel::Tls
+    }
+
+    /// Server certificate/key inputs (TCP server at TLS level or above).
+    fn show_server_cert(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Server
+            && self.tls_level() >= TlsLevel::Tls
+    }
+
+    /// Client mTLS certificate/key inputs.
+    fn show_client_cert(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Client
+            && self.tls_level() == TlsLevel::MutualTls
+    }
+
+    /// Server mTLS client-CA input.
+    fn show_client_ca(&self) -> bool {
+        self.tls_shown()
+            && self.role.get_value() == Role::Server
+            && self.tls_level() == TlsLevel::MutualTls
+    }
+
+    /// First certificate row: server cert/key, or the client trust anchor.
+    fn show_cert_row_a(&self) -> bool {
+        self.show_ca_file() || self.show_server_cert()
+    }
+
+    /// Second certificate row: client mTLS cert/key, or the server client-CA.
+    fn show_cert_row_b(&self) -> bool {
+        self.show_client_cert() || self.show_client_ca()
     }
 
     /// Route a key: the close-confirm popup captures all keys while open; Esc opens it;
@@ -469,6 +673,38 @@ impl SetupDialog {
             discrete: opt(self.discrete_ranges.state.input()),
         };
 
+        // TLS is hidden entirely for RTU (MB-R-112): report no value at all, so a save on an
+        // RTU instance never clobbers a device config's existing `tls` setting.
+        let tls = if matches!(endpoint, Endpoint::Tcp { .. }) {
+            let level = self.tls_level.state.get_value();
+            if level == TlsLevel::Off {
+                Some(None)
+            } else {
+                let mut cfg = level.build_config(
+                    role,
+                    TlsInputs {
+                        ca_file: self.ca_file.state.input(),
+                        cert_file: self.cert_file.state.input(),
+                        key_file: self.key_file.state.input(),
+                        client_cert_file: self.client_cert_file.state.input(),
+                        client_key_file: self.client_key_file.state.input(),
+                        client_ca_file: self.client_ca_file.state.input(),
+                    },
+                );
+                if role == Role::Server {
+                    cfg.self_signed = self.self_signed.state.get_value() == SelfSignedChoice::On;
+                }
+                if role == Role::Client {
+                    cfg.insecure_skip_verify =
+                        self.skip_verify.state.get_value() == SkipVerifyChoice::On;
+                }
+                validate_tls(&cfg, role, level, &|p| std::path::Path::new(p).exists())?;
+                Some(Some(cfg))
+            }
+        } else {
+            None
+        };
+
         Ok(SetupValues {
             name,
             config_path,
@@ -479,6 +715,7 @@ impl SetupDialog {
             interval_ms,
             reconnect,
             read_ranges,
+            tls,
         })
     }
 
@@ -493,9 +730,13 @@ impl SetupDialog {
         let is_rtu = self.transport.state.get_value() == Transport::Rtu;
         // RTU needs three endpoint rows (path/baud, parity/data-bits, stop-bits); TCP one.
         let endpoint_rows: u16 = if is_rtu { 3 } else { 1 };
+        let show_tls = self.tls_shown();
+        let show_cert_row_a = self.show_cert_row_a();
+        let show_cert_row_b = self.show_cert_row_b();
+        let tls_rows: u16 = show_tls as u16 + show_cert_row_a as u16 + show_cert_row_b as u16;
         // border(2) + inner margin(2) + name(3) + device(3) + select(3) + endpoint + timing(3) + ranges(6)
-        // + error(4) + keybinds(1) + optional config-path row (New mode).
-        let box_height = 27 + endpoint_rows * 3;
+        // + error(4) + keybinds(1) + optional config-path row (New mode) + optional TLS rows.
+        let box_height = 27 + endpoint_rows * 3 + tls_rows * 3;
 
         let [_, hcenter, _] = Layout::horizontal([
             Constraint::Min(1),
@@ -525,7 +766,7 @@ impl SetupDialog {
         ratatui::prelude::Widget::render(&ratatui::widgets::Clear, vcenter, buf);
         block.render(vcenter, buf);
 
-        let constraints = vec![
+        let mut constraints = vec![
             Constraint::Length(3),                 // name
             Constraint::Length(3),                 // config path
             Constraint::Length(3),                 // transport + role
@@ -533,9 +774,18 @@ impl SetupDialog {
             Constraint::Length(3),                 // timeout + delay + interval
             Constraint::Length(3),                 // holding + input ranges
             Constraint::Length(3),                 // coil + discrete ranges
-            Constraint::Length(4),                 // error
-            Constraint::Length(1),                 // keybinds
         ];
+        if show_tls {
+            constraints.push(Constraint::Length(3)); // TLS level (+ self-signed/skip-verify)
+        }
+        if show_cert_row_a {
+            constraints.push(Constraint::Length(3)); // ca_file, or cert_file + key_file
+        }
+        if show_cert_row_b {
+            constraints.push(Constraint::Length(3)); // client_cert_file + client_key_file, or client_ca_file
+        }
+        constraints.push(Constraint::Length(4)); // error
+        constraints.push(Constraint::Length(1)); // keybinds
         let rows = Layout::vertical(constraints).split(inner);
 
         let mut idx = 0;
@@ -660,6 +910,82 @@ impl SetupDialog {
             idx += 1;
         }
 
+        if show_tls {
+            let is_server = self.role.state.get_value() == Role::Server;
+            let show_side = if is_server {
+                self.show_self_signed()
+            } else {
+                self.show_skip_verify()
+            };
+            if show_side {
+                let [level_area, side_area] =
+                    Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                        .areas(rows[idx]);
+                StatefulWidget::render(
+                    &self.tls_level.widget,
+                    level_area,
+                    buf,
+                    &mut self.tls_level.state,
+                );
+                if is_server {
+                    StatefulWidget::render(
+                        &self.self_signed.widget,
+                        side_area,
+                        buf,
+                        &mut self.self_signed.state,
+                    );
+                } else {
+                    StatefulWidget::render(
+                        &self.skip_verify.widget,
+                        side_area,
+                        buf,
+                        &mut self.skip_verify.state,
+                    );
+                }
+            } else {
+                StatefulWidget::render(
+                    &self.tls_level.widget,
+                    rows[idx],
+                    buf,
+                    &mut self.tls_level.state,
+                );
+            }
+            idx += 1;
+        }
+
+        if show_cert_row_a {
+            if self.show_ca_file() {
+                StatefulWidget::render(
+                    &self.ca_file.widget,
+                    rows[idx],
+                    buf,
+                    &mut self.ca_file.state,
+                );
+            } else {
+                render_suggest_pair(&mut self.cert_file, &mut self.key_file, rows[idx], buf);
+            }
+            idx += 1;
+        }
+
+        if show_cert_row_b {
+            if self.show_client_cert() {
+                render_suggest_pair(
+                    &mut self.client_cert_file,
+                    &mut self.client_key_file,
+                    rows[idx],
+                    buf,
+                );
+            } else {
+                StatefulWidget::render(
+                    &self.client_ca_file.widget,
+                    rows[idx],
+                    buf,
+                    &mut self.client_ca_file.state,
+                );
+            }
+            idx += 1;
+        }
+
         let error_area = rows[idx];
         idx += 1;
         if !self.error.state.is_empty() {
@@ -681,6 +1007,24 @@ impl SetupDialog {
         self.path
             .widget
             .render_overlay(area, buf, &mut self.path.state);
+        self.ca_file
+            .widget
+            .render_overlay(area, buf, &mut self.ca_file.state);
+        self.cert_file
+            .widget
+            .render_overlay(area, buf, &mut self.cert_file.state);
+        self.key_file
+            .widget
+            .render_overlay(area, buf, &mut self.key_file.state);
+        self.client_cert_file
+            .widget
+            .render_overlay(area, buf, &mut self.client_cert_file.state);
+        self.client_key_file
+            .widget
+            .render_overlay(area, buf, &mut self.client_key_file.state);
+        self.client_ca_file
+            .widget
+            .render_overlay(area, buf, &mut self.client_ca_file.state);
 
         if let Some(d) = self.close_confirm.as_mut() {
             d.render(vcenter, buf);
@@ -692,6 +1036,19 @@ impl SetupDialog {
 fn render_pair(
     left: &mut Widget<InputFieldState, InputField<String>>,
     right: &mut Widget<InputFieldState, InputField<String>>,
+    area: Rect,
+    buf: &mut Buffer,
+) {
+    let [left_area, right_area] =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).areas(area);
+    StatefulWidget::render(&left.widget, left_area, buf, &mut left.state);
+    StatefulWidget::render(&right.widget, right_area, buf, &mut right.state);
+}
+
+/// Render two path-suggesting input fields side by side in `area`.
+fn render_suggest_pair(
+    left: &mut Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
+    right: &mut Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
     area: Rect,
     buf: &mut Buffer,
 ) {
@@ -922,10 +1279,90 @@ mod tests {
             &endpoint,
             timing,
             &ReadRanges::default(),
+            None,
         );
         assert_eq!(dialog.reconnect.state.get_value(), ReconnectChoice::Off);
         let outcome = dialog.resolve().unwrap();
         assert_eq!(outcome.values.reconnect, Some(false));
+    }
+
+    #[test]
+    /// UI-R-024 — a TCP setup dialog exposes the TLS section.
+    fn ut_tcp_dialog_shows_tls_section() {
+        let dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        assert_eq!(dialog.transport.state.get_value(), Transport::Tcp);
+        assert!(dialog.tls_shown());
+    }
+
+    #[test]
+    /// UI-R-024 — an RTU setup dialog never shows the TLS section (MB-R-112).
+    fn ut_rtu_dialog_hides_tls_section() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        dialog.transport.state.set_selection(1); // Rtu
+        assert_eq!(dialog.transport.state.get_value(), Transport::Rtu);
+        assert!(!dialog.tls_shown());
+    }
+
+    #[test]
+    /// UI-R-024 — resolving an RTU dialog reports no TLS value at all, so applying it can never
+    /// clobber a device config's existing `tls` setting (MB-R-112).
+    fn ut_resolve_rtu_reports_no_tls() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        dialog.transport.state.set_selection(1); // Rtu
+        set_suggest_input(&mut dialog.path, "/dev/ttyUSB0");
+        let outcome = dialog.resolve().unwrap();
+        assert_eq!(outcome.values.tls, None);
+    }
+
+    #[test]
+    /// UI-R-024 — resolving a TCP dialog at TLS level Off reports an explicit no-TLS setting.
+    fn ut_resolve_tcp_tls_off_reports_some_none() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        let outcome = dialog.resolve().unwrap();
+        assert_eq!(outcome.values.tls, Some(None));
+    }
+
+    #[test]
+    /// UI-R-024 — resolving a TCP dialog at TLS level Tls (server, self-signed) builds a config
+    /// with `self_signed` set and drops the mTLS-only client-CA field.
+    fn ut_resolve_tcp_tls_server_self_signed_builds_config() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        dialog.tls_level.state.set_selection(TlsLevel::Tls.index());
+        dialog.self_signed.state.set_selection(1); // On
+        set_suggest_input(&mut dialog.client_ca_file, "client_ca.pem");
+        let outcome = dialog.resolve().unwrap();
+        let cfg = outcome.values.tls.unwrap().unwrap();
+        assert!(cfg.self_signed);
+        assert_eq!(cfg.client_ca_file, None);
+        assert!(!cfg.require_client_cert);
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/setup_dialog/tls.rs
+++ b/ferrowl/src/module/modbus/setup_dialog/tls.rs
@@ -1,0 +1,484 @@
+//! TLS domain for the Modbus setup dialog: the transport security level and its toggles, plus
+//! the mapping between raw field text and a [`ModbusTlsConfig`] (`from_config` infers a level,
+//! `build_config` resolves one, `validate_tls` checks files). Mirrors
+//! `ferrowl::module::ocpp::setup_dialog::security` exactly, minus Basic Auth (Modbus/TCP TLS has
+//! no credential level, only Off/TLS/mTLS) — see `MB-R-104`..`MB-R-112`.
+
+use ferrowl_ui::traits::ToLabel;
+
+use crate::config::Role;
+use ferrowl_modbus::tcp::ModbusTlsConfig;
+
+/// Modbus/TCP TLS level. Cumulative: `MutualTls`'s fields are shown in addition to `Tls`'s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TlsLevel {
+    Off,
+    Tls,
+    MutualTls,
+}
+
+impl ToLabel for TlsLevel {
+    fn to_label(&self) -> String {
+        match self {
+            TlsLevel::Off => "Off",
+            TlsLevel::Tls => "TLS",
+            TlsLevel::MutualTls => "mTLS",
+        }
+        .to_string()
+    }
+}
+
+/// Server-only "generate an ephemeral self-signed certificate" toggle, offered whenever `Tls`/
+/// `MutualTls` is selected (orthogonal to whether `cert_file`/`key_file` are also set — per
+/// edge-cases.md, explicit files win over `self_signed` when both are present).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelfSignedChoice {
+    Off,
+    On,
+}
+
+impl ToLabel for SelfSignedChoice {
+    fn to_label(&self) -> String {
+        match self {
+            SelfSignedChoice::Off => "Off",
+            SelfSignedChoice::On => "On",
+        }
+        .to_string()
+    }
+}
+
+/// Client-only "accept any server certificate" toggle, offered whenever `Tls`/`MutualTls` is
+/// selected. Mirrors `SkipVerifyChoice` in the OCPP dialog's `security` module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipVerifyChoice {
+    Off,
+    On,
+}
+
+impl ToLabel for SkipVerifyChoice {
+    fn to_label(&self) -> String {
+        match self {
+            SkipVerifyChoice::Off => "Off",
+            SkipVerifyChoice::On => "On",
+        }
+        .to_string()
+    }
+}
+
+/// Raw text of every TLS path field, passed by name so the many look-alike path fields cannot be
+/// transposed at a call site.
+pub struct TlsInputs<'a> {
+    pub ca_file: &'a str,
+    pub cert_file: &'a str,
+    pub key_file: &'a str,
+    pub client_cert_file: &'a str,
+    pub client_key_file: &'a str,
+    pub client_ca_file: &'a str,
+}
+
+impl TlsLevel {
+    /// Infer the level an existing [`ModbusTlsConfig`] represents, by role. Precedence (highest
+    /// first): client cert (client) / require-client-cert or client CA (server) → `MutualTls`;
+    /// CA file or skip-verify (client) / cert+key or self-signed (server) → `Tls`; else `Off`.
+    pub fn from_config(cfg: &ModbusTlsConfig, role: Role) -> TlsLevel {
+        match role {
+            Role::Client => {
+                if cfg.client_cert_file.is_some() {
+                    TlsLevel::MutualTls
+                } else if cfg.ca_file.is_some() || cfg.insecure_skip_verify {
+                    TlsLevel::Tls
+                } else {
+                    TlsLevel::Off
+                }
+            }
+            Role::Server => {
+                if cfg.require_client_cert || cfg.client_ca_file.is_some() {
+                    TlsLevel::MutualTls
+                } else if cfg.cert_file.is_some() || cfg.key_file.is_some() || cfg.self_signed {
+                    TlsLevel::Tls
+                } else {
+                    TlsLevel::Off
+                }
+            }
+        }
+    }
+
+    /// Build the resolved [`ModbusTlsConfig`] for this level/role from raw field text, so a field
+    /// not visible at this level/role (e.g. `client_cert_file` at `Tls`) is dropped rather than
+    /// smuggled through from a stale input.
+    pub fn build_config(self, role: Role, inputs: TlsInputs<'_>) -> ModbusTlsConfig {
+        let TlsInputs {
+            ca_file,
+            cert_file,
+            key_file,
+            client_cert_file,
+            client_key_file,
+            client_ca_file,
+        } = inputs;
+        let opt = |s: &str| {
+            let t = s.trim();
+            (!t.is_empty()).then(|| t.to_string())
+        };
+        let tls = self >= TlsLevel::Tls;
+        let mtls = self == TlsLevel::MutualTls;
+        let is_client = role == Role::Client;
+        let is_server = role == Role::Server;
+        ModbusTlsConfig {
+            ca_file: if tls && is_client { opt(ca_file) } else { None },
+            cert_file: if tls && is_server {
+                opt(cert_file)
+            } else {
+                None
+            },
+            key_file: if tls && is_server {
+                opt(key_file)
+            } else {
+                None
+            },
+            client_cert_file: if mtls && is_client {
+                opt(client_cert_file)
+            } else {
+                None
+            },
+            client_key_file: if mtls && is_client {
+                opt(client_key_file)
+            } else {
+                None
+            },
+            client_ca_file: if mtls && is_server {
+                opt(client_ca_file)
+            } else {
+                None
+            },
+            require_client_cert: mtls && is_server,
+            // Set by the caller (`resolve`), which reads the dialog's `self_signed`/
+            // `skip_verify` toggle widgets — neither is derivable from the raw field text this
+            // function works from.
+            self_signed: false,
+            insecure_skip_verify: false,
+        }
+    }
+
+    /// Index into the `tls_level` selection's value list (declaration order above).
+    pub(super) fn index(self) -> usize {
+        match self {
+            TlsLevel::Off => 0,
+            TlsLevel::Tls => 1,
+            TlsLevel::MutualTls => 2,
+        }
+    }
+}
+
+/// Check every required certificate file is present and exists on disk. `level` has already been
+/// checked `>= Tls` by the caller where relevant.
+pub(super) fn validate_tls(
+    cfg: &ModbusTlsConfig,
+    role: Role,
+    level: TlsLevel,
+    file_exists: &dyn Fn(&str) -> bool,
+) -> Result<(), String> {
+    let exists = |label: &str, path: &str| -> Result<(), String> {
+        if !file_exists(path) {
+            return Err(format!("{label} not found: {path}"));
+        }
+        Ok(())
+    };
+
+    match role {
+        Role::Server => {
+            if level >= TlsLevel::Tls && !cfg.self_signed {
+                let cert = cfg
+                    .cert_file
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or("Certificate file is required for TLS (or enable Self-Signed).")?;
+                exists("Certificate file", cert)?;
+                let key = cfg
+                    .key_file
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or("Key file is required for TLS (or enable Self-Signed).")?;
+                exists("Key file", key)?;
+            }
+            if level == TlsLevel::MutualTls {
+                let ca = cfg
+                    .client_ca_file
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or("Client CA file is required for mTLS.")?;
+                exists("Client CA file", ca)?;
+            }
+        }
+        Role::Client => {
+            if let Some(ca) = cfg.ca_file.as_deref()
+                && !ca.is_empty()
+            {
+                exists("CA file", ca)?;
+            }
+            if level == TlsLevel::MutualTls {
+                let cert = cfg
+                    .client_cert_file
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or("Client certificate file is required for mTLS.")?;
+                exists("Client certificate file", cert)?;
+                let key = cfg
+                    .client_key_file
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .ok_or("Client key file is required for mTLS.")?;
+                exists("Client key file", key)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- TlsLevel::from_config -----------------------------------------------------------------
+
+    #[test]
+    /// UI-R-024 — the TLS fields load from a no-TLS config for both roles.
+    fn ut_from_config_off_both_roles() {
+        let cfg = ModbusTlsConfig::default();
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Client), TlsLevel::Off);
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Server), TlsLevel::Off);
+    }
+
+    #[test]
+    /// UI-R-024 — a client TLS config loads into the CA-file field.
+    fn ut_from_config_tls_client_is_ca_file() {
+        let cfg = ModbusTlsConfig {
+            ca_file: Some("ca.pem".into()),
+            ..Default::default()
+        };
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Client), TlsLevel::Tls);
+    }
+
+    #[test]
+    /// UI-R-024 — a client config with only skip-verify set still loads at the TLS level.
+    fn ut_from_config_tls_client_is_skip_verify_alone() {
+        let cfg = ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        };
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Client), TlsLevel::Tls);
+    }
+
+    #[test]
+    /// UI-R-024 — a server TLS config loads into the cert and key fields.
+    fn ut_from_config_tls_server_is_cert_and_key() {
+        let cfg = ModbusTlsConfig {
+            cert_file: Some("s.crt".into()),
+            key_file: Some("s.key".into()),
+            ..Default::default()
+        };
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Server), TlsLevel::Tls);
+    }
+
+    #[test]
+    /// UI-R-024 — a server config with only self_signed set still loads at the TLS level.
+    fn ut_from_config_tls_server_is_self_signed_alone() {
+        let cfg = ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        };
+        assert_eq!(TlsLevel::from_config(&cfg, Role::Server), TlsLevel::Tls);
+    }
+
+    #[test]
+    /// UI-R-024 — a mutual-TLS client config loads into the client-cert fields.
+    fn ut_from_config_mutual_tls_client_is_client_cert() {
+        let cfg = ModbusTlsConfig {
+            client_cert_file: Some("c.crt".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            TlsLevel::from_config(&cfg, Role::Client),
+            TlsLevel::MutualTls
+        );
+    }
+
+    #[test]
+    /// UI-R-024 — a mutual-TLS server config loads into the require-flag/client-CA fields.
+    fn ut_from_config_mutual_tls_server_is_require_flag_or_client_ca() {
+        let by_flag = ModbusTlsConfig {
+            require_client_cert: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            TlsLevel::from_config(&by_flag, Role::Server),
+            TlsLevel::MutualTls
+        );
+        let by_ca = ModbusTlsConfig {
+            client_ca_file: Some("ca.pem".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            TlsLevel::from_config(&by_ca, Role::Server),
+            TlsLevel::MutualTls
+        );
+    }
+
+    // --- TlsLevel::build_config -----------------------------------------------------------------
+
+    #[test]
+    /// UI-R-024 — building the config drops every field when the level is Off.
+    fn ut_build_config_drops_fields_when_off() {
+        let cfg = TlsLevel::Off.build_config(
+            Role::Server,
+            TlsInputs {
+                ca_file: "ca",
+                cert_file: "cert",
+                key_file: "key",
+                client_cert_file: "ccert",
+                client_key_file: "ckey",
+                client_ca_file: "cca",
+            },
+        );
+        assert_eq!(cfg.cert_file, None);
+        assert_eq!(cfg.key_file, None);
+        assert_eq!(cfg.client_ca_file, None);
+        assert!(!cfg.require_client_cert);
+    }
+
+    #[test]
+    /// UI-R-024 — a server TLS build keeps cert/key and drops client fields.
+    fn ut_build_config_tls_server_keeps_cert_key_not_client_fields() {
+        let cfg = TlsLevel::Tls.build_config(
+            Role::Server,
+            TlsInputs {
+                ca_file: "ca",
+                cert_file: "cert",
+                key_file: "key",
+                client_cert_file: "ccert",
+                client_key_file: "ckey",
+                client_ca_file: "cca",
+            },
+        );
+        assert_eq!(cfg.cert_file.as_deref(), Some("cert"));
+        assert_eq!(cfg.key_file.as_deref(), Some("key"));
+        assert_eq!(cfg.ca_file, None); // client-only field
+        assert_eq!(cfg.client_ca_file, None);
+    }
+
+    #[test]
+    /// UI-R-024 — a mutual-TLS server build sets require-client-cert.
+    fn ut_build_config_mutual_tls_server_sets_require_client_cert() {
+        let cfg = TlsLevel::MutualTls.build_config(
+            Role::Server,
+            TlsInputs {
+                ca_file: "",
+                cert_file: "cert",
+                key_file: "key",
+                client_cert_file: "",
+                client_key_file: "",
+                client_ca_file: "cca",
+            },
+        );
+        assert_eq!(cfg.client_ca_file.as_deref(), Some("cca"));
+        assert!(cfg.require_client_cert);
+        assert_eq!(cfg.client_cert_file, None); // client-only field
+    }
+
+    #[test]
+    /// UI-R-024 — a mutual-TLS client build keeps the client cert/key.
+    fn ut_build_config_mutual_tls_client_keeps_client_cert_key() {
+        let cfg = TlsLevel::MutualTls.build_config(
+            Role::Client,
+            TlsInputs {
+                ca_file: "ca",
+                cert_file: "",
+                key_file: "",
+                client_cert_file: "ccert",
+                client_key_file: "ckey",
+                client_ca_file: "",
+            },
+        );
+        assert_eq!(cfg.ca_file.as_deref(), Some("ca"));
+        assert_eq!(cfg.client_cert_file.as_deref(), Some("ccert"));
+        assert_eq!(cfg.client_key_file.as_deref(), Some("ckey"));
+        assert_eq!(cfg.client_ca_file, None); // server-only field
+        assert!(!cfg.require_client_cert);
+    }
+
+    // --- validate_tls ----------------------------------------------------------------------------
+
+    #[test]
+    /// UI-R-024 — a server at TLS with self_signed set needs no cert/key files.
+    fn ut_validate_tls_server_self_signed_needs_no_files() {
+        let cfg = ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        };
+        assert!(validate_tls(&cfg, Role::Server, TlsLevel::Tls, &|_| false).is_ok());
+    }
+
+    #[test]
+    /// UI-R-024 — a server at TLS without self_signed requires an existing cert and key file.
+    fn ut_validate_tls_server_requires_cert_and_key_files() {
+        let missing = ModbusTlsConfig::default();
+        assert!(validate_tls(&missing, Role::Server, TlsLevel::Tls, &|_| false).is_err());
+
+        let cfg = ModbusTlsConfig {
+            cert_file: Some("s.crt".into()),
+            key_file: Some("s.key".into()),
+            ..Default::default()
+        };
+        assert!(validate_tls(&cfg, Role::Server, TlsLevel::Tls, &|_| true).is_ok());
+        assert!(validate_tls(&cfg, Role::Server, TlsLevel::Tls, &|_| false).is_err());
+    }
+
+    #[test]
+    /// UI-R-024 — a server at mTLS additionally requires an existing client CA file.
+    fn ut_validate_tls_server_mutual_tls_requires_client_ca_file() {
+        let cfg = ModbusTlsConfig {
+            self_signed: true,
+            client_ca_file: Some("ca.pem".into()),
+            ..Default::default()
+        };
+        assert!(validate_tls(&cfg, Role::Server, TlsLevel::MutualTls, &|_| true).is_ok());
+        assert!(validate_tls(&cfg, Role::Server, TlsLevel::MutualTls, &|_| false).is_err());
+
+        let no_ca = ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        };
+        assert!(validate_tls(&no_ca, Role::Server, TlsLevel::MutualTls, &|_| true).is_err());
+    }
+
+    #[test]
+    /// UI-R-024 — a client's CA file, when set, must exist; skip-verify alone needs no file.
+    fn ut_validate_tls_client_ca_file_must_exist_when_set() {
+        let cfg = ModbusTlsConfig {
+            ca_file: Some("ca.pem".into()),
+            ..Default::default()
+        };
+        assert!(validate_tls(&cfg, Role::Client, TlsLevel::Tls, &|_| true).is_ok());
+        assert!(validate_tls(&cfg, Role::Client, TlsLevel::Tls, &|_| false).is_err());
+
+        let skip_verify_only = ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        };
+        assert!(validate_tls(&skip_verify_only, Role::Client, TlsLevel::Tls, &|_| false).is_ok());
+    }
+
+    #[test]
+    /// UI-R-024 — a client at mTLS requires existing client cert and key files.
+    fn ut_validate_tls_client_mutual_tls_requires_client_cert_key_files() {
+        let missing = ModbusTlsConfig::default();
+        assert!(validate_tls(&missing, Role::Client, TlsLevel::MutualTls, &|_| false).is_err());
+
+        let cfg = ModbusTlsConfig {
+            client_cert_file: Some("c.crt".into()),
+            client_key_file: Some("c.key".into()),
+            ..Default::default()
+        };
+        assert!(validate_tls(&cfg, Role::Client, TlsLevel::MutualTls, &|_| true).is_ok());
+        assert!(validate_tls(&cfg, Role::Client, TlsLevel::MutualTls, &|_| false).is_err());
+    }
+}

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -654,6 +654,7 @@ impl ModuleView for ModbusModuleView {
                     &self.spec.endpoint,
                     timing,
                     &self.device.read_ranges,
+                    self.device.tls.as_ref(),
                 );
                 self.overlay = ModbusViewOverlay::Setup(Box::new(dialog));
                 Box::pin(std::future::ready(CommandResult::Handled(None)))
@@ -1618,6 +1619,7 @@ mod tests {
             interval_ms: None,
             reconnect: None,
             read_ranges: Default::default(),
+            tls: None,
         };
         view.apply_setup(values).await;
         assert_eq!(view.device.reconnect, Some(false));

--- a/ferrowl/src/module/modbus/view/mod.rs
+++ b/ferrowl/src/module/modbus/view/mod.rs
@@ -1047,6 +1047,7 @@ mod tests {
             delay_ms: None,
             interval_ms: None,
             reconnect: None,
+            tls: None,
             log_file: None,
             read_ranges: Default::default(),
             definitions: Default::default(),

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -234,6 +234,9 @@ impl ModbusModuleView {
             self.device.reconnect = Some(reconnect);
         }
         self.device.read_ranges = values.read_ranges.clone();
+        if let Some(tls) = values.tls.clone() {
+            self.device.tls = tls;
+        }
 
         let timing = ModbusModule::resolve_timing(&self.device);
         let role = self.spec.role.to_string();

--- a/ferrowl/src/module/modbus/view/mutate.rs
+++ b/ferrowl/src/module/modbus/view/mutate.rs
@@ -241,7 +241,13 @@ impl ModbusModuleView {
 
         if let Err(e) = self
             .module
-            .reconfigure(&values.endpoint, values.role, timing, values.read_ranges)
+            .reconfigure(
+                &values.endpoint,
+                values.role,
+                timing,
+                values.read_ranges,
+                self.device.tls.clone(),
+            )
             .await
         {
             self.module

--- a/ferrowl/src/module/ocpp/action_dialog.rs
+++ b/ferrowl/src/module/ocpp/action_dialog.rs
@@ -16,7 +16,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use ferrowl_lua::module::ValueType;
 use ferrowl_syntax::Language;
 use ferrowl_ui::{
-    COLOR_SCHEME, EventResult,
+    COLOR_SCHEME, EventResult, render_field, render_row,
     state::{
         ButtonState, CodeInputFieldState, CodeInputFieldStateBuilder, InputFieldState,
         SelectionState, SelectionStateBuilder, TableState,
@@ -533,33 +533,29 @@ impl ActionDialog {
             self.json
                 .state
                 .set_focused(self.focus == ActionDialogFocus::Json);
-            StatefulWidget::render(&self.json.widget, json_area, buf, &mut self.json.state);
+            render_field!(self, json, json_area, buf);
         } else {
             self.table
                 .state
                 .set_focused(self.focus == ActionDialogFocus::Table);
-            StatefulWidget::render(&self.table.widget, body, buf, &mut self.table.state);
+            render_field!(self, table, body, buf);
         }
 
         // Buttons: [Toggle] [Send] (Toggle hidden for JSON-only dialogs).
         let show_toggle = self.assemble.is_some();
         if show_toggle {
-            let [tb, sb] =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .areas(buttons);
             self.toggle
                 .state
                 .set_focused(self.focus == ActionDialogFocus::Toggle);
             self.send
                 .state
                 .set_focused(self.focus == ActionDialogFocus::Send);
-            StatefulWidget::render(&self.toggle.widget, tb, buf, &mut self.toggle.state);
-            StatefulWidget::render(&self.send.widget, sb, buf, &mut self.send.state);
+            render_row!(self, buttons, buf; toggle, send);
         } else {
             self.send
                 .state
                 .set_focused(self.focus == ActionDialogFocus::Send);
-            StatefulWidget::render(&self.send.widget, buttons, buf, &mut self.send.state);
+            render_field!(self, send, buttons, buf);
         }
 
         if let Some(editor) = self.editor.as_mut() {

--- a/ferrowl/src/module/ocpp/server/detail.rs
+++ b/ferrowl/src/module/ocpp/server/detail.rs
@@ -21,7 +21,7 @@ use crate::dialog::close_confirm::{CloseConfirmDialog, CloseConfirmOutcome, rout
 use crate::module::ocpp::server::backend::Scope;
 use crate::module::ocpp::widgets;
 use ferrowl_ui::{
-    COLOR_SCHEME,
+    COLOR_SCHEME, render_col, render_field,
     state::{InputFieldState, TableState},
     style::InputFieldStyle,
     traits::{HandleEvents, SetFocus},
@@ -138,7 +138,7 @@ pub struct DetailOverlay {
     cfg: CfgTable,
     /// CS-level "Configuration" table with a Component column (2.0.1), used when `component_col`.
     #[focus(when = self.is_cs && self.component_col)]
-    cfg4: CfgTableC,
+    cfg_component: CfgTableC,
     /// Whether the config table carries a Component column (2.0.1) vs a flat key (1.6).
     component_col: bool,
     #[focus(when = self.is_cs)]
@@ -172,7 +172,7 @@ impl DetailOverlay {
             state: kv_table("State"),
             side: kv_table("Metering"),
             cfg: cfg_table(),
-            cfg4: cfg4_table(),
+            cfg_component: cfg_component_table(),
             component_col,
             key_input: key_input(),
             config: Vec::new(),
@@ -267,7 +267,7 @@ impl DetailOverlay {
                     }
                 })
                 .collect();
-            self.cfg4.state.set_values(rows);
+            self.cfg_component.state.set_values(rows);
         } else {
             let rows: Vec<CfgRow> = self
                 .config
@@ -313,14 +313,14 @@ impl DetailOverlay {
         self.state.widget.set_row_margin(margin);
         self.side.widget.set_row_margin(margin);
         self.cfg.widget.set_row_margin(margin);
-        self.cfg4.widget.set_row_margin(margin);
+        self.cfg_component.widget.set_row_margin(margin);
         self.rfid.widget.set_row_margin(margin);
     }
 
     /// The selected row index of the active config table.
     fn config_selected(&self) -> Option<usize> {
         if self.component_col {
-            self.cfg4.state.table_state().selected()
+            self.cfg_component.state.table_state().selected()
         } else {
             self.cfg.state.table_state().selected()
         }
@@ -414,7 +414,7 @@ impl DetailOverlay {
             (KeyModifiers::NONE, KeyCode::Char('d'))
                 if matches!(
                     self.focus,
-                    DetailOverlayFocus::Cfg | DetailOverlayFocus::Cfg4
+                    DetailOverlayFocus::Cfg | DetailOverlayFocus::CfgComponent
                 ) =>
             {
                 self.delete_selected_config()
@@ -422,7 +422,7 @@ impl DetailOverlay {
             (KeyModifiers::NONE, KeyCode::Char('u'))
                 if matches!(
                     self.focus,
-                    DetailOverlayFocus::Cfg | DetailOverlayFocus::Cfg4
+                    DetailOverlayFocus::Cfg | DetailOverlayFocus::CfgComponent
                 ) =>
             {
                 if let Some(key) = self.selected_config_key() {
@@ -432,7 +432,7 @@ impl DetailOverlay {
             (KeyModifiers::NONE, KeyCode::Enter)
                 if matches!(
                     self.focus,
-                    DetailOverlayFocus::Cfg | DetailOverlayFocus::Cfg4
+                    DetailOverlayFocus::Cfg | DetailOverlayFocus::CfgComponent
                 ) =>
             {
                 if let Some(key) = self.selected_config_key() {
@@ -457,8 +457,8 @@ impl DetailOverlay {
             DetailOverlayFocus::State => {
                 let _ = self.state.state.handle_events(modifiers, code);
             }
-            DetailOverlayFocus::Cfg4 => {
-                let _ = self.cfg4.state.handle_events(modifiers, code);
+            DetailOverlayFocus::CfgComponent => {
+                let _ = self.cfg_component.state.handle_events(modifiers, code);
             }
             DetailOverlayFocus::Cfg => {
                 let _ = self.cfg.state.handle_events(modifiers, code);
@@ -518,9 +518,9 @@ impl DetailOverlay {
         self.cfg
             .state
             .set_focused(self.focus == DetailOverlayFocus::Cfg);
-        self.cfg4
+        self.cfg_component
             .state
-            .set_focused(self.focus == DetailOverlayFocus::Cfg4);
+            .set_focused(self.focus == DetailOverlayFocus::CfgComponent);
         self.rfid
             .state
             .set_focused(self.focus == DetailOverlayFocus::Rfid);
@@ -536,51 +536,26 @@ impl DetailOverlay {
             let [left, right] =
                 Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
                     .areas(mid);
-            let [config_area, fetch_area] =
-                Layout::vertical([Constraint::Min(1), Constraint::Length(3)]).areas(left);
-            let [rfid_area, rfid_input_area] =
-                Layout::vertical([Constraint::Min(1), Constraint::Length(3)]).areas(right);
             self.key_input
                 .state
                 .set_focused(self.focus == DetailOverlayFocus::KeyInput);
-            StatefulWidget::render(&self.state.widget, state_area, buf, &mut self.state.state);
+            render_field!(self, state, state_area, buf);
             if self.component_col {
-                StatefulWidget::render(&self.cfg4.widget, config_area, buf, &mut self.cfg4.state);
+                render_col!(self, left, buf; cfg_component => Constraint::Min(1), key_input => Constraint::Length(3));
             } else {
-                StatefulWidget::render(&self.cfg.widget, config_area, buf, &mut self.cfg.state);
+                render_col!(self, left, buf; cfg => Constraint::Min(1), key_input => Constraint::Length(3));
             }
-            StatefulWidget::render(
-                &self.key_input.widget,
-                fetch_area,
-                buf,
-                &mut self.key_input.state,
-            );
-            StatefulWidget::render(&self.rfid.widget, rfid_area, buf, &mut self.rfid.state);
-            StatefulWidget::render(
-                &self.rfid_input.widget,
-                rfid_input_area,
-                buf,
-                &mut self.rfid_input.state,
-            );
+            render_col!(self, right, buf; rfid => Constraint::Min(1), rfid_input => Constraint::Length(3));
         } else {
             // Connector: State above the RFID list (+ add input) on the left, Metering on the right.
             let [left, right] =
                 Layout::horizontal([Constraint::Percentage(50), Constraint::Min(1)]).areas(inner);
-            let [state_area, rfid_area, rfid_input_area] = Layout::vertical([
-                Constraint::Percentage(45),
-                Constraint::Min(1),
-                Constraint::Length(3),
-            ])
-            .areas(left);
-            StatefulWidget::render(&self.state.widget, state_area, buf, &mut self.state.state);
-            StatefulWidget::render(&self.rfid.widget, rfid_area, buf, &mut self.rfid.state);
-            StatefulWidget::render(
-                &self.rfid_input.widget,
-                rfid_input_area,
-                buf,
-                &mut self.rfid_input.state,
+            render_col!(self, left, buf;
+                state => Constraint::Percentage(45),
+                rfid => Constraint::Min(1),
+                rfid_input => Constraint::Length(3)
             );
-            StatefulWidget::render(&self.side.widget, right, buf, &mut self.side.state);
+            render_field!(self, side, right, buf);
         }
 
         if let Some((_key, field)) = self.set_dialog.as_mut() {
@@ -618,7 +593,7 @@ fn cfg_table() -> CfgTable {
     widgets::table("Configuration")
 }
 
-fn cfg4_table() -> CfgTableC {
+fn cfg_component_table() -> CfgTableC {
     widgets::table("Configuration")
 }
 
@@ -722,14 +697,14 @@ mod tests {
         d.merge_config("OCPPCommCtrlr/HeartbeatInterval".into(), "30".into(), true);
         // A key without a `/` keeps an empty component.
         d.merge_config("Bare".into(), "x".into(), false);
-        let rows = d.cfg4.state.values();
+        let rows = d.cfg_component.state.values();
         assert_eq!(rows[0].component, "OCPPCommCtrlr");
         assert_eq!(rows[0].key, "HeartbeatInterval");
         assert_eq!(rows[0].readonly, "yes");
         assert_eq!(rows[1].component, "");
         assert_eq!(rows[1].key, "Bare");
         // The selected key fed to fetch/set is the full combined `Component/Variable`.
-        d.focus = DetailOverlayFocus::Cfg4;
+        d.focus = DetailOverlayFocus::CfgComponent;
         let req = d.input(KeyModifiers::NONE, KeyCode::Char('u'));
         assert!(
             matches!(req, Some(DetailRequest::Fetch(k)) if k == "OCPPCommCtrlr/HeartbeatInterval")
@@ -795,10 +770,10 @@ mod tests {
     #[test]
     /// UI-R-022 — the CS detail focus cycle includes the component column.
     fn focus_cycle_cs_component_col() {
-        // CS with a Component column: State -> Cfg4 -> KeyInput -> Rfid -> RfidInput -> wrap.
+        // CS with a Component column: State -> CfgComponent -> KeyInput -> Rfid -> RfidInput -> wrap.
         let mut d = DetailOverlay::new("CP".into(), Scope::CS, true);
         for expected in [
-            DetailOverlayFocus::Cfg4,
+            DetailOverlayFocus::CfgComponent,
             DetailOverlayFocus::KeyInput,
             DetailOverlayFocus::Rfid,
             DetailOverlayFocus::RfidInput,
@@ -812,7 +787,7 @@ mod tests {
             DetailOverlayFocus::RfidInput,
             DetailOverlayFocus::Rfid,
             DetailOverlayFocus::KeyInput,
-            DetailOverlayFocus::Cfg4,
+            DetailOverlayFocus::CfgComponent,
             DetailOverlayFocus::State,
         ] {
             d.focus_previous();

--- a/ferrowl/src/module/ocpp/setup_dialog.rs
+++ b/ferrowl/src/module/ocpp/setup_dialog.rs
@@ -5,7 +5,7 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 use derive_builder::Builder;
 use ferrowl_ui::{
-    Border, COLOR_SCHEME, EventResult,
+    Border, COLOR_SCHEME, EventResult, render_field, render_row,
     state::{
         InputFieldState, InputFieldStateBuilder, SelectionState, SelectionStateBuilder,
         SuggestInputState, SuggestInputStateBuilder,
@@ -22,7 +22,7 @@ use ferrowl_util::convert::FileType;
 use ratatui::{
     buffer::Buffer,
     layout::{Constraint, HorizontalAlignment, Layout, Margin, Rect},
-    widgets::{Block, Clear, StatefulWidget, Widget as UiWidget},
+    widgets::{Block, Clear, Widget as UiWidget},
 };
 
 use crate::dialog::NonEmpty;
@@ -589,186 +589,68 @@ impl OcppSetupDialog {
         ])
         .split(inner);
 
-        StatefulWidget::render(&self.name.widget, rows[0], buf, &mut self.name.state);
-        StatefulWidget::render(
-            &self.config_path.widget,
-            rows[1],
-            buf,
-            &mut self.config_path.state,
-        );
-
-        let [vl, vr] = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-            .areas(rows[2]);
-        StatefulWidget::render(&self.version.widget, vl, buf, &mut self.version.state);
-        StatefulWidget::render(&self.role.widget, vr, buf, &mut self.role.state);
+        render_field!(self, name, rows[0], buf);
+        render_field!(self, config_path, rows[1], buf);
+        render_row!(self, rows[2], buf; version, role);
 
         if self.path_hidden() {
             // No URL path for the server role — let ip take the freed space.
-            let [proto, ip, port] = Layout::horizontal([
-                Constraint::Length(12),
-                Constraint::Min(1),
-                Constraint::Length(13),
-            ])
-            .areas(rows[3]);
-            StatefulWidget::render(&self.protocol.widget, proto, buf, &mut self.protocol.state);
-            StatefulWidget::render(&self.ip.widget, ip, buf, &mut self.ip.state);
-            StatefulWidget::render(&self.port.widget, port, buf, &mut self.port.state);
+            render_row!(self, rows[3], buf;
+                protocol => Constraint::Length(12),
+                ip => Constraint::Min(1),
+                port => Constraint::Length(13)
+            );
         } else {
-            let [proto, ip, port, path] = Layout::horizontal([
-                Constraint::Length(12),
-                Constraint::Min(1),
-                Constraint::Length(13),
-                Constraint::Length(24),
-            ])
-            .areas(rows[3]);
-            StatefulWidget::render(&self.protocol.widget, proto, buf, &mut self.protocol.state);
-            StatefulWidget::render(&self.ip.widget, ip, buf, &mut self.ip.state);
-            StatefulWidget::render(&self.port.widget, port, buf, &mut self.port.state);
-            StatefulWidget::render(&self.path.widget, path, buf, &mut self.path.state);
+            render_row!(self, rows[3], buf;
+                protocol => Constraint::Length(12),
+                ip => Constraint::Min(1),
+                port => Constraint::Length(13),
+                path => Constraint::Length(24)
+            );
         }
 
         let is_client = role == OcppRole::Client;
         if show_security_row {
             if show_credentials {
                 if is_client {
-                    let [sec, user, pass, skip] = Layout::horizontal([
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                        Constraint::Percentage(25),
-                    ])
-                    .areas(rows[4]);
-                    StatefulWidget::render(
-                        &self.security.widget,
-                        sec,
-                        buf,
-                        &mut self.security.state,
-                    );
-                    StatefulWidget::render(
-                        &self.username.widget,
-                        user,
-                        buf,
-                        &mut self.username.state,
-                    );
-                    StatefulWidget::render(
-                        &self.password.widget,
-                        pass,
-                        buf,
-                        &mut self.password.state,
-                    );
-                    StatefulWidget::render(
-                        &self.skip_verify.widget,
-                        skip,
-                        buf,
-                        &mut self.skip_verify.state,
-                    );
+                    render_row!(self, rows[4], buf; security, username, password, skip_verify);
                 } else {
-                    let [sec, user, pass] = Layout::horizontal([
-                        Constraint::Percentage(34),
-                        Constraint::Percentage(33),
-                        Constraint::Percentage(33),
-                    ])
-                    .areas(rows[4]);
-                    StatefulWidget::render(
-                        &self.security.widget,
-                        sec,
-                        buf,
-                        &mut self.security.state,
-                    );
-                    StatefulWidget::render(
-                        &self.username.widget,
-                        user,
-                        buf,
-                        &mut self.username.state,
-                    );
-                    StatefulWidget::render(
-                        &self.password.widget,
-                        pass,
-                        buf,
-                        &mut self.password.state,
-                    );
+                    render_row!(self, rows[4], buf; security, username, password);
                 }
             } else if is_client {
-                let [sec, skip] =
-                    Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                        .areas(rows[4]);
-                StatefulWidget::render(&self.security.widget, sec, buf, &mut self.security.state);
-                StatefulWidget::render(
-                    &self.skip_verify.widget,
-                    skip,
-                    buf,
-                    &mut self.skip_verify.state,
-                );
+                render_row!(self, rows[4], buf; security, skip_verify);
             } else {
                 // Server without credential fields: the selection is the row's only widget,
                 // so it takes the full width instead of leaving two thirds blank.
-                StatefulWidget::render(
-                    &self.security.widget,
-                    rows[4],
-                    buf,
-                    &mut self.security.state,
-                );
+                render_field!(self, security, rows[4], buf);
             }
         }
 
         if show_hint {
             self.hint.state = "Self-signed certificate is generated at each start (clients: skip-verify or pinned certs)".to_string();
-            StatefulWidget::render(&self.hint.widget, rows[5], buf, &mut self.hint.state);
+            render_field!(self, hint, rows[5], buf);
         }
 
         if show_cert_a {
             if show_server_cert {
-                let [left, right] =
-                    Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                        .areas(rows[6]);
-                StatefulWidget::render(
-                    &self.cert_file.widget,
-                    left,
-                    buf,
-                    &mut self.cert_file.state,
-                );
-                StatefulWidget::render(&self.key_file.widget, right, buf, &mut self.key_file.state);
+                render_row!(self, rows[6], buf; cert_file, key_file);
             } else {
-                StatefulWidget::render(&self.ca_file.widget, rows[6], buf, &mut self.ca_file.state);
+                render_field!(self, ca_file, rows[6], buf);
             }
         }
 
         if show_cert_b {
             if show_client_ca {
-                StatefulWidget::render(
-                    &self.client_ca_file.widget,
-                    rows[7],
-                    buf,
-                    &mut self.client_ca_file.state,
-                );
+                render_field!(self, client_ca_file, rows[7], buf);
             } else {
-                let [left, right] =
-                    Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                        .areas(rows[7]);
-                StatefulWidget::render(
-                    &self.client_cert_file.widget,
-                    left,
-                    buf,
-                    &mut self.client_cert_file.state,
-                );
-                StatefulWidget::render(
-                    &self.client_key_file.widget,
-                    right,
-                    buf,
-                    &mut self.client_key_file.state,
-                );
+                render_row!(self, rows[7], buf; client_cert_file, client_key_file);
             }
         }
 
         if has_error {
-            StatefulWidget::render(&self.error.widget, rows[8], buf, &mut self.error.state);
+            render_field!(self, error, rows[8], buf);
         }
-        StatefulWidget::render(
-            &self.keybinds.widget,
-            rows[9],
-            buf,
-            &mut self.keybinds.state,
-        );
+        render_field!(self, keybinds, rows[9], buf);
 
         // Must be called after every sibling widget above has been rendered, so a popup paints on
         // top rather than being overwritten (painter's-algorithm buffer model).


### PR DESCRIPTION
## Why

rust-modbus added TLS support. This extends Ferrowl's Modbus/TCP client and
server with optional TLS, including mutual TLS, mirroring the pattern
already used for OCPP's security config.

## Spec

Adds MB-R-104 through MB-R-112 (docs/specs/modbus/requirements.md):

- MB-R-104: `tls` config field on `tcp::Config`, `ModbusTlsConfig` shape
- MB-R-105: RTU carries no `tls` field
- MB-R-106/107: server certificate resolution, self-signed fallback
- MB-R-108: mTLS `require_client_cert` rules
- MB-R-109/110: client verification, `insecure_skip_verify`, client identity pairing
- MB-R-111: TLS handshake failures logged with distinct peer/error detail (SHA-256 fingerprint of the rejected certificate)
- MB-R-112: RTU excluded from TLS entirely

Also extends UI-R-024 coverage: the module setup dialog exposes the new TLS settings (level, self-signed, skip-verify, cert/key/CA file inputs) for TCP endpoints, mirroring OCPP's `setup_dialog/security.rs`.

## How

- `ferrowl-modbus`: `ModbusTlsConfig`, TLS-aware `Client::connect` and server `run()`, using rust-modbus's new `TlsListener`/`connect_tls`
- `ferrowl-modbus::server_core`: `on_tls_handshake_failed` logs the rejected-cert fingerprint via `ring::digest`
- `ferrowl`: `DeviceConfig.tls`, threaded through module build/reconfigure, and a new `setup_dialog/tls.rs` for the TUI
- `ferrowl-ui`: three new macros (`render_field!`, `render_row!`, `render_col!`) collapsing repetitive per-widget render boilerplate, applied to both the new Modbus TLS dialog code and pre-existing bloat in OCPP's setup dialog, detail overlay, and action dialog

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo check --workspace`: clean
- `cargo test --workspace`: 796+ tests pass; one pre-existing flaky test (`ws_loopback_v16::cs_does_not_reconnect`) reproduces identically on `main`, unrelated to this change
- `cargo llvm-cov --workspace --fail-under-lines 80`: 86.84% lines (floor 80%)
- Independent gate-3 review completed on the Modbus TLS implementation

Closes #158