### PR TITLE
Add RtuOverTcp transport support to Modbus

### DIFF
--- a/docs/specs/cli-headless/api-contract.md
+++ b/docs/specs/cli-headless/api-contract.md
@@ -98,9 +98,9 @@ without `=` is an error. Later duplicate keys overwrite earlier ones.
 | `device` | yes* | — | Path to the device-config file. |
 | `type` | — | — | **Alias for `device`**: used only if `device` is absent. |
 | `role` | — | `server` | `client` or `server`. Any other value is an error. |
-| `transport` | — | `tcp` | `tcp` or `rtu`. Any other value is an error. |
+| `transport` | — | `tcp` | `tcp`, `rtu`, or `rtu_over_tcp`. Any other value is an error. |
 | `ip` | — | `127.0.0.1` | TCP only: peer/bind IP. |
-| `port` | yes (tcp) | — | TCP only: port. Required for `transport=tcp`; must parse as a number. |
+| `port` | yes (tcp) | — | TCP only: port. Required for `transport=tcp` or `transport=rtu_over_tcp`; must parse as a number. |
 | `path` | yes (rtu) | — | RTU only: serial device path. Required for `transport=rtu`. |
 | `baud` / `baud_rate` | — | `19200` | RTU only: baud rate (`baud` and `baud_rate` are aliases). |
 | `parity` | — | unset | RTU only: parity string (passed through). |

--- a/docs/specs/cli-headless/edge-cases.md
+++ b/docs/specs/cli-headless/edge-cases.md
@@ -28,7 +28,7 @@ Lua/assertion semantics live in [`../scripting/`](../scripting/).
   `--ocpp` without `name`, `device`, or `port` → parse error.
 - **Non-numeric `port`/`data_bits`/`stop_bits`/`baud`** → parse error.
 - **Invalid enum value** — `role` other than `client`/`server`, `transport` other
-  than `tcp`/`rtu`, `protocol` other than `ws`/`wss` → parse error.
+  than `tcp`/`rtu`/`rtu_over_tcp`, `protocol` other than `ws`/`wss` → parse error.
 - In `ferrowl run`, any such descriptor error is a setup failure: the run exits
   **1** with an `Error:` diagnostic on stderr before the loop starts. In the TUI
   path it aborts startup with `Error:` on stderr and no TUI.

--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -68,8 +68,7 @@ No other exception code is ever produced by the server.
 
 ## 2. Transports
 
-Exactly two transports are supported: **TCP** and **RTU** (serial). There is no
-Modbus ASCII, no Modbus-over-UDP, and no RTU-over-TCP gateway mode.
+Exactly three transports are supported: **TCP**, **RTU** (serial), and **RtuOverTcp** (RTU framing over a TCP socket). There is no Modbus ASCII and no Modbus-over-UDP.
 
 ---
 
@@ -89,6 +88,9 @@ Fields of the TCP transport config, shared by the client and server roles.
 
 When these fields are absent from a serialized config, `reconnect` defaults to
 `true`; the remaining fields have no serde defaults and must be present.
+
+The `RtuOverTcp` transport (tag value `rtu_over_tcp`) uses this exact same
+field table — no additions or removals.
 
 ---
 
@@ -122,7 +124,7 @@ One Modbus module instance. This is the per-instance, on-the-wire endpoint; all
 | `name` | string | — (required) | tab / instance name |
 | `device` | string | — (required) | path to the device config file |
 | `role` | `client` \| `server` | `server` | |
-| `endpoint` | tagged union, tag `transport` | — (required) | `tcp` or `rtu` |
+| `endpoint` | tagged union, tag `transport` | — (required) | `tcp`, `rtu`, or `rtu_over_tcp` |
 
 ### `endpoint` with `transport = "tcp"`
 
@@ -146,6 +148,10 @@ Note the RTU baud default here (`19200`) differs from the transport-level defaul
 spec carries **no** `slave` field — a client addresses each request with the slave
 id of the register being polled or written.
 
+### endpoint with `transport = "rtu_over_tcp"`
+
+Takes the same fields as `transport = "tcp"` (§3), by reference.
+
 ### `--module` key/value form
 
 `--module name=…,device=…,transport=…,…` accepts the same keys, with:
@@ -155,7 +161,8 @@ id of the register being polled or written.
 - `transport` defaulting to `tcp`
 - `role` defaulting to `server`
 - `ip` defaulting to `127.0.0.1`
-- `port` **required** for `transport=tcp`; `path` **required** for `transport=rtu`
+- `port` **required** for `transport=tcp` and `transport=rtu_over_tcp`; `path`
+  **required** for `transport=rtu`
 
 ---
 

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -146,9 +146,9 @@ task; it does not retry the bind or the port open. Restarting it is the operator
 A TCP server spawns one task per accepted connection with no cap on the number of
 concurrent connections and no idle timeout.
 
-### 6.6 Only TCP and RTU
+### 6.6 Only three transports
 
-There is no Modbus ASCII, no Modbus-over-UDP, and no RTU-over-TCP gateway mode.
+There is no Modbus ASCII and no Modbus-over-UDP. `RtuOverTcp` reuses the TCP config verbatim (no new/removed fields); its only difference from plain TCP is wire framing.
 
 ### 6.7 Display resolution is one-way
 

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -213,22 +213,11 @@ behavior, stated limitations).
 
 ## Transport — RtuOverTcp
 
-**MB-R-113** — The Modbus transport config shall offer a third option, `RtuOverTcp`
-(config/CLI tag value `rtu_over_tcp`), carrying exactly the same connection
-parameters as the TCP option (`ip`, `port`, `timeout_ms`, `delay_ms`,
-`interval_ms`, `reconnect`, `tls`) and no RTU serial parameters
-(`baud_rate`, `parity`, `data_bits`, `stop_bits`).
+**MB-R-113** — The Modbus transport config shall offer a third option, `RtuOverTcp` (config/CLI tag value `rtu_over_tcp`), carrying exactly the same connection parameters as the TCP option (`ip`, `port`, `timeout_ms`, `delay_ms`, `interval_ms`, `reconnect`, `tls`) and no RTU serial parameters (`baud_rate`, `parity`, `data_bits`, `stop_bits`).
 
-**MB-R-114** — An `RtuOverTcp` connection shall be established exactly as a TCP connection
-(MB-R-068–MB-R-071 apply verbatim: `ip:port` connect/bind bounded by
-`timeout_ms`, address-parse failure, accept loop, bind failure), but
-requests and responses on it shall use RTU-style framing (unit id + CRC, no
-MBAP header) instead of Modbus TCP framing.
+**MB-R-114** — An `RtuOverTcp` connection shall be established exactly as a TCP connection (MB-R-068–MB-R-071 apply verbatim: `ip:port` connect/bind bounded by `timeout_ms`, address-parse failure, accept loop, bind failure), but requests and responses on it shall use RTU-style framing (unit id + CRC, no MBAP header) instead of Modbus TCP framing.
 
-**MB-R-115** — TLS (MB-R-104–MB-R-111) shall apply to an `RtuOverTcp` connection exactly as
-it does to a Modbus-TCP-framed one: the same `tls` field, certificate
-resolution, self-signed fallback, mTLS rules, and handshake-failure
-logging, with only the post-handshake framing differing.
+**MB-R-115** — TLS (MB-R-104–MB-R-111) shall apply to an `RtuOverTcp` connection exactly as it does to a Modbus-TCP-framed one: the same `tls` field, certificate resolution, self-signed fallback, mTLS rules, and handshake-failure logging, with only the post-handshake framing differing.
 
 ---
 

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -135,9 +135,9 @@ behavior, stated limitations).
 
 **MB-R-049** — Receiving the terminate command, or the command channel closing, shall disconnect the client, end its task with success, and emit a client- disconnected status.
 
-**MB-R-101** — On the RTU transport, a poll operation addressed to slave id 0 (the broadcast address) shall fail locally without reaching the wire. The client shall treat that failure as a Modbus exception per MB-R-043 — retried, then skipped after 3 consecutive occurrences — and shall not disconnect.
+**MB-R-101** — On the RTU or RtuOverTcp transport, a poll operation addressed to slave id 0 (the broadcast address) shall fail locally without reaching the wire. The client shall treat that failure as a Modbus exception per MB-R-043 — retried, then skipped after 3 consecutive occurrences — and shall not disconnect.
 
-**MB-R-102** — On the RTU transport, a write command addressed to slave id 0 shall be transmitted without awaiting a response, logged as executed, and shall not disconnect the client.
+**MB-R-102** — On the RTU or RtuOverTcp transport, a write command addressed to slave id 0 shall be transmitted without awaiting a response, logged as executed, and shall not disconnect the client.
 
 ---
 
@@ -179,11 +179,11 @@ behavior, stated limitations).
 
 **MB-R-065** — A server shall serve any slave id for which memory regions are declared; it shall not filter requests by a configured slave id.
 
-**MB-R-103** — An RTU server shall apply an inbound request addressed to slave id 0 (the broadcast address) to the store exactly as it would any other request, but shall emit no response frame for it — including no exception response.
+**MB-R-103** — An RTU or RtuOverTcp server shall apply an inbound request addressed to slave id 0 (the broadcast address) to the store exactly as it would any other request, but shall emit no response frame for it — including no exception response.
 
 **MB-R-066** — A server shall log a "request received" line for every inbound request, including for rejected function codes.
 
-**MB-R-067** — A TCP server shall additionally log the per-request outcome (success or failure). An RTU server shall not.
+**MB-R-067** — A server shall additionally log the per-request outcome (success or failure), for TCP, RTU, and RtuOverTcp alike.
 
 ---
 
@@ -211,9 +211,30 @@ behavior, stated limitations).
 
 ---
 
+## Transport — RtuOverTcp
+
+**MB-R-113** — The Modbus transport config shall offer a third option, `RtuOverTcp`
+(config/CLI tag value `rtu_over_tcp`), carrying exactly the same connection
+parameters as the TCP option (`ip`, `port`, `timeout_ms`, `delay_ms`,
+`interval_ms`, `reconnect`, `tls`) and no RTU serial parameters
+(`baud_rate`, `parity`, `data_bits`, `stop_bits`).
+
+**MB-R-114** — An `RtuOverTcp` connection shall be established exactly as a TCP connection
+(MB-R-068–MB-R-071 apply verbatim: `ip:port` connect/bind bounded by
+`timeout_ms`, address-parse failure, accept loop, bind failure), but
+requests and responses on it shall use RTU-style framing (unit id + CRC, no
+MBAP header) instead of Modbus TCP framing.
+
+**MB-R-115** — TLS (MB-R-104–MB-R-111) shall apply to an `RtuOverTcp` connection exactly as
+it does to a Modbus-TCP-framed one: the same `tls` field, certificate
+resolution, self-signed fallback, mTLS rules, and handshake-failure
+logging, with only the post-handshake framing differing.
+
+---
+
 ## Module lifecycle and device configuration
 
-**MB-R-076** — Each Modbus module instance shall be either a client or a server (never both), over either TCP or RTU, and shall own one shared register store, one register set, and one log.
+**MB-R-076** — Each Modbus module instance shall be either a client or a server (never both), over TCP, RTU, or RtuOverTcp, and shall own one shared register store, one register set, and one log.
 
 **MB-R-077** — A module's register store shall be built from its device config's register definitions: each fixed-address register shall declare the range `[address, address + format width)` under the key (slave id, kind).
 

--- a/ferrowl-modbus/src/lib.rs
+++ b/ferrowl-modbus/src/lib.rs
@@ -15,6 +15,7 @@ mod key;
 mod log;
 mod operation;
 pub mod rtu;
+pub mod rtu_over_tcp;
 mod run_config;
 mod scalar;
 mod server_core;

--- a/ferrowl-modbus/src/rtu/server.rs
+++ b/ferrowl-modbus/src/rtu/server.rs
@@ -37,8 +37,12 @@ impl<T: KeyParams> ServerBuilder<T> {
     }
 }
 
+/// Every production server now logs per-request outcomes (MB-R-067); RTU is no longer the
+/// quiet exception it used to be.
+const VERBOSE: bool = true;
+
 /// Open the configured serial port and spawn the RTU serve loop, answering from the shared `memory`
-/// via a [`Server`] (verbose logging off).
+/// via a [`Server`] (verbose logging on, MB-R-067).
 async fn run<T, L>(
     config: &Config,
     memory: Arc<MemLock<Memory<Key<T>>>>,
@@ -56,8 +60,7 @@ where
     )?;
     match open_serial::<Rtu>(&config.path, serial) {
         Ok(transport) => {
-            // RTU servers stay quiet on per-request outcomes (verbose = false).
-            let server = ModbusServer::new(Server::new(memory, log, false));
+            let server = ModbusServer::new(Server::new(memory, log, VERBOSE));
             // One port, one link, no accept loop (MB-R-074). The default `ServerConfig` filters
             // by no unit id, so every slave id with declared regions is served (MB-R-065).
             Ok(tokio::task::spawn(async move {
@@ -65,5 +68,17 @@ where
             }))
         }
         Err(e) => Err(SerialError::Error(e).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the RTU server logs per-request outcomes exactly like every
+    /// other transport now; there is no more quiet-RTU special case.
+    #[test]
+    fn ut_rtu_server_is_verbose() {
+        assert!(VERBOSE);
     }
 }

--- a/ferrowl-modbus/src/rtu_over_tcp/client.rs
+++ b/ferrowl-modbus/src/rtu_over_tcp/client.rs
@@ -1,0 +1,128 @@
+use crate::client_core::{ClientCore, ConnectAttempt};
+use crate::tcp::Config;
+use crate::tcp::tls::{ClientStream, build_client_tls_config};
+use crate::{Command, Error, Key, KeyParams, LogFn, Operation, TcpError};
+
+use ferrowl_store::Memory;
+use parking_lot::RwLock as MemLock;
+use rust_modbus::{
+    Client as ModbusClient, FrameTransport, TcpConfig, connect_tcp_framed, connect_tls_framed,
+};
+use tokio::task::JoinHandle;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc::Receiver;
+
+/// Builds and spawns a Modbus RTU-over-TCP client task that polls `operations` into
+/// the shared `memory` and executes incoming [`Command`]s.
+pub struct ClientBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    operations: Arc<RwLock<Vec<Operation>>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ClientBuilder<T> {
+    pub fn new(
+        config: Arc<RwLock<Config>>,
+        operations: Arc<RwLock<Vec<Operation>>>,
+        memory: Arc<MemLock<Memory<Key<T>>>>,
+    ) -> Self {
+        Self {
+            config,
+            operations,
+            memory,
+        }
+    }
+
+    /// Connects to the configured endpoint and spawns the client loop as a tokio task. `log`
+    /// receives log lines, `status` receives connection status updates, and `receiver` delivers
+    /// write/terminate [`Command`]s.
+    ///
+    /// With `config.reconnect` set (the default), a lost or refused connection does not end the
+    /// task: it logs, waits an exponential backoff (capped, reset after a run that got at least
+    /// one read through), and reconnects. `Command::Terminate` (or the channel closing) aborts a
+    /// backoff wait immediately. With `config.reconnect` unset, a transport error ends the task
+    /// exactly as before this behavior was added.
+    pub async fn spawn<L, S>(
+        &self,
+        receiver: Receiver<Command>,
+        log: L,
+        status: S,
+    ) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+        S: LogFn + Clone,
+    {
+        let config = self.config.clone();
+        let operations = self.operations.clone();
+        let memory = self.memory.clone();
+        Ok(tokio::task::spawn(async move {
+            ClientCore::run_reconnect_loop(receiver, log, status, operations, memory, move || {
+                let config = config.clone();
+                async move {
+                    let guard = config.read().await;
+                    let attempt = ConnectAttempt {
+                        reconnect: guard.reconnect,
+                        timeout_ms: guard.timeout_ms,
+                        delay_ms: guard.delay_ms,
+                        interval_ms: guard.interval_ms,
+                        client: Client::connect(&guard).await.map(|client| client.core),
+                    };
+                    drop(guard);
+                    attempt
+                }
+            })
+            .await
+        }))
+    }
+}
+
+/// A connected Modbus RTU-over-TCP client. Connection setup mirrors plain TCP (MB-R-113); the
+/// read/command loop is shared via the internal `ClientCore`, over a socket carrying RTU framing.
+pub struct Client {
+    pub(crate) core: ClientCore<ClientStream, rust_modbus::RtuOverTcp>,
+}
+
+impl Client {
+    /// Opens a TCP connection to `config.ip:config.port`, bounded by the
+    /// configured timeout. Plain TCP unless `config.tls` is set (MB-R-115), in which
+    /// case the same timeout bounds the TCP connect and the TLS handshake together.
+    pub async fn connect(config: &Config) -> Result<Self, Error> {
+        let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
+            .parse()
+            .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
+        let tls_config = config
+            .tls
+            .as_ref()
+            .map(build_client_tls_config)
+            .transpose()?;
+        let attempt = async {
+            match tls_config {
+                None => connect_tcp_framed::<rust_modbus::RtuOverTcp>(addr, TcpConfig::default())
+                    .await
+                    .map(|t| ClientStream::Plain(t.into_inner())),
+                Some(tls) => {
+                    connect_tls_framed::<rust_modbus::RtuOverTcp>(addr, TcpConfig::default(), tls)
+                        .await
+                        .map(|t| ClientStream::Tls(Box::new(t.into_inner())))
+                }
+            }
+        };
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(config.timeout_ms as u64),
+            attempt,
+        )
+        .await
+        {
+            Ok(Ok(stream)) => Ok(Self {
+                core: ClientCore {
+                    client: ModbusClient::<_, _>::new(FrameTransport::new(stream)),
+                },
+            }),
+            Ok(Err(e)) => Err(TcpError::Error(e).into()),
+            Err(e) => Err(TcpError::Timeout(e).into()),
+        }
+    }
+}

--- a/ferrowl-modbus/src/rtu_over_tcp/mod.rs
+++ b/ferrowl-modbus/src/rtu_over_tcp/mod.rs
@@ -1,0 +1,9 @@
+//! Modbus RTU-over-TCP: RTU framing carried over a TCP socket (MB-R-113..MB-R-115).
+//! Reuses `tcp::Config` verbatim — same connect/bind/TLS behavior as plain TCP,
+//! differing only in on-wire framing (RTU ADU: unit id + CRC, no MBAP header).
+
+mod client;
+mod server;
+
+pub use client::{Client, ClientBuilder};
+pub use server::ServerBuilder;

--- a/ferrowl-modbus/src/rtu_over_tcp/server.rs
+++ b/ferrowl-modbus/src/rtu_over_tcp/server.rs
@@ -38,6 +38,10 @@ impl<T: KeyParams> ServerBuilder<T> {
     }
 }
 
+/// Every production server now logs per-request outcomes (MB-R-067); RtuOverTcp is no
+/// exception.
+const VERBOSE: bool = true;
+
 /// Bind the configured TCP address and spawn the accept loop; each accepted connection answers
 /// from the shared `memory` via a [`Server`] using RTU framing (MB-R-113), verbose logging on
 /// (MB-R-067). Plain TCP unless `config.tls` is set (MB-R-115), in which case the listener
@@ -56,7 +60,7 @@ where
         .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
     // One service instance answers every accepted connection, so all of them share the
     // one store (MB-R-070). Every server logs per-request outcomes (verbose = true, MB-R-067).
-    let server = ModbusServer::new(Server::new(memory, log.clone(), true));
+    let server = ModbusServer::new(Server::new(memory, log.clone(), VERBOSE));
     match &config.tls {
         None => match TcpListener::bind(addr).await {
             Ok(listener) => Ok(tokio::task::spawn(async move {
@@ -88,5 +92,17 @@ where
                 Err(e) => Err(Error::Server(e)),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the RtuOverTcp server logs per-request outcomes exactly like every other
+    /// transport (RTU, RTU-over-TCP, TCP alike now).
+    #[test]
+    fn ut_rtu_over_tcp_server_is_verbose() {
+        assert!(VERBOSE);
     }
 }

--- a/ferrowl-modbus/src/rtu_over_tcp/server.rs
+++ b/ferrowl-modbus/src/rtu_over_tcp/server.rs
@@ -1,0 +1,92 @@
+// Crate
+use crate::server_core::Server;
+use crate::tcp::Config;
+use crate::tcp::tls::build_server_tls_config;
+use crate::{Error, Key, KeyParams, LogFn, TcpError};
+
+// Workspace
+use ferrowl_store::Memory;
+
+// External
+use parking_lot::RwLock as MemLock;
+use rust_modbus::{Server as ModbusServer, TcpListener, TlsListener};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+/// Builds and spawns a Modbus RTU-over-TCP server task answering requests from the
+/// shared `memory`.
+pub struct ServerBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ServerBuilder<T> {
+    pub fn new(config: Arc<RwLock<Config>>, memory: Arc<MemLock<Memory<Key<T>>>>) -> Self {
+        Self { config, memory }
+    }
+
+    /// Binds the configured listen address and spawns the accept loop as a
+    /// tokio task. `log` receives log lines.
+    pub async fn spawn<L>(&self, log: L) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+    {
+        let guard = self.config.read().await;
+        run(&guard, self.memory.clone(), log).await
+    }
+}
+
+/// Bind the configured TCP address and spawn the accept loop; each accepted connection answers
+/// from the shared `memory` via a [`Server`] using RTU framing (MB-R-113), verbose logging on
+/// (MB-R-067). Plain TCP unless `config.tls` is set (MB-R-115), in which case the listener
+/// terminates TLS on each accepted connection.
+async fn run<T, L>(
+    config: &Config,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+    log: L,
+) -> Result<JoinHandle<Result<(), Error>>, Error>
+where
+    T: KeyParams,
+    L: LogFn + Clone,
+{
+    let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
+        .parse()
+        .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
+    // One service instance answers every accepted connection, so all of them share the
+    // one store (MB-R-070). Every server logs per-request outcomes (verbose = true, MB-R-067).
+    let server = ModbusServer::new(Server::new(memory, log.clone(), true));
+    match &config.tls {
+        None => match TcpListener::bind(addr).await {
+            Ok(listener) => Ok(tokio::task::spawn(async move {
+                server
+                    .serve_framed::<rust_modbus::RtuOverTcp>(listener)
+                    .await
+                    .map_err(Error::Server)
+            })),
+            Err(e) => Err(Error::Server(e)),
+        },
+        Some(tls) => {
+            let (tls_config, used_fallback) =
+                build_server_tls_config(tls, &config.ip).map_err(Error::Tcp)?;
+            if used_fallback {
+                log.invoke(
+                    "No cert_file/key_file/self_signed configured for this TLS \
+                     server; falling back to an ephemeral self-signed certificate."
+                        .to_string(),
+                )
+                .await;
+            }
+            match TlsListener::bind(addr, tls_config).await {
+                Ok(listener) => Ok(tokio::task::spawn(async move {
+                    server
+                        .serve_tls::<rust_modbus::RtuOverTcp>(listener)
+                        .await
+                        .map_err(Error::Server)
+                })),
+                Err(e) => Err(Error::Server(e)),
+            }
+        }
+    }
+}

--- a/ferrowl-modbus/src/server_core.rs
+++ b/ferrowl-modbus/src/server_core.rs
@@ -184,10 +184,12 @@ where
     }
 }
 
-/// Handle one inbound Modbus server request against `memory`, shared by the TCP and RTU servers.
+/// Handle one inbound Modbus server request against `memory`, shared by every server transport
+/// (TCP, RTU, RTU-over-TCP).
 ///
-/// Every arm logs a "request received" line. When `verbose` is set (TCP), each arm additionally
-/// logs per-request success/failure; RTU passes `verbose = false` and stays quiet on the outcome.
+/// Every arm logs a "request received" line. When `verbose` is set, each arm additionally logs
+/// per-request success/failure; every production caller now passes `verbose = true` (MB-R-067) —
+/// `verbose = false` remains reachable only for tests exercising the quiet path.
 pub(crate) async fn handle_request<T, L>(
     slave: UnitId,
     request: RequestPdu,
@@ -445,10 +447,11 @@ where
     }
 }
 
-/// Per-connection Modbus server service shared by the TCP and RTU servers: every request is
-/// answered directly from the shared `memory` via [`handle_request`]. `verbose` toggles the
-/// per-request success/failure logging — TCP sets it, RTU leaves it off. (The transport-specific
-/// bind/accept vs serial-open setup stays in `tcp::server`/`rtu::server`.)
+/// Per-connection Modbus server service shared by every server transport (TCP, RTU,
+/// RTU-over-TCP): every request is answered directly from the shared `memory` via
+/// [`handle_request`]. `verbose` toggles the per-request success/failure logging — every
+/// production caller sets it (MB-R-067). (The transport-specific bind/accept vs serial-open
+/// setup stays in `tcp::server`/`rtu::server`/`rtu_over_tcp::server`.)
 pub(crate) struct Server<T, L>
 where
     T: KeyParams,
@@ -491,9 +494,9 @@ where
         handle_request(unit, request, &self.memory, &self.log, self.verbose).await
     }
 
-    // A framing or I/O failure on the wire never reaches `on_request`. TCP reports it (the
-    // former `on_process_error` callback); RTU stays quiet on per-request outcomes, and
-    // `verbose` is exactly that distinction (MB-R-067).
+    // A framing or I/O failure on the wire never reaches `on_request`; this reports it (the
+    // former `on_process_error` callback) whenever `verbose` is set — every production caller
+    // now sets it (MB-R-067).
     async fn on_error(&self, _conn: &Connection, error: &rust_modbus::Error) {
         if self.verbose {
             self.log
@@ -808,7 +811,9 @@ mod tests {
     }
 
     #[tokio::test]
-    /// MB-R-067 — a TCP (verbose) server logs the per-request outcome; without verbose only the "received" line.
+    /// `verbose` gates outcome logging directly: on, the per-request success/failure is logged
+    /// alongside the "received" line; off, only "received" is logged. Every production caller
+    /// now passes `verbose = true` (MB-R-067) — this exercises both branches of the mechanism.
     async fn ut_handle_verbose_logs_outcome_quiet_when_off() {
         let mem = seeded_memory(&[1, 2]);
 

--- a/ferrowl-modbus/src/tcp/client.rs
+++ b/ferrowl-modbus/src/tcp/client.rs
@@ -1,22 +1,15 @@
 use crate::client_core::{ClientCore, ConnectAttempt};
 use crate::tcp::Config;
-use crate::tcp::tls::{map_tls_err, read_pem};
+use crate::tcp::tls::{ClientStream, build_client_tls_config};
 use crate::{Command, Error, Key, KeyParams, LogFn, Operation, TcpError};
 
 use ferrowl_store::Memory;
 use parking_lot::RwLock as MemLock;
-use rust_modbus::{
-    Client as ModbusClient, ClientIdentity, FrameTransport, RootStore, ServerCertVerification,
-    TcpConfig, TlsClientConfig, connect_tcp, connect_tls, load_pem_cert_chain,
-    load_pem_private_key,
-};
+use rust_modbus::{Client as ModbusClient, FrameTransport, TcpConfig, connect_tcp, connect_tls};
 use tokio::task::JoinHandle;
 
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Receiver;
 
@@ -84,78 +77,6 @@ impl<T: KeyParams> ClientBuilder<T> {
     }
 }
 
-/// A client-side socket that is either plain TCP or TLS-terminated TCP (MB-R-104).
-pub(crate) enum ClientStream {
-    Plain(tokio::net::TcpStream),
-    Tls(Box<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>),
-}
-
-impl AsyncRead for ClientStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            ClientStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
-            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
-        }
-    }
-}
-
-impl AsyncWrite for ClientStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        match self.get_mut() {
-            ClientStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
-            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
-        }
-    }
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            ClientStream::Plain(s) => Pin::new(s).poll_flush(cx),
-            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
-        }
-    }
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            ClientStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
-            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
-        }
-    }
-}
-
-/// Build the `rust_modbus` client TLS config from ours: native roots plus `ca_file`
-/// if set, unless `insecure_skip_verify` is set (in which case `ca_file` is ignored
-/// and no server certificate is checked at all) — MB-R-109. A client identity is
-/// presented only when both `client_cert_file` and `client_key_file` are set;
-/// either alone presents nothing — MB-R-110.
-fn build_client_tls_config(cfg: &crate::tcp::ModbusTlsConfig) -> Result<TlsClientConfig, TcpError> {
-    let server_cert = if cfg.insecure_skip_verify {
-        ServerCertVerification::DangerousDisableVerification
-    } else {
-        let mut roots = RootStore::native();
-        if let Some(path) = &cfg.ca_file {
-            roots.add_pem(&read_pem(path)?).map_err(map_tls_err)?;
-        }
-        ServerCertVerification::Verify(roots)
-    };
-    let client_identity = match (&cfg.client_cert_file, &cfg.client_key_file) {
-        (Some(cert), Some(key)) => Some(ClientIdentity {
-            cert_chain: load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?,
-            key: load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?,
-        }),
-        _ => None,
-    };
-    Ok(TlsClientConfig {
-        server_cert,
-        client_identity,
-    })
-}
-
 /// A connected Modbus TCP client. Connection setup is TCP-specific; the read/command loop is
 /// shared via the internal `ClientCore`, over a socket carrying Modbus TCP framing.
 pub struct Client {
@@ -199,84 +120,5 @@ impl Client {
             Ok(Err(e)) => Err(TcpError::Error(e).into()),
             Err(e) => Err(TcpError::Timeout(e).into()),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::build_client_tls_config;
-    use crate::tcp::ModbusTlsConfig;
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    fn write_pem(label: &str, pem: &str) -> String {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
-        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "ferrowl-modbus-client-tls-ut-{}-{label}-{n}.pem",
-            std::process::id()
-        ));
-        std::fs::write(&path, pem).expect("write test pem");
-        path.to_string_lossy().into_owned()
-    }
-
-    fn cert_and_key_pem() -> (String, String) {
-        let key = rcgen::KeyPair::generate().expect("keypair generation failed");
-        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
-            .expect("cert params")
-            .self_signed(&key)
-            .expect("self-signed cert");
-        (cert.pem(), key.serialize_pem())
-    }
-
-    /// MB-R-110 — a client identity is presented only when both `client_cert_file` and
-    /// `client_key_file` are set.
-    #[test]
-    fn ut_build_client_tls_config_identity_only_when_both_files_set() {
-        let (cert_pem, key_pem) = cert_and_key_pem();
-        let cert_file = write_pem("cert", &cert_pem);
-        let key_file = write_pem("key", &key_pem);
-
-        let both = build_client_tls_config(&ModbusTlsConfig {
-            client_cert_file: Some(cert_file.clone()),
-            client_key_file: Some(key_file.clone()),
-            ..Default::default()
-        })
-        .expect("builds");
-        assert!(both.client_identity.is_some());
-
-        let cert_only = build_client_tls_config(&ModbusTlsConfig {
-            client_cert_file: Some(cert_file),
-            ..Default::default()
-        })
-        .expect("builds");
-        assert!(cert_only.client_identity.is_none());
-
-        let key_only = build_client_tls_config(&ModbusTlsConfig {
-            client_key_file: Some(key_file),
-            ..Default::default()
-        })
-        .expect("builds");
-        assert!(key_only.client_identity.is_none());
-
-        let neither = build_client_tls_config(&ModbusTlsConfig::default()).expect("builds");
-        assert!(neither.client_identity.is_none());
-    }
-
-    /// MB-R-109 — `insecure_skip_verify` disables server certificate verification and
-    /// ignores `ca_file`, rather than combining the two.
-    #[test]
-    fn ut_build_client_tls_config_insecure_skip_verify_ignores_ca_file() {
-        use rust_modbus::ServerCertVerification;
-
-        let cfg = ModbusTlsConfig {
-            ca_file: Some("/no/such/ca.pem".to_string()),
-            insecure_skip_verify: true,
-            ..Default::default()
-        };
-        let built = build_client_tls_config(&cfg).expect("builds despite unreadable ca_file");
-        assert!(matches!(
-            built.server_cert,
-            ServerCertVerification::DangerousDisableVerification
-        ));
     }
 }

--- a/ferrowl-modbus/src/tcp/mod.rs
+++ b/ferrowl-modbus/src/tcp/mod.rs
@@ -2,7 +2,7 @@
 
 mod client;
 mod server;
-mod tls;
+pub(crate) mod tls;
 
 use clap::Args;
 use serde::{Deserialize, Serialize};

--- a/ferrowl-modbus/src/tcp/server.rs
+++ b/ferrowl-modbus/src/tcp/server.rs
@@ -1,7 +1,7 @@
 // Crate
 use crate::server_core::Server;
 use crate::tcp::Config;
-use crate::tcp::tls::{map_tls_err, read_pem};
+use crate::tcp::tls::build_server_tls_config;
 use crate::{Error, Key, KeyParams, LogFn, TcpError};
 
 // Workspace
@@ -9,10 +9,7 @@ use ferrowl_store::Memory;
 
 // External
 use parking_lot::RwLock as MemLock;
-use rust_modbus::{
-    ClientCertPolicy, RootStore, Server as ModbusServer, TcpListener, TlsListener, TlsServerConfig,
-};
-use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use rust_modbus::{Server as ModbusServer, TcpListener, TlsListener};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -39,96 +36,6 @@ impl<T: KeyParams> ServerBuilder<T> {
         let guard = self.config.read().await;
         run(&guard, self.memory.clone(), log).await
     }
-}
-
-/// Resolve the server's presented certificate per MB-R-106/107, and whether an
-/// ephemeral self-signed certificate was used *without* being explicitly
-/// requested (the caller logs that case). Explicit `cert_file`/`key_file` always
-/// win over `self_signed` when both are set (edge-cases.md "TLS boundaries").
-fn resolve_server_identity(
-    cfg: &crate::tcp::ModbusTlsConfig,
-    bind_host: &str,
-) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>, bool), TcpError> {
-    match (&cfg.cert_file, &cfg.key_file) {
-        (Some(cert), Some(key)) => {
-            let chain = rust_modbus::load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?;
-            // A PEM document with no certificate blocks at all (garbage input) parses
-            // successfully to an empty chain rather than erroring; catch that here so it
-            // fails at the same TLS-configuration-error tier as every other malformed-PEM
-            // case (edge-cases.md "TLS boundaries"), rather than surfacing later, at TLS
-            // listener bind time, as a bare `Error::Server(Error::TlsHandshake)`.
-            if chain.is_empty() {
-                return Err(TcpError::Configuration(format!(
-                    "{cert} contains no certificate"
-                )));
-            }
-            let k = rust_modbus::load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?;
-            Ok((chain, k, false))
-        }
-        (None, None) => {
-            let (chain, k) = generate_self_signed(bind_host)?;
-            Ok((chain, k, !cfg.self_signed))
-        }
-        _ => Err(TcpError::Configuration(
-            "cert_file and key_file must both be set, or neither (MB-R-107)".into(),
-        )),
-    }
-}
-
-/// An ephemeral self-signed certificate/key pair, generated fresh in memory and
-/// never written to disk (MB-R-106 fallback). `host` and `"localhost"` (when
-/// different) are carried as SAN entries, mirroring
-/// `ferrowl-ocpp/src/security.rs::generate_self_signed`.
-fn generate_self_signed(
-    host: &str,
-) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), TcpError> {
-    let mut names = vec![host.to_string()];
-    if host != "localhost" {
-        names.push("localhost".to_string());
-    }
-    let mut params = rcgen::CertificateParams::new(names)
-        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
-    params
-        .distinguished_name
-        .push(rcgen::DnType::CommonName, "ferrowl Modbus");
-    let key_pair = rcgen::KeyPair::generate()
-        .map_err(|e| TcpError::Configuration(format!("self-signed key generation failed: {e}")))?;
-    let cert = params
-        .self_signed(&key_pair)
-        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
-    let cert_der = cert.der().clone();
-    let key_der = PrivateKeyDer::try_from(key_pair.serialize_der())
-        .map_err(|e| TcpError::Configuration(format!("self-signed key encoding failed: {e}")))?;
-    Ok((vec![cert_der], key_der))
-}
-
-/// Build the full `rust_modbus` server TLS config, and whether the self-signed
-/// fallback was used without being requested (the caller logs that case).
-fn build_server_tls_config(
-    cfg: &crate::tcp::ModbusTlsConfig,
-    bind_host: &str,
-) -> Result<(TlsServerConfig, bool), TcpError> {
-    let (cert_chain, key, used_fallback) = resolve_server_identity(cfg, bind_host)?;
-    let client_certs = if cfg.require_client_cert {
-        let ca = cfg.client_ca_file.as_ref().ok_or_else(|| {
-            TcpError::Configuration(
-                "require_client_cert is set but no client_ca_file was configured (MB-R-108)".into(),
-            )
-        })?;
-        let mut roots = RootStore::empty();
-        roots.add_pem(&read_pem(ca)?).map_err(map_tls_err)?;
-        ClientCertPolicy::Require(roots)
-    } else {
-        ClientCertPolicy::None
-    };
-    Ok((
-        TlsServerConfig {
-            cert_chain,
-            key,
-            client_certs,
-        },
-        used_fallback,
-    ))
 }
 
 /// Bind the configured TCP address and spawn the accept loop; each accepted connection answers from

--- a/ferrowl-modbus/src/tcp/tls.rs
+++ b/ferrowl-modbus/src/tcp/tls.rs
@@ -1,6 +1,17 @@
-//! Modbus/TCP TLS configuration (MB-R-104 .. MB-R-112).
+//! Modbus/TCP TLS configuration (MB-R-104 .. MB-R-112), plus the client/server TLS glue
+//! shared by every TCP-framed transport (`tcp`, and — MB-R-115 — `rtu_over_tcp`).
 
 use serde::{Deserialize, Serialize};
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use rust_modbus::{
+    ClientCertPolicy, ClientIdentity, RootStore, ServerCertVerification, TlsClientConfig,
+    TlsServerConfig, load_pem_cert_chain, load_pem_private_key,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::TcpError;
 
@@ -39,9 +50,248 @@ pub(crate) fn map_tls_err(e: rust_modbus::Error) -> TcpError {
     TcpError::Configuration(e.to_string())
 }
 
+/// A client-side socket that is either plain TCP or TLS-terminated TCP (MB-R-104),
+/// shared by every TCP-framed client (`tcp`, and — MB-R-115 — `rtu_over_tcp`).
+pub(crate) enum ClientStream {
+    Plain(tokio::net::TcpStream),
+    Tls(Box<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>),
+}
+
+impl AsyncRead for ClientStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ClientStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        }
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_flush(cx),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        }
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ClientStream::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            ClientStream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
+/// Build the `rust_modbus` client TLS config from ours: native roots plus `ca_file`
+/// if set, unless `insecure_skip_verify` is set (in which case `ca_file` is ignored
+/// and no server certificate is checked at all) — MB-R-109. A client identity is
+/// presented only when both `client_cert_file` and `client_key_file` are set;
+/// either alone presents nothing — MB-R-110.
+pub(crate) fn build_client_tls_config(cfg: &ModbusTlsConfig) -> Result<TlsClientConfig, TcpError> {
+    let server_cert = if cfg.insecure_skip_verify {
+        ServerCertVerification::DangerousDisableVerification
+    } else {
+        let mut roots = RootStore::native();
+        if let Some(path) = &cfg.ca_file {
+            roots.add_pem(&read_pem(path)?).map_err(map_tls_err)?;
+        }
+        ServerCertVerification::Verify(roots)
+    };
+    let client_identity = match (&cfg.client_cert_file, &cfg.client_key_file) {
+        (Some(cert), Some(key)) => Some(ClientIdentity {
+            cert_chain: load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?,
+            key: load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?,
+        }),
+        _ => None,
+    };
+    Ok(TlsClientConfig {
+        server_cert,
+        client_identity,
+    })
+}
+
+/// Resolve the server's presented certificate per MB-R-106/107, and whether an
+/// ephemeral self-signed certificate was used *without* being explicitly
+/// requested (the caller logs that case). Explicit `cert_file`/`key_file` always
+/// win over `self_signed` when both are set (edge-cases.md "TLS boundaries").
+pub(crate) fn resolve_server_identity(
+    cfg: &ModbusTlsConfig,
+    bind_host: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>, bool), TcpError> {
+    match (&cfg.cert_file, &cfg.key_file) {
+        (Some(cert), Some(key)) => {
+            let chain = rust_modbus::load_pem_cert_chain(&read_pem(cert)?).map_err(map_tls_err)?;
+            // A PEM document with no certificate blocks at all (garbage input) parses
+            // successfully to an empty chain rather than erroring; catch that here so it
+            // fails at the same TLS-configuration-error tier as every other malformed-PEM
+            // case (edge-cases.md "TLS boundaries"), rather than surfacing later, at TLS
+            // listener bind time, as a bare `Error::Server(Error::TlsHandshake)`.
+            if chain.is_empty() {
+                return Err(TcpError::Configuration(format!(
+                    "{cert} contains no certificate"
+                )));
+            }
+            let k = rust_modbus::load_pem_private_key(&read_pem(key)?).map_err(map_tls_err)?;
+            Ok((chain, k, false))
+        }
+        (None, None) => {
+            let (chain, k) = generate_self_signed(bind_host)?;
+            Ok((chain, k, !cfg.self_signed))
+        }
+        _ => Err(TcpError::Configuration(
+            "cert_file and key_file must both be set, or neither (MB-R-107)".into(),
+        )),
+    }
+}
+
+/// An ephemeral self-signed certificate/key pair, generated fresh in memory and
+/// never written to disk (MB-R-106 fallback). `host` and `"localhost"` (when
+/// different) are carried as SAN entries, mirroring
+/// `ferrowl-ocpp/src/security.rs::generate_self_signed`.
+fn generate_self_signed(
+    host: &str,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), TcpError> {
+    let mut names = vec![host.to_string()];
+    if host != "localhost" {
+        names.push("localhost".to_string());
+    }
+    let mut params = rcgen::CertificateParams::new(names)
+        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "ferrowl Modbus");
+    let key_pair = rcgen::KeyPair::generate()
+        .map_err(|e| TcpError::Configuration(format!("self-signed key generation failed: {e}")))?;
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(|e| TcpError::Configuration(format!("self-signed cert generation failed: {e}")))?;
+    let cert_der = cert.der().clone();
+    let key_der = PrivateKeyDer::try_from(key_pair.serialize_der())
+        .map_err(|e| TcpError::Configuration(format!("self-signed key encoding failed: {e}")))?;
+    Ok((vec![cert_der], key_der))
+}
+
+/// Build the full `rust_modbus` server TLS config, and whether the self-signed
+/// fallback was used without being requested (the caller logs that case).
+pub(crate) fn build_server_tls_config(
+    cfg: &ModbusTlsConfig,
+    bind_host: &str,
+) -> Result<(TlsServerConfig, bool), TcpError> {
+    let (cert_chain, key, used_fallback) = resolve_server_identity(cfg, bind_host)?;
+    let client_certs = if cfg.require_client_cert {
+        let ca = cfg.client_ca_file.as_ref().ok_or_else(|| {
+            TcpError::Configuration(
+                "require_client_cert is set but no client_ca_file was configured (MB-R-108)".into(),
+            )
+        })?;
+        let mut roots = RootStore::empty();
+        roots.add_pem(&read_pem(ca)?).map_err(map_tls_err)?;
+        ClientCertPolicy::Require(roots)
+    } else {
+        ClientCertPolicy::None
+    };
+    Ok((
+        TlsServerConfig {
+            cert_chain,
+            key,
+            client_certs,
+        },
+        used_fallback,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::ModbusTlsConfig;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn write_pem(label: &str, pem: &str) -> String {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "ferrowl-modbus-client-tls-ut-{}-{label}-{n}.pem",
+            std::process::id()
+        ));
+        std::fs::write(&path, pem).expect("write test pem");
+        path.to_string_lossy().into_owned()
+    }
+
+    fn cert_and_key_pem() -> (String, String) {
+        let key = rcgen::KeyPair::generate().expect("keypair generation failed");
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .expect("cert params")
+            .self_signed(&key)
+            .expect("self-signed cert");
+        (cert.pem(), key.serialize_pem())
+    }
+
+    /// MB-R-110 — a client identity is presented only when both `client_cert_file` and
+    /// `client_key_file` are set.
+    #[test]
+    fn ut_build_client_tls_config_identity_only_when_both_files_set() {
+        use super::build_client_tls_config;
+
+        let (cert_pem, key_pem) = cert_and_key_pem();
+        let cert_file = write_pem("cert", &cert_pem);
+        let key_file = write_pem("key", &key_pem);
+
+        let both = build_client_tls_config(&ModbusTlsConfig {
+            client_cert_file: Some(cert_file.clone()),
+            client_key_file: Some(key_file.clone()),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(both.client_identity.is_some());
+
+        let cert_only = build_client_tls_config(&ModbusTlsConfig {
+            client_cert_file: Some(cert_file),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(cert_only.client_identity.is_none());
+
+        let key_only = build_client_tls_config(&ModbusTlsConfig {
+            client_key_file: Some(key_file),
+            ..Default::default()
+        })
+        .expect("builds");
+        assert!(key_only.client_identity.is_none());
+
+        let neither = build_client_tls_config(&ModbusTlsConfig::default()).expect("builds");
+        assert!(neither.client_identity.is_none());
+    }
+
+    /// MB-R-109 — `insecure_skip_verify` disables server certificate verification and
+    /// ignores `ca_file`, rather than combining the two.
+    #[test]
+    fn ut_build_client_tls_config_insecure_skip_verify_ignores_ca_file() {
+        use super::build_client_tls_config;
+        use rust_modbus::ServerCertVerification;
+
+        let cfg = ModbusTlsConfig {
+            ca_file: Some("/no/such/ca.pem".to_string()),
+            insecure_skip_verify: true,
+            ..Default::default()
+        };
+        let built = build_client_tls_config(&cfg).expect("builds despite unreadable ca_file");
+        assert!(matches!(
+            built.server_cert,
+            ServerCertVerification::DangerousDisableVerification
+        ));
+    }
 
     /// MB-R-105 — `ModbusTlsConfig` carries exactly nine fields, six optional
     /// strings unset and three bools false, by default.

--- a/ferrowl-modbus/src/transport.rs
+++ b/ferrowl-modbus/src/transport.rs
@@ -1,4 +1,4 @@
-//! Transport selection between TCP and RTU connection settings.
+//! Transport selection between TCP, RTU, and RtuOverTcp connection settings.
 
 use crate::{rtu, tcp};
 
@@ -7,4 +7,22 @@ use crate::{rtu, tcp};
 pub enum Transport {
     Tcp(tcp::Config),
     Rtu(rtu::Config),
+    /// RTU framing carried over a TCP socket (MB-R-113); carries exactly the same
+    /// connection parameters as `Tcp` — no separate config type.
+    RtuOverTcp(tcp::Config),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transport;
+
+    /// MB-R-113 — `RtuOverTcp` carries exactly a `tcp::Config`, the same type (and
+    /// so the same fields) the `Tcp` variant carries — no separate struct.
+    #[test]
+    fn ut_rtu_over_tcp_variant_carries_tcp_config() {
+        let cfg = crate::tcp::Config::default();
+        let _: Transport = Transport::RtuOverTcp(cfg.clone());
+        // Compiles iff both variants take the identical `tcp::Config` type.
+        let _: Transport = Transport::Tcp(cfg);
+    }
 }

--- a/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
+++ b/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
@@ -1,0 +1,279 @@
+//! End-to-end RTU-over-TCP test: a ferrowl Modbus server and client speak RTU framing
+//! (unit id + CRC, no MBAP header) over a loopback TCP socket. Reuses `tcp::Config` for
+//! connection settings (MB-R-113) — only the on-wire framing differs from plain TCP.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrowl_codec::Kind as RegKind;
+use ferrowl_modbus::tcp;
+use ferrowl_modbus::{Address, Command, FunctionCode, Key, Operation, SlaveKey, UnitId, Word};
+use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKey> {
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
+}
+
+/// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+/// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn config(port: u16) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: None,
+    }
+}
+
+/// Server memory seeded with distinct values in all four register tables.
+fn server_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::Coil),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 8)],
+    );
+    mem.write(
+        key(RegKind::Coil),
+        &CellType::Coil,
+        &Range::new(0, 4),
+        &[1, 0, 1, 0],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::DiscreteInput),
+        &CellType::Coil,
+        &Range::new(0, 4),
+        &[0, 1, 1, 0],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::InputRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[100, 200, 300, 400],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 8)],
+    );
+    mem.write(
+        key(RegKind::HoldingRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[10, 20, 30, 40],
+    )
+    .unwrap();
+    Arc::new(MemLock::new(mem))
+}
+
+/// Client memory with the same regions declared but no values (the client fills them from reads).
+fn client_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::Coil),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 8)],
+    );
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 8)],
+    );
+    Arc::new(MemLock::new(mem))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-114 — RTU-over-TCP carries the same client/server behavior as plain TCP (polling every
+/// read operation into the shared store, MB-R-035, executing write commands, MB-R-046, and
+/// terminating gracefully, MB-R-049), differing only in on-wire framing.
+async fn rtu_over_tcp_client_polls_server_and_executes_commands() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // Start the server.
+    let server = ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem.clone(),
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    // Operations cover every read function code the client supports.
+    let operations = Arc::new(RwLock::new(vec![
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadCoils,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadDiscreteInputs,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadInputRegisters,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadHoldingRegisters,
+            range: Range::new(0, 4),
+        },
+    ]));
+
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::rtu_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Let the client poll every operation at least once.
+    sleep(Duration::from_millis(800)).await;
+
+    {
+        let g = cli_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![10, 20, 30, 40]
+        );
+        assert_eq!(
+            g.read(
+                key(RegKind::InputRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![100, 200, 300, 400]
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4))
+                .unwrap(),
+            vec![1, 0, 1, 0]
+        );
+        assert_eq!(
+            g.read(
+                key(RegKind::DiscreteInput),
+                &CellType::Coil,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![0, 1, 1, 0]
+        );
+    }
+
+    // Exercise every write command against the server.
+    tx.send(Command::WriteSingleRegister(
+        UnitId(1),
+        Address(0),
+        Word(99),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteMultipleRegister(
+        UnitId(1),
+        Address(1),
+        vec![5, 6].into_iter().map(Word).collect(),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteSingleCoil(UnitId(1), Address(5), true))
+        .await
+        .unwrap();
+    tx.send(Command::WriteMultipleCoils(
+        UnitId(1),
+        Address(6),
+        vec![true, false],
+    ))
+    .await
+    .unwrap();
+    sleep(Duration::from_millis(600)).await;
+
+    {
+        let g = srv_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 3)
+            )
+            .unwrap(),
+            vec![99, 5, 6]
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(5, 3))
+                .unwrap(),
+            vec![1, 1, 0]
+        );
+    }
+
+    // Graceful termination returns Ok and ends the client task.
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+
+    server.abort();
+}

--- a/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
+++ b/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
@@ -277,3 +277,155 @@ async fn rtu_over_tcp_client_polls_server_and_executes_commands() {
 
     server.abort();
 }
+
+#[tokio::test]
+/// MB-R-114, MB-R-069 — an `ip`/`port` pair that does not parse as a socket address fails with a
+/// TCP address error, for both the RTU-over-TCP client and the server, same as plain TCP.
+async fn rtu_over_tcp_unparseable_address_is_error() {
+    use ferrowl_modbus::{Error, TcpError};
+
+    let mut bad = config(502);
+    bad.ip = "not.an.ip.address".to_string();
+
+    // Client side (`Client` isn't `Debug`, so match the result rather than `unwrap_err`).
+    assert!(matches!(
+        ferrowl_modbus::rtu_over_tcp::Client::connect(&bad).await,
+        Err(Error::Tcp(TcpError::Address(_)))
+    ));
+
+    // Server side.
+    let mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let server_err =
+        ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(Arc::new(RwLock::new(bad)), mem)
+            .spawn(sink())
+            .await
+            .unwrap_err();
+    assert!(matches!(server_err, Error::Tcp(TcpError::Address(_))));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-114, MB-R-071 — failure to bind the RTU-over-TCP listen address fails the server's start
+/// and surfaces the error, same as plain TCP.
+async fn rtu_over_tcp_server_bind_conflict_is_error() {
+    let port = free_port();
+    // Occupy the port so the server's bind fails.
+    let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let res =
+        ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port))), mem)
+            .spawn(sink())
+            .await;
+    assert!(res.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-101 — over RTU-over-TCP framing (which shares RTU's broadcast address), a read addressed
+/// to slave id 0 is skipped by the client without disconnecting: the client_core mechanism is
+/// framing-generic (`F::is_broadcast`), so this proves the wiring carries the RTU broadcast
+/// behavior over the RtuOverTcp transport end-to-end.
+async fn rtu_over_tcp_client_skips_broadcast_poll_without_disconnect() {
+    let port = free_port();
+    let srv_mem = server_mem();
+
+    let server = ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem,
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    // Slave id 0 is the broadcast address: no server answers a read addressed to it.
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: UnitId(0),
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::rtu_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        client_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Several poll cycles at a broadcast address that never gets a response.
+    sleep(Duration::from_millis(600)).await;
+
+    // The client is still alive and responsive to Terminate: the broadcast poll never
+    // disconnected it.
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-102 — over RTU-over-TCP framing, a write addressed to slave id 0 (broadcast) is
+/// transmitted fire-and-forget: the server applies it (MB-R-103) without the client waiting for
+/// (or the server sending) a response.
+async fn rtu_over_tcp_client_fire_and_forget_broadcast_write() {
+    let port = free_port();
+    let mut srv_mem_raw = Memory::<Key<SlaveKey>>::default();
+    let broadcast_key = Key::new(SlaveKey {
+        slave_id: UnitId(0),
+        kind: RegKind::HoldingRegister,
+    });
+    srv_mem_raw.add_ranges(
+        broadcast_key.clone(),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let srv_mem: Mem = Arc::new(MemLock::new(srv_mem_raw));
+
+    let server = ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem.clone(),
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    let operations = Arc::new(RwLock::new(vec![]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::rtu_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        client_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    tx.send(Command::WriteSingleRegister(
+        UnitId(0),
+        Address(1),
+        Word(0x1234),
+    ))
+    .await
+    .unwrap();
+    sleep(Duration::from_millis(300)).await;
+
+    // MB-R-103: the store took the broadcast write even though nothing answered it.
+    {
+        let g = srv_mem.read();
+        assert_eq!(
+            g.read(broadcast_key, &CellType::Register, &Range::new(1, 1))
+                .unwrap(),
+            vec![0x1234]
+        );
+    }
+
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}

--- a/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
+++ b/ferrowl-modbus/tests/rtu_over_tcp_loopback.rs
@@ -429,3 +429,68 @@ async fn rtu_over_tcp_client_fire_and_forget_broadcast_write() {
     assert!(joined.is_ok());
     server.abort();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-103 — a server never sends a response frame for a request addressed to slave id 0
+/// (broadcast), over RtuOverTcp. Client-independent: uses a raw `rust_modbus::Client` directly
+/// against the real socket (bypassing ferrowl's own fire-and-forget client, which never even
+/// tries to read a response and so could not catch a server that wrongly sent one), then reads
+/// the raw bytes off the wire with a timeout and asserts nothing arrived.
+async fn rtu_over_tcp_server_sends_no_response_frame_for_broadcast_write() {
+    use rust_modbus::{
+        Address as RmAddress, Client as RmClient, RegisterValue, RtuOverTcp, TcpConfig,
+        connect_tcp_framed,
+    };
+    use tokio::io::AsyncReadExt;
+
+    let port = free_port();
+    let mut srv_mem_raw = Memory::<Key<SlaveKey>>::default();
+    let broadcast_key = Key::new(SlaveKey {
+        slave_id: UnitId(0),
+        kind: RegKind::HoldingRegister,
+    });
+    srv_mem_raw.add_ranges(
+        broadcast_key,
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let srv_mem: Mem = Arc::new(MemLock::new(srv_mem_raw));
+
+    let server = ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem,
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    let transport = connect_tcp_framed::<RtuOverTcp>(addr, TcpConfig::default())
+        .await
+        .expect("raw client failed to connect");
+    let mut client: RmClient<_, RtuOverTcp> = RmClient::new(transport);
+
+    // Broadcast write: rust_modbus's own Client already knows (via `ClientFraming::is_broadcast`)
+    // not to wait for a response here, so this returns as soon as the frame is written.
+    client
+        .write_single_register(UnitId(0), RmAddress(1), RegisterValue(0x1234))
+        .await
+        .expect("broadcast write send failed");
+
+    // Reclaim the raw stream and read directly off the wire: if the server incorrectly sent a
+    // response frame anyway, it would be sitting here.
+    let mut stream = client.into_inner().into_inner();
+    let mut buf = [0u8; 64];
+    let read = tokio::time::timeout(Duration::from_millis(300), stream.read(&mut buf)).await;
+    match read {
+        Err(_) => {}    // Timed out waiting for bytes: no response frame arrived. Correct.
+        Ok(Ok(0)) => {} // Connection closed with no bytes sent: also no response frame. Correct.
+        Ok(Ok(n)) => panic!(
+            "server sent {n} unexpected byte(s) after a broadcast write: {:?}",
+            &buf[..n]
+        ),
+        Ok(Err(e)) => panic!("unexpected read error: {e}"),
+    }
+
+    server.abort();
+}

--- a/ferrowl-modbus/tests/rtu_over_tcp_tls.rs
+++ b/ferrowl-modbus/tests/rtu_over_tcp_tls.rs
@@ -1,0 +1,170 @@
+//! RTU-over-TCP TLS tests (MB-R-115): the same TLS glue plain TCP uses (MB-R-104..MB-R-111),
+//! reused verbatim under RTU framing.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use ferrowl_codec::Kind as RegKind;
+use ferrowl_modbus::rtu_over_tcp;
+use ferrowl_modbus::tcp;
+use ferrowl_modbus::{Command, FunctionCode, Key, Operation, SlaveKey, UnitId};
+use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKey> {
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
+}
+
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn server_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::HoldingRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[10, 20, 30, 40],
+    )
+    .unwrap();
+    Arc::new(MemLock::new(mem))
+}
+
+fn client_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    Arc::new(MemLock::new(mem))
+}
+
+fn config(port: u16, tls: tcp::ModbusTlsConfig) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: Some(tls),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-115 — an RTU-over-TCP client and server, both configured for TLS, complete the
+/// handshake and exchange Modbus RTU-framed traffic over it, exactly as plain TCP does.
+async fn rtu_over_tcp_client_server_tls_roundtrip() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // Server: an ephemeral self-signed cert (`self_signed = true`, no cert_file/key_file).
+    let server_tls = tcp::ModbusTlsConfig {
+        self_signed: true,
+        ..Default::default()
+    };
+    let server =
+        rtu_over_tcp::ServerBuilder::new(Arc::new(RwLock::new(config(port, server_tls))), srv_mem)
+            .spawn(sink())
+            .await
+            .expect("server failed to start");
+
+    // Client: trusts whatever certificate the server presents (this test is about the
+    // RTU-over-TCP handshake plumbing, not certificate validation, which MB-R-109's
+    // tcp_tls_client.rs tests already cover in depth).
+    let client_tls = tcp::ModbusTlsConfig {
+        insecure_skip_verify: true,
+        ..Default::default()
+    };
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: UnitId(1),
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = rtu_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port, client_tls))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    sleep(std::time::Duration::from_millis(800)).await;
+
+    {
+        let g = cli_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![10, 20, 30, 40]
+        );
+    }
+
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(std::time::Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-115 — a TLS-configured RTU-over-TCP client against a plain (non-TLS) listener fails the
+/// connect with a handshake error, same as plain TCP (MB-R-111).
+async fn rtu_over_tcp_tls_handshake_failure_is_connect_failure() {
+    let plain_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let plain_addr = plain_listener.local_addr().unwrap();
+    let plain_server = tokio::spawn(async move {
+        loop {
+            if plain_listener.accept().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let handshake_cfg = config(
+        plain_addr.port(),
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    let result = rtu_over_tcp::Client::connect(&handshake_cfg).await;
+    assert!(
+        result.is_err(),
+        "expected TLS handshake against a plain listener to fail"
+    );
+    plain_server.abort();
+}

--- a/ferrowl/src/cli/mod.rs
+++ b/ferrowl/src/cli/mod.rs
@@ -229,6 +229,13 @@ pub fn parse_module_spec(input: &str) -> Result<ModuleSpec, String> {
                 .parse()
                 .map_err(|_| "invalid 'port'")?,
         },
+        "rtu_over_tcp" => Endpoint::RtuOverTcp {
+            ip: get("ip").unwrap_or_else(|| "127.0.0.1".to_string()),
+            port: get("port")
+                .ok_or("rtu_over_tcp module requires 'port'")?
+                .parse()
+                .map_err(|_| "invalid 'port'")?,
+        },
         "rtu" => Endpoint::Rtu {
             path: get("path").ok_or("rtu module requires 'path'")?,
             baud_rate: parse_opt(get("baud").or_else(|| get("baud_rate")), "baud")?
@@ -237,7 +244,11 @@ pub fn parse_module_spec(input: &str) -> Result<ModuleSpec, String> {
             data_bits: parse_opt(get("data_bits"), "data_bits")?,
             stop_bits: parse_opt(get("stop_bits"), "stop_bits")?,
         },
-        other => return Err(format!("invalid transport '{other}' (expected tcp|rtu)")),
+        other => {
+            return Err(format!(
+                "invalid transport '{other}' (expected tcp|rtu|rtu_over_tcp)"
+            ));
+        }
     };
 
     Ok(ModuleSpec {
@@ -355,6 +366,31 @@ mod tests {
                 stop_bits: None,
             }
         );
+    }
+
+    #[test]
+    /// CL-R-002 — a --module RtuOverTcp descriptor parses like TCP (same ip/port
+    /// keys), tagged `rtu_over_tcp`.
+    fn ut_parse_rtu_over_tcp_module() {
+        let spec = parse_module_spec(
+            "name=m,device=d.toml,transport=rtu_over_tcp,ip=10.0.0.5,port=502,role=client",
+        )
+        .unwrap();
+        assert_eq!(spec.role, Role::Client);
+        assert_eq!(
+            spec.endpoint,
+            Endpoint::RtuOverTcp {
+                ip: "10.0.0.5".into(),
+                port: 502
+            }
+        );
+    }
+
+    #[test]
+    /// CL-R-002 — an unknown `transport` value is still a parse error, listing all
+    /// three valid options.
+    fn ut_parse_invalid_transport_still_errors() {
+        assert!(parse_module_spec("name=m,device=d,transport=usb").is_err());
     }
 
     #[test]

--- a/ferrowl/src/instance/builder.rs
+++ b/ferrowl/src/instance/builder.rs
@@ -1,6 +1,6 @@
 //! Transport/role-specific builder held by an [`Instance`](crate::instance::Instance).
 
-use ferrowl_modbus::{KeyParams, rtu, tcp};
+use ferrowl_modbus::{KeyParams, rtu, rtu_over_tcp, tcp};
 
 /// The underlying ferrowl-modbus builder for each transport/role combination.
 pub enum Builder<T: KeyParams> {
@@ -8,4 +8,6 @@ pub enum Builder<T: KeyParams> {
     TcpServer(tcp::ServerBuilder<T>),
     RtuClient(rtu::ClientBuilder<T>),
     RtuServer(rtu::ServerBuilder<T>),
+    RtuOverTcpClient(rtu_over_tcp::ClientBuilder<T>),
+    RtuOverTcpServer(rtu_over_tcp::ServerBuilder<T>),
 }

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -73,6 +73,27 @@ impl<T: KeyParams> Instance<T> {
         }
     }
 
+    pub fn with_rtu_over_tcp_client(config: ClientConfig<T, ferrowl_modbus::tcp::Config>) -> Self {
+        Self {
+            builder: Builder::RtuOverTcpClient(ferrowl_modbus::rtu_over_tcp::ClientBuilder::new(
+                config.config,
+                config.operations,
+                config.memory,
+            )),
+            handle: None,
+        }
+    }
+
+    pub fn with_rtu_over_tcp_server(config: ServerConfig<T, ferrowl_modbus::tcp::Config>) -> Self {
+        Self {
+            builder: Builder::RtuOverTcpServer(ferrowl_modbus::rtu_over_tcp::ServerBuilder::new(
+                config.config,
+                config.memory,
+            )),
+            handle: None,
+        }
+    }
+
     /// Spawns the endpoint's background task. Fails with
     /// [`InstanceError::AlreadyActive`] if it is still running.
     pub async fn start<L, S>(&mut self, log: L, status: S) -> Result<(), Error>
@@ -123,6 +144,29 @@ impl<T: KeyParams> Instance<T> {
                 }
             }
             Builder::RtuServer(builder) => {
+                let res = builder.spawn(log).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Server(handle::ServerHandle { handle }));
+                    }
+                }
+            }
+            Builder::RtuOverTcpClient(builder) => {
+                let (sender, receiver) = tokio::sync::mpsc::channel(10);
+                let res = builder.spawn(receiver, log, status).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Client(handle::ClientHandle { handle, sender }));
+                    }
+                }
+            }
+            Builder::RtuOverTcpServer(builder) => {
                 let res = builder.spawn(log).await;
                 match res {
                     Err(e) => {
@@ -334,6 +378,29 @@ mod tests {
         // Restart the same instance.
         instance.start(sink(), sink()).await.expect("restart");
         assert!(instance.active());
+        instance.stop().await.expect("cleanup stop");
+    }
+
+    /// MB-R-114 — an RtuOverTcp client instance starts, connects, and stops exactly
+    /// like a TCP client instance (reuses `tcp::Config`, MB-R-113).
+    fn rtu_over_tcp_client_instance() -> Instance<SlaveKey> {
+        let operations = Arc::new(RwLock::new(vec![]));
+        Instance::with_rtu_over_tcp_client(config::ClientConfig {
+            config: Arc::new(RwLock::new(dead_tcp_config())),
+            operations,
+            memory: Arc::new(MemLock::new(
+                ferrowl_store::Memory::<Key<SlaveKey>>::default(),
+            )),
+        })
+    }
+
+    #[tokio::test]
+    async fn rtu_over_tcp_start_twice_is_already_active() {
+        let mut instance = rtu_over_tcp_client_instance();
+        instance.start(sink(), sink()).await.expect("first start");
+        assert!(instance.active());
+        let err = instance.start(sink(), sink()).await.unwrap_err();
+        assert!(matches!(err, Error::Instance(InstanceError::AlreadyActive)));
         instance.stop().await.expect("cleanup stop");
     }
 

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -266,6 +266,15 @@ pub(crate) fn endpoint_to_config(
             reconnect: timing.reconnect,
             tls,
         }),
+        Endpoint::RtuOverTcp { ip, port } => NetConfig::RtuOverTcp(ferrowl_modbus::tcp::Config {
+            ip: ip.clone(),
+            port: *port,
+            timeout_ms: timing.timeout_ms,
+            delay_ms: timing.delay_ms,
+            interval_ms: timing.interval_ms,
+            reconnect: timing.reconnect,
+            tls,
+        }),
         Endpoint::Rtu {
             path,
             baud_rate,
@@ -312,6 +321,19 @@ pub(crate) fn build_instance(
             config: Arc::new(RwLock::new(cfg)),
             memory,
         }),
+        (Role::Client, NetConfig::RtuOverTcp(cfg)) => {
+            Instance::with_rtu_over_tcp_client(ClientConfig {
+                config: Arc::new(RwLock::new(cfg)),
+                operations,
+                memory,
+            })
+        }
+        (Role::Server, NetConfig::RtuOverTcp(cfg)) => {
+            Instance::with_rtu_over_tcp_server(ServerConfig {
+                config: Arc::new(RwLock::new(cfg)),
+                memory,
+            })
+        }
     }
 }
 
@@ -680,7 +702,38 @@ mod tests {
         let net_config = endpoint_to_config(&endpoint, &timing, tls.clone());
         match net_config {
             NetConfig::Tcp(cfg) => assert_eq!(cfg.tls, tls),
-            NetConfig::Rtu(_) => panic!("expected a TCP config"),
+            _ => panic!("expected a TCP config"),
+        }
+    }
+
+    #[test]
+    /// MB-R-115 — `endpoint_to_config` threads `tls` through for an RtuOverTcp
+    /// endpoint exactly as it does for Tcp (MB-R-104), producing
+    /// `NetConfig::RtuOverTcp(tcp::Config { .. })`.
+    fn ut_endpoint_to_config_carries_tls_for_rtu_over_tcp_endpoint() {
+        use super::{Timing, endpoint_to_config};
+        use crate::config::Endpoint;
+        use ferrowl_modbus::Transport as NetConfig;
+        use ferrowl_modbus::tcp::ModbusTlsConfig;
+
+        let timing = Timing {
+            timeout_ms: 1000,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let tls = Some(ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        });
+        let endpoint = Endpoint::RtuOverTcp {
+            ip: "127.0.0.1".to_string(),
+            port: 502,
+        };
+        let net_config = endpoint_to_config(&endpoint, &timing, tls.clone());
+        match net_config {
+            NetConfig::RtuOverTcp(cfg) => assert_eq!(cfg.tls, tls),
+            _ => panic!("expected an RtuOverTcp config"),
         }
     }
 }

--- a/ferrowl/src/module/modbus/config/session.rs
+++ b/ferrowl/src/module/modbus/config/session.rs
@@ -89,6 +89,13 @@ pub enum Endpoint {
         ip: String,
         port: u16,
     },
+    /// RTU framing carried over a TCP socket (MB-R-113); `rename_all = "lowercase"` alone
+    /// would tag this `"rtuovertcp"`, not the required `"rtu_over_tcp"`.
+    #[serde(rename = "rtu_over_tcp")]
+    RtuOverTcp {
+        ip: String,
+        port: u16,
+    },
     Rtu {
         path: String,
         #[serde(default = "default_baud")]
@@ -107,6 +114,9 @@ impl std::fmt::Display for Endpoint {
         match self {
             Endpoint::Tcp { ip, port } => {
                 write!(fmt, "{}:{}", ip, port)
+            }
+            Endpoint::RtuOverTcp { ip, port } => {
+                write!(fmt, "{}:{} (rtu/tcp)", ip, port)
             }
             Endpoint::Rtu {
                 path,
@@ -261,6 +271,14 @@ mod tests {
             .to_string(),
             "127.0.0.1:502"
         );
+        assert_eq!(
+            Endpoint::RtuOverTcp {
+                ip: "127.0.0.1".into(),
+                port: 502
+            }
+            .to_string(),
+            "127.0.0.1:502 (rtu/tcp)"
+        );
         // RTU with all optional fields present.
         assert_eq!(
             Endpoint::Rtu {
@@ -290,5 +308,22 @@ mod tests {
     #[test]
     fn ut_default_baud() {
         assert_eq!(default_baud(), 19200);
+    }
+
+    #[test]
+    /// MB-R-113 — the `RtuOverTcp` endpoint variant tags as `rtu_over_tcp` on the
+    /// wire (not `rtuovertcp`, which `rename_all = "lowercase"` alone would produce),
+    /// and carries exactly `ip`/`port`, the same fields as `Tcp`.
+    fn ut_endpoint_rtu_over_tcp_serde_tag() {
+        let ep = Endpoint::RtuOverTcp {
+            ip: "10.0.0.1".into(),
+            port: 502,
+        };
+        let v = serde_json::to_value(&ep).unwrap();
+        assert_eq!(v["transport"], "rtu_over_tcp");
+        assert_eq!(v["ip"], "10.0.0.1");
+        assert_eq!(v["port"], 502);
+        let back: Endpoint = serde_json::from_value(v).unwrap();
+        assert_eq!(back, ep);
     }
 }

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -203,6 +203,15 @@ impl SetupDialog {
                 set_input(&mut dialog.ip, ip);
                 set_input(&mut dialog.port, &port.to_string());
             }
+            // TODO(s4): the dialog's own `Transport` selector has no RtuOverTcp choice yet
+            // (that is s4's job — a real third selector value plus `tls_shown` gating). Until
+            // then, editing an RtuOverTcp instance's ip/port prefills identically to Tcp so the
+            // crate compiles against the now-3-variant `Endpoint`; s4 replaces this arm.
+            Endpoint::RtuOverTcp { ip, port } => {
+                dialog.transport.state.set_selection(0);
+                set_input(&mut dialog.ip, ip);
+                set_input(&mut dialog.port, &port.to_string());
+            }
             Endpoint::Rtu {
                 path,
                 baud_rate,

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -105,8 +105,9 @@ pub struct SetupDialog {
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<ConfigPath, FsPathProvider>>,
     #[focus]
     pub transport: Widget<SelectionState<Transport>, Selection<Transport>>,
-    /// TLS level, offered only for TCP (MB-R-112: RTU carries no `tls` field at all).
-    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    /// TLS level, offered for TCP and RtuOverTcp (MB-R-115) — not RTU (MB-R-112: RTU carries
+    /// no `tls` field at all).
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp)})]
     pub tls_level: Widget<SelectionState<TlsLevel>, Selection<TlsLevel>>,
     #[focus]
     pub role: Widget<SelectionState<Role>, Selection<Role>>,
@@ -138,9 +139,9 @@ pub struct SetupDialog {
     #[focus(when = {self.show_client_ca()})]
     pub client_ca_file:
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp)})]
     pub ip: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Tcp})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp)})]
     pub port: Widget<InputFieldState, InputField<String>>,
     #[focus(when = {self.transport.get_value() == Transport::Rtu})]
     pub path: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
@@ -203,12 +204,8 @@ impl SetupDialog {
                 set_input(&mut dialog.ip, ip);
                 set_input(&mut dialog.port, &port.to_string());
             }
-            // TODO(s4): the dialog's own `Transport` selector has no RtuOverTcp choice yet
-            // (that is s4's job — a real third selector value plus `tls_shown` gating). Until
-            // then, editing an RtuOverTcp instance's ip/port prefills identically to Tcp so the
-            // crate compiles against the now-3-variant `Endpoint`; s4 replaces this arm.
             Endpoint::RtuOverTcp { ip, port } => {
-                dialog.transport.state.set_selection(0);
+                dialog.transport.state.set_selection(2); // Tcp=0, Rtu=1, RtuOverTcp=2
                 set_input(&mut dialog.ip, ip);
                 set_input(&mut dialog.port, &port.to_string());
             }
@@ -302,7 +299,9 @@ impl SetupDialog {
             .transport(selection(
                 "Transport",
                 None,
-                vec![Transport::Tcp, Transport::Rtu],
+                // Tcp=0, Rtu=1, RtuOverTcp=2 — appended last to keep Rtu's existing index
+                // stable rather than reordering around it.
+                vec![Transport::Tcp, Transport::Rtu, Transport::RtuOverTcp],
                 &selection_style,
             ))
             .role(selection(
@@ -496,9 +495,12 @@ impl SetupDialog {
     // dialog-height computation, so keyboard focus, painting and layout can never disagree about
     // which fields exist. Mirrors `ferrowl::module::ocpp::setup_dialog`'s own `show_*` methods.
 
-    /// The TLS level selection row (any TCP endpoint; never RTU, MB-R-112).
+    /// The TLS level selection row (TCP or RtuOverTcp, MB-R-115; never RTU, MB-R-112).
     fn tls_shown(&self) -> bool {
-        self.transport.get_value() == Transport::Tcp && self.tls_level.get_value() != TlsLevel::Off
+        matches!(
+            self.transport.get_value(),
+            Transport::Tcp | Transport::RtuOverTcp
+        ) && self.tls_level.get_value() != TlsLevel::Off
     }
 
     /// The currently selected TLS level.
@@ -632,6 +634,21 @@ impl SetupDialog {
                 };
                 Endpoint::Tcp { ip, port }
             }
+            Transport::RtuOverTcp => {
+                let mut ip = self.ip.state.input().trim().to_string();
+                if ip.is_empty() {
+                    ip = "127.0.0.1".to_string();
+                }
+                let port = self.port.state.input();
+                let port = if !port.is_empty() {
+                    port.trim()
+                        .parse::<u16>()
+                        .map_err(|_| "Port must be a number (0-65535).".to_string())?
+                } else {
+                    502
+                };
+                Endpoint::RtuOverTcp { ip, port }
+            }
             Transport::Rtu => {
                 let mut path = self.path.state.input().trim().to_string();
                 if path.is_empty() {
@@ -685,8 +702,9 @@ impl SetupDialog {
         };
 
         // TLS is hidden entirely for RTU (MB-R-112): report no value at all, so a save on an
-        // RTU instance never clobbers a device config's existing `tls` setting.
-        let tls = if matches!(endpoint, Endpoint::Tcp { .. }) {
+        // RTU instance never clobbers a device config's existing `tls` setting. RtuOverTcp
+        // carries TLS exactly like Tcp (MB-R-115).
+        let tls = if matches!(endpoint, Endpoint::Tcp { .. } | Endpoint::RtuOverTcp { .. }) {
             let level = self.tls_level.state.get_value();
             if level == TlsLevel::Off {
                 Some(None)
@@ -738,6 +756,8 @@ impl SetupDialog {
         }
 
         let is_new = self.mode == DialogMode::New;
+        // Deliberately not `!= Transport::Tcp`: RtuOverTcp uses the 1-row TCP-shaped ip/port
+        // layout, not RTU's 2-row serial layout, so it must stay excluded from `is_rtu` here.
         let is_rtu = self.transport.state.get_value() == Transport::Rtu;
         // RTU needs two endpoint rows (path/baud, parity/data-bits/stop-bits); TCP one.
         let endpoint_rows: u16 = if is_rtu { 2 } else { 1 };
@@ -1262,6 +1282,60 @@ mod tests {
         set_suggest_input(&mut dialog.path, "/dev/ttyUSB0");
         let outcome = dialog.resolve().unwrap();
         assert_eq!(outcome.values.tls, None);
+    }
+
+    #[test]
+    /// UI-R-024 — an RtuOverTcp setup dialog shows the same fields as TCP (ip/port,
+    /// TLS level selector) and none of RTU's serial fields (MB-R-113).
+    fn ut_rtu_over_tcp_dialog_shows_tcp_like_fields() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        dialog.transport.state.set_selection(2); // Tcp=0, Rtu=1, RtuOverTcp=2
+        assert_eq!(dialog.transport.state.get_value(), Transport::RtuOverTcp);
+        let area = Rect::new(0, 0, 80, 60);
+        let mut buf = Buffer::empty(area);
+        dialog.render(area, &mut buf);
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("IP"),
+            "missing IP field for RtuOverTcp:\n{text}"
+        );
+        assert!(
+            text.contains("TLS"),
+            "missing TLS selector for RtuOverTcp:\n{text}"
+        );
+        assert!(
+            !text.contains("Baud"),
+            "RTU serial field leaked into RtuOverTcp:\n{text}"
+        );
+    }
+
+    #[test]
+    /// MB-R-113 — resolving an RtuOverTcp dialog produces `Endpoint::RtuOverTcp`
+    /// with the entered ip/port.
+    fn ut_resolve_rtu_over_tcp_endpoint() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        dialog.transport.state.set_selection(2);
+        set_input(&mut dialog.ip, "10.0.0.9");
+        set_input(&mut dialog.port, "1502");
+        let outcome = dialog.resolve().unwrap();
+        assert_eq!(
+            outcome.values.endpoint,
+            Endpoint::RtuOverTcp {
+                ip: "10.0.0.9".into(),
+                port: 1502
+            }
+        );
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/setup_dialog/choices.rs
+++ b/ferrowl/src/module/modbus/setup_dialog/choices.rs
@@ -18,6 +18,9 @@ pub enum DialogMode {
 pub enum Transport {
     Tcp,
     Rtu,
+    /// RTU framing carried over a TCP socket (MB-R-113) — shares the `Tcp` field set
+    /// (ip/port, TLS), not RTU's serial fields.
+    RtuOverTcp,
 }
 
 impl ToLabel for Transport {
@@ -25,6 +28,7 @@ impl ToLabel for Transport {
         match self {
             Transport::Tcp => "TCP",
             Transport::Rtu => "RTU",
+            Transport::RtuOverTcp => "RTU over TCP",
         }
         .to_string()
     }
@@ -117,6 +121,7 @@ mod tests {
     fn ut_labels() {
         assert_eq!(Transport::Tcp.to_label(), "TCP");
         assert_eq!(Transport::Rtu.to_label(), "RTU");
+        assert_eq!(Transport::RtuOverTcp.to_label(), "RTU over TCP");
         assert_eq!(Parity::Even.to_label(), "Even");
         assert_eq!(ReconnectChoice::On.to_label(), "On");
         assert_eq!(U8Choice(8).to_label(), "8");


### PR DESCRIPTION
## Why

Some Modbus deployments bridge serial RTU devices onto TCP networks (RTU gateways) using RTU-style framing carried over a TCP socket instead of serial. The pinned rust-modbus fork already supports this generically via its `Framing` trait; ferrowl previously exposed only `Tcp` and `Rtu` as transport options.

## What changed

Adds `RtuOverTcp` as a third Modbus transport, selectable in config, CLI, and the TUI setup dialog — same connection parameters as `Tcp` (`ip`, `port`, `timeout_ms`, `delay_ms`, `interval_ms`, `reconnect`, `tls`), RTU-style wire framing (unit id + CRC, no MBAP header) instead of Modbus TCP framing.

Requirements: MB-R-113 (new — config option), MB-R-114 (new — connection/framing), MB-R-115 (new — TLS parity with TCP), MB-R-067 (changed — servers now log per-request outcomes for TCP/RTU/RtuOverTcp alike, fixing a pre-existing gap where RTU servers stayed silent), MB-R-076/101/102/103 (changed — broadcast/module-lifecycle wording extended to cover RtuOverTcp). Plus matching `api-contract.md`/`edge-cases.md` updates in both `docs/specs/modbus/` and `docs/specs/cli-headless/` (the `--module transport=` enum gains `rtu_over_tcp`).

## How

- `ferrowl-modbus`: relocated the TCP TLS glue into `tcp::tls` for reuse, added `Transport::RtuOverTcp` and a new `rtu_over_tcp` client/server module built on the upstream fork's generic `connect_tcp_framed`/`connect_tls_framed`/`serve_framed`/`serve_tls::<F>` — no upstream gap, the fork already exposes everything needed. Fixed MB-R-067 by flipping the RTU server's verbose-logging flag.
- `ferrowl` bin: `Endpoint::RtuOverTcp` (explicit `#[serde(rename = "rtu_over_tcp")]`), CLI `--module transport=rtu_over_tcp` parsing, and matching `Instance`/`Builder` wiring.
- TUI: setup dialog's Transport selector gains `RtuOverTcp` as a third choice, presenting the same fields as `Tcp` when selected (covered by existing UI-R-024, no new UI-R id).

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo check --workspace`, `cargo test --workspace` — all pass, 0 failures.
- `cargo llvm-cov --workspace --fail-under-lines 80` — 86.83% total line coverage.
- Independent gate-3 review (separate agent, no shared context with implementation): spec fidelity, standards, and TDD honesty all pass; two minor findings raised and fixed (MB-R-113/114/115 reflowed to one physical line each per repo convention; added a wire-level test proving MB-R-103's "no response frame" behavior specifically over RtuOverTcp, independent of client-side skip logic).

Closes #160
