### PR TITLE
Add Modbus ASCII and AsciiOverTcp transport support (client + server)

### DIFF
--- a/docs/specs/cli-headless/api-contract.md
+++ b/docs/specs/cli-headless/api-contract.md
@@ -98,10 +98,10 @@ without `=` is an error. Later duplicate keys overwrite earlier ones.
 | `device` | yes* | — | Path to the device-config file. |
 | `type` | — | — | **Alias for `device`**: used only if `device` is absent. |
 | `role` | — | `server` | `client` or `server`. Any other value is an error. |
-| `transport` | — | `tcp` | `tcp`, `rtu`, `rtu_over_tcp`, or `udp`. Any other value is an error. |
+| `transport` | — | `tcp` | `tcp`, `rtu`, `rtu_over_tcp`, `udp`, `ascii`, or `ascii_over_tcp`. Any other value is an error. |
 | `ip` | — | `127.0.0.1` | TCP/UDP only: peer/bind IP. |
-| `port` | yes (tcp) | — | TCP/UDP only: port. Required for `transport=tcp`, `transport=rtu_over_tcp`, or `transport=udp`; must parse as a number. |
-| `path` | yes (rtu) | — | RTU only: serial device path. Required for `transport=rtu`. |
+| `port` | yes (tcp) | — | TCP/UDP only: port. Required for `transport=tcp`, `transport=rtu_over_tcp`, `transport=udp`, or `transport=ascii_over_tcp`; must parse as a number. |
+| `path` | yes (rtu) | — | RTU only: serial device path. Required for `transport=rtu` or `transport=ascii`. |
 | `baud` / `baud_rate` | — | `19200` | RTU only: baud rate (`baud` and `baud_rate` are aliases). |
 | `parity` | — | unset | RTU only: parity string (passed through). |
 | `data_bits` | — | unset | RTU only: data bits (numeric). |

--- a/docs/specs/cli-headless/edge-cases.md
+++ b/docs/specs/cli-headless/edge-cases.md
@@ -28,7 +28,8 @@ Lua/assertion semantics live in [`../scripting/`](../scripting/).
   `--ocpp` without `name`, `device`, or `port` → parse error.
 - **Non-numeric `port`/`data_bits`/`stop_bits`/`baud`** → parse error.
 - **Invalid enum value** — `role` other than `client`/`server`, `transport` other
-  than `tcp`/`rtu`/`rtu_over_tcp`/`udp`, `protocol` other than `ws`/`wss` → parse error.
+  than `tcp`/`rtu`/`rtu_over_tcp`/`udp`/`ascii`/`ascii_over_tcp`, `protocol` other
+  than `ws`/`wss` → parse error.
 - In `ferrowl run`, any such descriptor error is a setup failure: the run exits
   **1** with an `Error:` diagnostic on stderr before the loop starts. In the TUI
   path it aborts startup with `Error:` on stderr and no TUI.

--- a/docs/specs/modbus/api-contract.md
+++ b/docs/specs/modbus/api-contract.md
@@ -68,7 +68,7 @@ No other exception code is ever produced by the server.
 
 ## 2. Transports
 
-Exactly four transports are supported: **TCP**, **RTU** (serial), **RtuOverTcp** (RTU framing over a TCP socket), and **UDP** (Modbus TCP/MBAP framing over a UDP datagram). There is no Modbus ASCII.
+Exactly six transports are supported: **TCP**, **RTU** (serial), **RtuOverTcp** (RTU framing over a TCP socket), **UDP** (Modbus TCP/MBAP framing over a UDP datagram), **Ascii** (ASCII framing over a serial line), and **AsciiOverTcp** (ASCII framing over a TCP socket).
 
 ---
 
@@ -96,6 +96,9 @@ The `Udp` transport (tag value `udp`) uses this same field table minus `tls`,
 which it does not carry (MB-R-116): the upstream UDP transport performs no
 handshake and offers no TLS/DTLS option to configure.
 
+The `AsciiOverTcp` transport (tag value `ascii_over_tcp`) uses this exact
+same field table — no additions or removals (MB-R-125).
+
 ---
 
 ## 4. Modbus RTU connection config
@@ -116,6 +119,9 @@ handshake and offers no TLS/DTLS option to configure.
 An out-of-range `parity`, `data_bits`, or `stop_bits` fails with a serial
 configuration error **before** the port is opened.
 
+The `Ascii` transport (tag value `ascii`) uses this exact same field table —
+no additions or removals (MB-R-121).
+
 ---
 
 ## 5. Module instance spec (session / `--module`)
@@ -128,7 +134,7 @@ One Modbus module instance. This is the per-instance, on-the-wire endpoint; all
 | `name` | string | — (required) | tab / instance name |
 | `device` | string | — (required) | path to the device config file |
 | `role` | `client` \| `server` | `server` | |
-| `endpoint` | tagged union, tag `transport` | — (required) | `tcp`, `rtu`, `rtu_over_tcp`, or `udp` |
+| `endpoint` | tagged union, tag `transport` | — (required) | `tcp`, `rtu`, `rtu_over_tcp`, `udp`, `ascii`, or `ascii_over_tcp` |
 
 ### `endpoint` with `transport = "tcp"`
 
@@ -160,6 +166,14 @@ Takes the same fields as `transport = "tcp"` (§3), by reference.
 
 Takes the same fields as `transport = "tcp"` (§3), by reference.
 
+### endpoint with `transport = "ascii"`
+
+Takes the same fields as `transport = "rtu"` (above), by reference.
+
+### endpoint with `transport = "ascii_over_tcp"`
+
+Takes the same fields as `transport = "tcp"` (§3), by reference.
+
 ### `--module` key/value form
 
 `--module name=…,device=…,transport=…,…` accepts the same keys, with:
@@ -169,8 +183,9 @@ Takes the same fields as `transport = "tcp"` (§3), by reference.
 - `transport` defaulting to `tcp`
 - `role` defaulting to `server`
 - `ip` defaulting to `127.0.0.1`
-- `port` **required** for `transport=tcp`, `transport=rtu_over_tcp`, or
-  `transport=udp`; `path` **required** for `transport=rtu`
+- `port` **required** for `transport=tcp`, `transport=rtu_over_tcp`,
+  `transport=udp`, or `transport=ascii_over_tcp`; `path` **required** for
+  `transport=rtu` or `transport=ascii`
 
 ---
 

--- a/docs/specs/modbus/edge-cases.md
+++ b/docs/specs/modbus/edge-cases.md
@@ -146,9 +146,11 @@ task; it does not retry the bind or the port open. Restarting it is the operator
 A TCP server spawns one task per accepted connection with no cap on the number of
 concurrent connections and no idle timeout.
 
-### 6.6 Only four transports
+### 6.6 Only six transports
 
-There is no Modbus ASCII. `RtuOverTcp` reuses the TCP config verbatim (no new/removed fields); its only difference from plain TCP is wire framing. `Udp` reuses the TCP config too, except it drops `tls`: the upstream UDP transport performs no handshake and offers no DTLS option, so there is nothing for a `tls` field to configure. Unlike `RtuOverTcp`, `Udp` also does not inherit RTU/RtuOverTcp's broadcast slave id 0 handling (MB-R-101–MB-R-103) — on `Udp`, slave id 0 is an ordinary slave id.
+`RtuOverTcp` reuses the TCP config verbatim (no new/removed fields); its only difference from plain TCP is wire framing. `Udp` reuses the TCP config too, except it drops `tls`: the upstream UDP transport performs no handshake and offers no DTLS option, so there is nothing for a `tls` field to configure. Unlike `RtuOverTcp`, `Udp` also does not inherit RTU/RtuOverTcp's broadcast slave id 0 handling (MB-R-101–MB-R-103) — on `Udp`, slave id 0 is an ordinary slave id.
+
+`Ascii` reuses the RTU config verbatim; its only difference from plain `Rtu` is wire framing — LRC checksum and `:`/CR LF delimiters instead of CRC and silence-delimited binary. `AsciiOverTcp` reuses the TCP config verbatim, the same framing swap applied to `RtuOverTcp`. Both `Ascii` and `AsciiOverTcp` inherit the RTU-family broadcast slave id 0 handling (MB-R-101–MB-R-103), unlike `Udp`.
 
 ### 6.7 Display resolution is one-way
 

--- a/docs/specs/modbus/requirements.md
+++ b/docs/specs/modbus/requirements.md
@@ -135,9 +135,9 @@ behavior, stated limitations).
 
 **MB-R-049** — Receiving the terminate command, or the command channel closing, shall disconnect the client, end its task with success, and emit a client- disconnected status.
 
-**MB-R-101** — On the RTU or RtuOverTcp transport, a poll operation addressed to slave id 0 (the broadcast address) shall fail locally without reaching the wire. The client shall treat that failure as a Modbus exception per MB-R-043 — retried, then skipped after 3 consecutive occurrences — and shall not disconnect.
+**MB-R-101** — On the RTU, RtuOverTcp, Ascii, or AsciiOverTcp transport, a poll operation addressed to slave id 0 (the broadcast address) shall fail locally without reaching the wire. The client shall treat that failure as a Modbus exception per MB-R-043 — retried, then skipped after 3 consecutive occurrences — and shall not disconnect.
 
-**MB-R-102** — On the RTU or RtuOverTcp transport, a write command addressed to slave id 0 shall be transmitted without awaiting a response, logged as executed, and shall not disconnect the client.
+**MB-R-102** — On the RTU, RtuOverTcp, Ascii, or AsciiOverTcp transport, a write command addressed to slave id 0 shall be transmitted without awaiting a response, logged as executed, and shall not disconnect the client.
 
 ---
 
@@ -179,11 +179,11 @@ behavior, stated limitations).
 
 **MB-R-065** — A server shall serve any slave id for which memory regions are declared; it shall not filter requests by a configured slave id.
 
-**MB-R-103** — An RTU or RtuOverTcp server shall apply an inbound request addressed to slave id 0 (the broadcast address) to the store exactly as it would any other request, but shall emit no response frame for it — including no exception response.
+**MB-R-103** — An RTU, RtuOverTcp, Ascii, or AsciiOverTcp server shall apply an inbound request addressed to slave id 0 (the broadcast address) to the store exactly as it would any other request, but shall emit no response frame for it — including no exception response.
 
 **MB-R-066** — A server shall log a "request received" line for every inbound request, including for rejected function codes.
 
-**MB-R-067** — A server shall additionally log the per-request outcome (success or failure), for TCP, RTU, and RtuOverTcp alike.
+**MB-R-067** — A server shall additionally log the per-request outcome (success or failure), for TCP, RTU, RtuOverTcp, Udp, Ascii, and AsciiOverTcp alike.
 
 ---
 
@@ -235,9 +235,31 @@ behavior, stated limitations).
 
 ---
 
+## Transport — Ascii
+
+**MB-R-121** — The Modbus transport config shall offer a fifth option, `Ascii` (config/CLI tag value `ascii`), carrying exactly the same connection parameters as the RTU option (`path`, `baud_rate`, `parity`, `data_bits`, `stop_bits`) — reusing `rtu::Config` verbatim, no separate struct.
+
+**MB-R-122** — An `Ascii` client shall open the serial port exactly as an RTU client (MB-R-072–MB-R-073 apply verbatim: `baud_rate`/`parity`/`data_bits`/`stop_bits` handling and defaults, validation of `data_bits`/`stop_bits`/`parity`), but requests and responses on it shall use Modbus ASCII framing — `:` start character, hexadecimal-encoded PDU bytes, LRC checksum, CR LF terminator — instead of RTU binary framing.
+
+**MB-R-123** — An `Ascii` server shall open the serial port once and serve it as a single persistent point-to-point connection, with no accept loop (as MB-R-074), using ASCII framing for its requests and responses.
+
+**MB-R-124** — Failure to open the serial port for `Ascii` shall be handled exactly as MB-R-075: it shall fail the server's start with a serial error, and for a client it shall be treated as a failed connection attempt, subject to the reconnect rules (MB-R-050–MB-R-055).
+
+---
+
+## Transport — AsciiOverTcp
+
+**MB-R-125** — The Modbus transport config shall offer a sixth option, `AsciiOverTcp` (config/CLI tag value `ascii_over_tcp`), carrying exactly the same connection parameters as the TCP option (`ip`, `port`, `timeout_ms`, `delay_ms`, `interval_ms`, `reconnect`, `tls`) and no RTU/ASCII serial parameters (`baud_rate`, `parity`, `data_bits`, `stop_bits`).
+
+**MB-R-126** — An `AsciiOverTcp` connection shall be established exactly as a TCP connection (MB-R-068–MB-R-071 apply verbatim: `ip:port` connect/bind bounded by `timeout_ms`, address-parse failure, accept loop, bind failure), but requests and responses on it shall use Modbus ASCII framing (`:` start, hex-encoded PDU, LRC checksum, CR LF terminator) instead of Modbus TCP or RTU framing.
+
+**MB-R-127** — TLS (MB-R-104–MB-R-111) shall apply to an `AsciiOverTcp` connection exactly as it does to a Modbus-TCP-framed or `RtuOverTcp` one: the same `tls` field, certificate resolution, self-signed fallback, mTLS rules, and handshake-failure logging, with only the post-handshake framing differing.
+
+---
+
 ## Module lifecycle and device configuration
 
-**MB-R-076** — Each Modbus module instance shall be either a client or a server (never both), over TCP, RTU, RtuOverTcp, or Udp, and shall own one shared register store, one register set, and one log.
+**MB-R-076** — Each Modbus module instance shall be either a client or a server (never both), over TCP, RTU, RtuOverTcp, Udp, Ascii, or AsciiOverTcp, and shall own one shared register store, one register set, and one log.
 
 **MB-R-077** — A module's register store shall be built from its device config's register definitions: each fixed-address register shall declare the range `[address, address + format width)` under the key (slave id, kind).
 

--- a/ferrowl-modbus/src/ascii/client.rs
+++ b/ferrowl-modbus/src/ascii/client.rs
@@ -1,0 +1,107 @@
+use crate::client_core::{ClientCore, ConnectAttempt};
+use crate::common::serial_config_from;
+use crate::rtu::Config;
+use crate::{Command, Error, Key, KeyParams, LogFn, Operation, SerialError};
+
+use ferrowl_store::Memory;
+use parking_lot::RwLock as MemLock;
+use tokio::task::JoinHandle;
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc::Receiver;
+
+use rust_modbus::{Ascii, Client as ModbusClient, FrameTransport, SerialStream, open_serial};
+
+/// Builds and spawns a Modbus ASCII client task that polls `operations` into
+/// the shared `memory` and executes incoming [`Command`]s.
+pub struct ClientBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    operations: Arc<RwLock<Vec<Operation>>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ClientBuilder<T> {
+    pub fn new(
+        config: Arc<RwLock<Config>>,
+        operations: Arc<RwLock<Vec<Operation>>>,
+        memory: Arc<MemLock<Memory<Key<T>>>>,
+    ) -> Self {
+        Self {
+            config,
+            operations,
+            memory,
+        }
+    }
+
+    /// Opens the serial port and spawns the client loop as a tokio task. `log` receives log
+    /// lines, `status` receives connection status updates, and `receiver` delivers
+    /// write/terminate [`Command`]s.
+    ///
+    /// With `config.reconnect` set (the default), a lost or unopenable port does not end the
+    /// task: it logs, waits an exponential backoff (capped, reset after a run that got at least
+    /// one read through), and retries. `Command::Terminate` (or the channel closing) aborts a
+    /// backoff wait immediately. With `config.reconnect` unset, a transport error ends the task
+    /// exactly as before this behavior was added.
+    pub async fn spawn<L, S>(
+        &self,
+        receiver: Receiver<Command>,
+        log: L,
+        status: S,
+    ) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+        S: LogFn + Clone,
+    {
+        let config = self.config.clone();
+        let operations = self.operations.clone();
+        let memory = self.memory.clone();
+        Ok(tokio::task::spawn(async move {
+            ClientCore::run_reconnect_loop(receiver, log, status, operations, memory, move || {
+                let config = config.clone();
+                async move {
+                    let guard = config.read().await;
+                    let attempt = ConnectAttempt {
+                        reconnect: guard.reconnect,
+                        timeout_ms: guard.timeout_ms,
+                        delay_ms: guard.delay_ms,
+                        interval_ms: guard.interval_ms,
+                        client: Client::connect(&guard).await.map(|client| client.core),
+                    };
+                    drop(guard);
+                    attempt
+                }
+            })
+            .await
+        }))
+    }
+}
+
+/// A connected Modbus ASCII client. Connection setup is serial-specific; the read/command loop
+/// is shared via the internal `ClientCore`, over a serial port carrying ASCII framing.
+pub struct Client {
+    pub(crate) core: ClientCore<FrameTransport<SerialStream, Ascii>, Ascii>,
+}
+
+impl Client {
+    /// Opens the configured serial port under ASCII framing (MB-R-122).
+    ///
+    /// The port is not bound to a slave address: each request carries the slave id of the
+    /// operation or command that issued it (MB-R-048).
+    pub async fn connect(config: &Config) -> Result<Self, Error> {
+        let serial = serial_config_from(
+            config.baud_rate,
+            config.data_bits,
+            config.stop_bits,
+            config.parity.as_deref(),
+        )?;
+        match open_serial::<Ascii>(&config.path, serial) {
+            Ok(transport) => Ok(Self {
+                core: ClientCore {
+                    client: ModbusClient::new(transport),
+                },
+            }),
+            Err(e) => Err(SerialError::Error(e).into()),
+        }
+    }
+}

--- a/ferrowl-modbus/src/ascii/mod.rs
+++ b/ferrowl-modbus/src/ascii/mod.rs
@@ -1,0 +1,9 @@
+//! Modbus ASCII (serial) client and server: `:` start character, hexadecimal-encoded PDU,
+//! LRC checksum, CR LF terminator (MB-R-121..MB-R-124). Reuses `rtu::Config` verbatim — same
+//! serial connect/open behavior as RTU (MB-R-072/073), differing only in on-wire framing.
+
+mod client;
+mod server;
+
+pub use client::{Client, ClientBuilder};
+pub use server::ServerBuilder;

--- a/ferrowl-modbus/src/ascii/server.rs
+++ b/ferrowl-modbus/src/ascii/server.rs
@@ -1,0 +1,83 @@
+// Crate
+use crate::common::serial_config_from;
+use crate::rtu::Config;
+use crate::server_core::Server;
+use crate::{Error, Key, KeyParams, LogFn, SerialError};
+
+// Workspace
+use ferrowl_store::Memory;
+
+// External
+use parking_lot::RwLock as MemLock;
+use rust_modbus::{Ascii, Server as ModbusServer, open_serial};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+/// Builds and spawns a Modbus ASCII server task answering requests from the
+/// shared `memory`.
+pub struct ServerBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ServerBuilder<T> {
+    pub fn new(config: Arc<RwLock<Config>>, memory: Arc<MemLock<Memory<Key<T>>>>) -> Self {
+        Self { config, memory }
+    }
+
+    /// Opens the configured serial port and spawns the serve loop as a
+    /// tokio task. `log` receives log lines.
+    pub async fn spawn<L>(&self, log: L) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+    {
+        let guard = self.config.read().await;
+        run(&guard, self.memory.clone(), log).await
+    }
+}
+
+/// Every production server logs per-request outcomes (MB-R-067); Ascii is no exception.
+const VERBOSE: bool = true;
+
+/// Open the configured serial port and spawn the Ascii serve loop, answering from the shared
+/// `memory` via a [`Server`] (verbose logging on, MB-R-067).
+async fn run<T, L>(
+    config: &Config,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+    log: L,
+) -> Result<JoinHandle<Result<(), Error>>, Error>
+where
+    T: KeyParams,
+    L: LogFn + Clone,
+{
+    let serial = serial_config_from(
+        config.baud_rate,
+        config.data_bits,
+        config.stop_bits,
+        config.parity.as_deref(),
+    )?;
+    match open_serial::<Ascii>(&config.path, serial) {
+        Ok(transport) => {
+            let server = ModbusServer::new(Server::new(memory, log, VERBOSE));
+            // One port, one link, no accept loop (MB-R-123). The default `ServerConfig` filters
+            // by no unit id, so every slave id with declared regions is served (MB-R-065).
+            Ok(tokio::task::spawn(async move {
+                server.serve_link(transport).await.map_err(Error::Server)
+            }))
+        }
+        Err(e) => Err(SerialError::Error(e).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the Ascii server logs per-request outcomes exactly like every
+    /// other transport.
+    #[test]
+    fn ut_ascii_server_is_verbose() {
+        assert!(VERBOSE);
+    }
+}

--- a/ferrowl-modbus/src/ascii_over_tcp/client.rs
+++ b/ferrowl-modbus/src/ascii_over_tcp/client.rs
@@ -1,0 +1,128 @@
+use crate::client_core::{ClientCore, ConnectAttempt};
+use crate::tcp::Config;
+use crate::tcp::tls::{ClientStream, build_client_tls_config};
+use crate::{Command, Error, Key, KeyParams, LogFn, Operation, TcpError};
+
+use ferrowl_store::Memory;
+use parking_lot::RwLock as MemLock;
+use rust_modbus::{
+    Ascii, Client as ModbusClient, FrameTransport, TcpConfig, connect_tcp_framed,
+    connect_tls_framed,
+};
+use tokio::task::JoinHandle;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc::Receiver;
+
+/// Builds and spawns a Modbus ASCII-over-TCP client task that polls `operations` into
+/// the shared `memory` and executes incoming [`Command`]s.
+pub struct ClientBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    operations: Arc<RwLock<Vec<Operation>>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ClientBuilder<T> {
+    pub fn new(
+        config: Arc<RwLock<Config>>,
+        operations: Arc<RwLock<Vec<Operation>>>,
+        memory: Arc<MemLock<Memory<Key<T>>>>,
+    ) -> Self {
+        Self {
+            config,
+            operations,
+            memory,
+        }
+    }
+
+    /// Connects to the configured endpoint and spawns the client loop as a tokio task. `log`
+    /// receives log lines, `status` receives connection status updates, and `receiver` delivers
+    /// write/terminate [`Command`]s.
+    ///
+    /// With `config.reconnect` set (the default), a lost or refused connection does not end the
+    /// task: it logs, waits an exponential backoff (capped, reset after a run that got at least
+    /// one read through), and reconnects. `Command::Terminate` (or the channel closing) aborts a
+    /// backoff wait immediately. With `config.reconnect` unset, a transport error ends the task
+    /// exactly as before this behavior was added.
+    pub async fn spawn<L, S>(
+        &self,
+        receiver: Receiver<Command>,
+        log: L,
+        status: S,
+    ) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+        S: LogFn + Clone,
+    {
+        let config = self.config.clone();
+        let operations = self.operations.clone();
+        let memory = self.memory.clone();
+        Ok(tokio::task::spawn(async move {
+            ClientCore::run_reconnect_loop(receiver, log, status, operations, memory, move || {
+                let config = config.clone();
+                async move {
+                    let guard = config.read().await;
+                    let attempt = ConnectAttempt {
+                        reconnect: guard.reconnect,
+                        timeout_ms: guard.timeout_ms,
+                        delay_ms: guard.delay_ms,
+                        interval_ms: guard.interval_ms,
+                        client: Client::connect(&guard).await.map(|client| client.core),
+                    };
+                    drop(guard);
+                    attempt
+                }
+            })
+            .await
+        }))
+    }
+}
+
+/// A connected Modbus ASCII-over-TCP client. Connection setup mirrors plain TCP/RtuOverTcp
+/// (MB-R-125/126); the read/command loop is shared via the internal `ClientCore`, over a socket
+/// carrying ASCII framing.
+pub struct Client {
+    pub(crate) core: ClientCore<FrameTransport<ClientStream, Ascii>, Ascii>,
+}
+
+impl Client {
+    /// Opens a TCP connection to `config.ip:config.port`, bounded by the
+    /// configured timeout. Plain TCP unless `config.tls` is set (MB-R-127), in which
+    /// case the same timeout bounds the TCP connect and the TLS handshake together.
+    pub async fn connect(config: &Config) -> Result<Self, Error> {
+        let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
+            .parse()
+            .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
+        let tls_config = config
+            .tls
+            .as_ref()
+            .map(build_client_tls_config)
+            .transpose()?;
+        let attempt = async {
+            match tls_config {
+                None => connect_tcp_framed::<Ascii>(addr, TcpConfig::default())
+                    .await
+                    .map(|t| ClientStream::Plain(t.into_inner())),
+                Some(tls) => connect_tls_framed::<Ascii>(addr, TcpConfig::default(), tls)
+                    .await
+                    .map(|t| ClientStream::Tls(Box::new(t.into_inner()))),
+            }
+        };
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(config.timeout_ms as u64),
+            attempt,
+        )
+        .await
+        {
+            Ok(Ok(stream)) => Ok(Self {
+                core: ClientCore {
+                    client: ModbusClient::<_, _>::new(FrameTransport::new(stream)),
+                },
+            }),
+            Ok(Err(e)) => Err(TcpError::Error(e).into()),
+            Err(e) => Err(TcpError::Timeout(e).into()),
+        }
+    }
+}

--- a/ferrowl-modbus/src/ascii_over_tcp/mod.rs
+++ b/ferrowl-modbus/src/ascii_over_tcp/mod.rs
@@ -1,0 +1,14 @@
+//! Modbus ASCII-over-TCP: ASCII framing carried over a TCP socket (MB-R-125..MB-R-127).
+//! Reuses `tcp::Config` verbatim — same connect/bind/TLS behavior as plain TCP and
+//! RtuOverTcp, differing only in on-wire framing (Modbus ASCII: `:` start, hex PDU, LRC,
+//! CR LF terminator). Unlike RTU, ASCII framing is self-delimiting (`:`/CR LF), so it needs
+//! no distinct "-over-stream" framing marker the way RTU needs `RtuOverTcp` — this module
+//! uses rust_modbus's `Ascii` framing type directly, the same one the `ascii` (serial)
+//! module uses, over `connect_tcp_framed::<Ascii>` / `serve_framed::<Ascii>` /
+//! `serve_tls::<Ascii>` instead of `open_serial::<Ascii>`.
+
+mod client;
+mod server;
+
+pub use client::{Client, ClientBuilder};
+pub use server::ServerBuilder;

--- a/ferrowl-modbus/src/ascii_over_tcp/server.rs
+++ b/ferrowl-modbus/src/ascii_over_tcp/server.rs
@@ -1,0 +1,108 @@
+// Crate
+use crate::server_core::Server;
+use crate::tcp::Config;
+use crate::tcp::tls::build_server_tls_config;
+use crate::{Error, Key, KeyParams, LogFn, TcpError};
+
+// Workspace
+use ferrowl_store::Memory;
+
+// External
+use parking_lot::RwLock as MemLock;
+use rust_modbus::{Server as ModbusServer, TcpListener, TlsListener};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+/// Builds and spawns a Modbus ASCII-over-TCP server task answering requests from the
+/// shared `memory`.
+pub struct ServerBuilder<T: KeyParams> {
+    config: Arc<RwLock<Config>>,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+}
+
+impl<T: KeyParams> ServerBuilder<T> {
+    pub fn new(config: Arc<RwLock<Config>>, memory: Arc<MemLock<Memory<Key<T>>>>) -> Self {
+        Self { config, memory }
+    }
+
+    /// Binds the configured listen address and spawns the accept loop as a
+    /// tokio task. `log` receives log lines.
+    pub async fn spawn<L>(&self, log: L) -> Result<JoinHandle<Result<(), Error>>, Error>
+    where
+        L: LogFn + Clone,
+    {
+        let guard = self.config.read().await;
+        run(&guard, self.memory.clone(), log).await
+    }
+}
+
+/// Every production server logs per-request outcomes (MB-R-067); AsciiOverTcp is no
+/// exception.
+const VERBOSE: bool = true;
+
+/// Bind the configured TCP address and spawn the accept loop; each accepted connection answers
+/// from the shared `memory` via a [`Server`] using ASCII framing (MB-R-126), verbose logging on
+/// (MB-R-067). Plain TCP unless `config.tls` is set (MB-R-127), in which case the listener
+/// terminates TLS on each accepted connection.
+async fn run<T, L>(
+    config: &Config,
+    memory: Arc<MemLock<Memory<Key<T>>>>,
+    log: L,
+) -> Result<JoinHandle<Result<(), Error>>, Error>
+where
+    T: KeyParams,
+    L: LogFn + Clone,
+{
+    let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
+        .parse()
+        .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
+    // One service instance answers every accepted connection, so all of them share the
+    // one store (MB-R-070). Every server logs per-request outcomes (verbose = true, MB-R-067).
+    let server = ModbusServer::new(Server::new(memory, log.clone(), VERBOSE));
+    match &config.tls {
+        None => match TcpListener::bind(addr).await {
+            Ok(listener) => Ok(tokio::task::spawn(async move {
+                server
+                    .serve_framed::<rust_modbus::Ascii>(listener)
+                    .await
+                    .map_err(Error::Server)
+            })),
+            Err(e) => Err(Error::Server(e)),
+        },
+        Some(tls) => {
+            let (tls_config, used_fallback) =
+                build_server_tls_config(tls, &config.ip).map_err(Error::Tcp)?;
+            if used_fallback {
+                log.invoke(
+                    "No cert_file/key_file/self_signed configured for this TLS \
+                     server; falling back to an ephemeral self-signed certificate."
+                        .to_string(),
+                )
+                .await;
+            }
+            match TlsListener::bind(addr, tls_config).await {
+                Ok(listener) => Ok(tokio::task::spawn(async move {
+                    server
+                        .serve_tls::<rust_modbus::Ascii>(listener)
+                        .await
+                        .map_err(Error::Server)
+                })),
+                Err(e) => Err(Error::Server(e)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the AsciiOverTcp server logs per-request outcomes exactly like every other
+    /// transport (RTU, RTU-over-TCP, TCP, Ascii alike now).
+    #[test]
+    fn ut_ascii_over_tcp_server_is_verbose() {
+        assert!(VERBOSE);
+    }
+}

--- a/ferrowl-modbus/src/lib.rs
+++ b/ferrowl-modbus/src/lib.rs
@@ -8,6 +8,7 @@
 //! parameterized over [`KeyParams`] (default: [`SlaveKey`]).
 
 pub mod ascii;
+pub mod ascii_over_tcp;
 mod client_core;
 mod command;
 mod common;

--- a/ferrowl-modbus/src/lib.rs
+++ b/ferrowl-modbus/src/lib.rs
@@ -7,6 +7,7 @@
 //! incoming requests directly from memory. Memory is keyed by [`Key`]
 //! parameterized over [`KeyParams`] (default: [`SlaveKey`]).
 
+pub mod ascii;
 mod client_core;
 mod command;
 mod common;

--- a/ferrowl-modbus/src/tcp/server.rs
+++ b/ferrowl-modbus/src/tcp/server.rs
@@ -38,9 +38,13 @@ impl<T: KeyParams> ServerBuilder<T> {
     }
 }
 
+/// Every production server logs per-request outcomes (MB-R-067); TCP is no exception.
+const VERBOSE: bool = true;
+
 /// Bind the configured TCP address and spawn the accept loop; each accepted connection answers from
-/// the shared `memory` via a [`Server`] (verbose logging on). Plain TCP unless `config.tls` is set
-/// (MB-R-104), in which case the listener terminates TLS on each accepted connection.
+/// the shared `memory` via a [`Server`] (verbose logging on, MB-R-067). Plain TCP unless
+/// `config.tls` is set (MB-R-104), in which case the listener terminates TLS on each accepted
+/// connection.
 async fn run<T, L>(
     config: &Config,
     memory: Arc<MemLock<Memory<Key<T>>>>,
@@ -54,8 +58,8 @@ where
         .parse()
         .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
     // One service instance answers every accepted connection, so all of them share the
-    // one store (MB-R-070). TCP servers log per-request outcomes (verbose = true).
-    let server = ModbusServer::new(Server::new(memory, log.clone(), true));
+    // one store (MB-R-070). Every server logs per-request outcomes (verbose = true, MB-R-067).
+    let server = ModbusServer::new(Server::new(memory, log.clone(), VERBOSE));
     match &config.tls {
         None => match TcpListener::bind(addr).await {
             Ok(listener) => Ok(tokio::task::spawn(async move {
@@ -84,5 +88,16 @@ where
                 Err(e) => Err(Error::Server(e)),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the TCP server logs per-request outcomes exactly like every other transport.
+    #[test]
+    fn ut_tcp_server_is_verbose() {
+        assert!(VERBOSE);
     }
 }

--- a/ferrowl-modbus/src/transport.rs
+++ b/ferrowl-modbus/src/transport.rs
@@ -1,4 +1,5 @@
-//! Transport selection between TCP, RTU, and RtuOverTcp connection settings.
+//! Transport selection between TCP, RTU, RtuOverTcp, Udp, Ascii, and AsciiOverTcp connection
+//! settings.
 
 use crate::{rtu, tcp, udp};
 
@@ -13,6 +14,12 @@ pub enum Transport {
     /// MB-R-116 — same field set as `Tcp` minus `tls`; its own `udp::Config` type, not a
     /// reuse of `tcp::Config` (unlike `RtuOverTcp`).
     Udp(udp::Config),
+    /// ASCII framing over a serial line (MB-R-121); carries exactly the same connection
+    /// parameters as `Rtu` — no separate config type.
+    Ascii(rtu::Config),
+    /// ASCII framing carried over a TCP socket (MB-R-125); carries exactly the same
+    /// connection parameters as `Tcp`/`RtuOverTcp` — no separate config type.
+    AsciiOverTcp(tcp::Config),
 }
 
 #[cfg(test)]
@@ -35,5 +42,24 @@ mod tests {
     fn ut_udp_variant_carries_udp_config() {
         let cfg = crate::udp::Config::default();
         let _: Transport = Transport::Udp(cfg);
+    }
+
+    /// MB-R-121 — `Ascii` carries exactly a `rtu::Config`, the same type (and so the same
+    /// fields) the `Rtu` variant carries — no separate struct.
+    #[test]
+    fn ut_ascii_variant_carries_rtu_config() {
+        let cfg = crate::rtu::Config::default();
+        let _: Transport = Transport::Ascii(cfg.clone());
+        // Compiles iff both variants take the identical `rtu::Config` type.
+        let _: Transport = Transport::Rtu(cfg);
+    }
+
+    /// MB-R-125 — `AsciiOverTcp` carries exactly a `tcp::Config`, the same type `Tcp` and
+    /// `RtuOverTcp` carry — no separate struct.
+    #[test]
+    fn ut_ascii_over_tcp_variant_carries_tcp_config() {
+        let cfg = crate::tcp::Config::default();
+        let _: Transport = Transport::AsciiOverTcp(cfg.clone());
+        let _: Transport = Transport::Tcp(cfg);
     }
 }

--- a/ferrowl-modbus/src/udp/server.rs
+++ b/ferrowl-modbus/src/udp/server.rs
@@ -34,9 +34,13 @@ impl<T: KeyParams> ServerBuilder<T> {
     }
 }
 
+/// Every production server logs per-request outcomes (MB-R-067); UDP is no exception.
+const VERBOSE: bool = true;
+
 /// Bind the configured UDP address and spawn `serve_udp` (MB-R-119); each datagram answers
-/// from the shared `memory` via a [`Server`] (verbose logging on, mirroring the TCP server).
-/// No accept loop, no TLS branch (MB-R-116 — `udp::Config` carries no `tls` field at all).
+/// from the shared `memory` via a [`Server`] (verbose logging on, MB-R-067, mirroring the TCP
+/// server). No accept loop, no TLS branch (MB-R-116 — `udp::Config` carries no `tls` field at
+/// all).
 async fn run<T, L>(
     config: &Config,
     memory: Arc<MemLock<Memory<Key<T>>>>,
@@ -49,12 +53,23 @@ where
     let addr: SocketAddr = format!("{}:{}", config.ip, config.port)
         .parse()
         .map_err(|e| Error::Tcp(TcpError::Address(e)))?;
-    let server = ModbusServer::new(Server::new(memory, log.clone(), true));
+    let server = ModbusServer::new(Server::new(memory, log.clone(), VERBOSE));
     match UdpSocket::bind(addr).await {
         Ok(socket) => Ok(tokio::task::spawn(async move {
             server.serve_udp(socket).await.map_err(Error::Server)
         })),
         // MB-R-120 — a bind failure surfaces as an error from `spawn`, not retried.
         Err(e) => Err(Error::Server(e.into())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VERBOSE;
+
+    /// MB-R-067 — the UDP server logs per-request outcomes exactly like every other transport.
+    #[test]
+    fn ut_udp_server_is_verbose() {
+        assert!(VERBOSE);
     }
 }

--- a/ferrowl-modbus/tests/ascii_over_tcp_loopback.rs
+++ b/ferrowl-modbus/tests/ascii_over_tcp_loopback.rs
@@ -1,0 +1,499 @@
+//! End-to-end ASCII-over-TCP test: a ferrowl Modbus server and client speak Modbus ASCII
+//! framing (`:` start, hex-encoded PDU, LRC checksum, CR LF terminator) over a loopback TCP
+//! socket. Reuses `tcp::Config` for connection settings (MB-R-125) — only the on-wire framing
+//! differs from plain TCP. Mirrors `rtu_over_tcp_loopback.rs`.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrowl_codec::Kind as RegKind;
+use ferrowl_modbus::tcp;
+use ferrowl_modbus::{Address, Command, FunctionCode, Key, Operation, SlaveKey, UnitId, Word};
+use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKey> {
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
+}
+
+/// A no-op log/status sink. `LogFn + Clone` is satisfied by a capture-free closure.
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+/// An OS-assigned free TCP port (bind to :0, read the port, drop the listener).
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn config(port: u16) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: None,
+    }
+}
+
+/// Server memory seeded with distinct values in all four register tables.
+fn server_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::Coil),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 8)],
+    );
+    mem.write(
+        key(RegKind::Coil),
+        &CellType::Coil,
+        &Range::new(0, 4),
+        &[1, 0, 1, 0],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::DiscreteInput),
+        &CellType::Coil,
+        &Range::new(0, 4),
+        &[0, 1, 1, 0],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::InputRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[100, 200, 300, 400],
+    )
+    .unwrap();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 8)],
+    );
+    mem.write(
+        key(RegKind::HoldingRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[10, 20, 30, 40],
+    )
+    .unwrap();
+    Arc::new(MemLock::new(mem))
+}
+
+/// Client memory with the same regions declared but no values (the client fills them from reads).
+fn client_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::Coil),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 8)],
+    );
+    mem.add_ranges(
+        key(RegKind::DiscreteInput),
+        &MemKind::ReadWrite(CellType::Coil),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::InputRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 8)],
+    );
+    Arc::new(MemLock::new(mem))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-126 — ASCII-over-TCP carries the same client/server behavior as plain TCP (polling
+/// every read operation into the shared store, MB-R-035, executing write commands, MB-R-046,
+/// and terminating gracefully, MB-R-049), differing only in on-wire framing.
+async fn ascii_over_tcp_client_polls_server_and_executes_commands() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // Start the server.
+    let server = ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem.clone(),
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    // Operations cover every read function code the client supports.
+    let operations = Arc::new(RwLock::new(vec![
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadCoils,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadDiscreteInputs,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadInputRegisters,
+            range: Range::new(0, 4),
+        },
+        Operation {
+            slave_id: UnitId(1),
+            fn_code: FunctionCode::ReadHoldingRegisters,
+            range: Range::new(0, 4),
+        },
+    ]));
+
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::ascii_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Let the client poll every operation at least once.
+    sleep(Duration::from_millis(800)).await;
+
+    {
+        let g = cli_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![10, 20, 30, 40]
+        );
+        assert_eq!(
+            g.read(
+                key(RegKind::InputRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![100, 200, 300, 400]
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(0, 4))
+                .unwrap(),
+            vec![1, 0, 1, 0]
+        );
+        assert_eq!(
+            g.read(
+                key(RegKind::DiscreteInput),
+                &CellType::Coil,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![0, 1, 1, 0]
+        );
+    }
+
+    // Exercise every write command against the server.
+    tx.send(Command::WriteSingleRegister(
+        UnitId(1),
+        Address(0),
+        Word(99),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteMultipleRegister(
+        UnitId(1),
+        Address(1),
+        vec![5, 6].into_iter().map(Word).collect(),
+    ))
+    .await
+    .unwrap();
+    tx.send(Command::WriteSingleCoil(UnitId(1), Address(5), true))
+        .await
+        .unwrap();
+    tx.send(Command::WriteMultipleCoils(
+        UnitId(1),
+        Address(6),
+        vec![true, false],
+    ))
+    .await
+    .unwrap();
+    sleep(Duration::from_millis(600)).await;
+
+    {
+        let g = srv_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 3)
+            )
+            .unwrap(),
+            vec![99, 5, 6]
+        );
+        assert_eq!(
+            g.read(key(RegKind::Coil), &CellType::Coil, &Range::new(5, 3))
+                .unwrap(),
+            vec![1, 1, 0]
+        );
+    }
+
+    // Graceful termination returns Ok and ends the client task.
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-126, MB-R-069 — an `ip`/`port` pair that does not parse as a socket address fails with a
+/// TCP address error, for both the AsciiOverTcp client and the server, same as plain TCP.
+async fn ascii_over_tcp_unparseable_address_is_error() {
+    use ferrowl_modbus::{Error, TcpError};
+
+    let mut bad = config(502);
+    bad.ip = "not.an.ip.address".to_string();
+
+    // Client side (`Client` isn't `Debug`, so match the result rather than `unwrap_err`).
+    assert!(matches!(
+        ferrowl_modbus::ascii_over_tcp::Client::connect(&bad).await,
+        Err(Error::Tcp(TcpError::Address(_)))
+    ));
+
+    // Server side.
+    let mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let server_err =
+        ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(Arc::new(RwLock::new(bad)), mem)
+            .spawn(sink())
+            .await
+            .unwrap_err();
+    assert!(matches!(server_err, Error::Tcp(TcpError::Address(_))));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-126, MB-R-071 — failure to bind the AsciiOverTcp listen address fails the server's start
+/// and surfaces the error, same as plain TCP.
+async fn ascii_over_tcp_server_bind_conflict_is_error() {
+    let port = free_port();
+    // Occupy the port so the server's bind fails.
+    let _occupier = std::net::TcpListener::bind(("127.0.0.1", port)).unwrap();
+    let mem: Mem = Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()));
+    let res = ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        mem,
+    )
+    .spawn(sink())
+    .await;
+    assert!(res.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-101 — over AsciiOverTcp framing (which shares the RTU/Ascii-family broadcast address), a
+/// read addressed to slave id 0 is skipped by the client without disconnecting: the client_core
+/// mechanism is framing-generic (`F::is_broadcast`), so this proves the wiring carries the
+/// broadcast behavior over the AsciiOverTcp transport end-to-end.
+async fn ascii_over_tcp_client_skips_broadcast_poll_without_disconnect() {
+    let port = free_port();
+    let srv_mem = server_mem();
+
+    let server = ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem,
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    // Slave id 0 is the broadcast address: no server answers a read addressed to it.
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: UnitId(0),
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::ascii_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        client_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    // Several poll cycles at a broadcast address that never gets a response.
+    sleep(Duration::from_millis(600)).await;
+
+    // The client is still alive and responsive to Terminate: the broadcast poll never
+    // disconnected it.
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-102 — over AsciiOverTcp framing, a write addressed to slave id 0 (broadcast) is
+/// transmitted fire-and-forget: the server applies it (MB-R-103) without the client waiting for
+/// (or the server sending) a response.
+async fn ascii_over_tcp_client_fire_and_forget_broadcast_write() {
+    let port = free_port();
+    let mut srv_mem_raw = Memory::<Key<SlaveKey>>::default();
+    let broadcast_key = Key::new(SlaveKey {
+        slave_id: UnitId(0),
+        kind: RegKind::HoldingRegister,
+    });
+    srv_mem_raw.add_ranges(
+        broadcast_key.clone(),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let srv_mem: Mem = Arc::new(MemLock::new(srv_mem_raw));
+
+    let server = ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem.clone(),
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    let operations = Arc::new(RwLock::new(vec![]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ferrowl_modbus::ascii_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        operations,
+        client_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    tx.send(Command::WriteSingleRegister(
+        UnitId(0),
+        Address(1),
+        Word(0x1234),
+    ))
+    .await
+    .unwrap();
+    sleep(Duration::from_millis(300)).await;
+
+    // MB-R-103: the store took the broadcast write even though nothing answered it.
+    {
+        let g = srv_mem.read();
+        assert_eq!(
+            g.read(broadcast_key, &CellType::Register, &Range::new(1, 1))
+                .unwrap(),
+            vec![0x1234]
+        );
+    }
+
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-103 — a server never sends a response frame for a request addressed to slave id 0
+/// (broadcast), over AsciiOverTcp. Client-independent: uses a raw `rust_modbus::Client` directly
+/// against the real socket (bypassing ferrowl's own fire-and-forget client, which never even
+/// tries to read a response and so could not catch a server that wrongly sent one), then reads
+/// the raw bytes off the wire with a timeout and asserts nothing arrived.
+async fn ascii_over_tcp_server_sends_no_response_frame_for_broadcast_write() {
+    use rust_modbus::{
+        Address as RmAddress, Ascii, Client as RmClient, RegisterValue, TcpConfig,
+        connect_tcp_framed,
+    };
+    use tokio::io::AsyncReadExt;
+
+    let port = free_port();
+    let mut srv_mem_raw = Memory::<Key<SlaveKey>>::default();
+    let broadcast_key = Key::new(SlaveKey {
+        slave_id: UnitId(0),
+        kind: RegKind::HoldingRegister,
+    });
+    srv_mem_raw.add_ranges(
+        broadcast_key,
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    let srv_mem: Mem = Arc::new(MemLock::new(srv_mem_raw));
+
+    let server = ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port))),
+        srv_mem,
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    let transport = connect_tcp_framed::<Ascii>(addr, TcpConfig::default())
+        .await
+        .expect("raw client failed to connect");
+    let mut client: RmClient<_, Ascii> = RmClient::new(transport);
+
+    // Broadcast write: rust_modbus's own Client already knows (via `ClientFraming::is_broadcast`)
+    // not to wait for a response here, so this returns as soon as the frame is written.
+    client
+        .write_single_register(UnitId(0), RmAddress(1), RegisterValue(0x1234))
+        .await
+        .expect("broadcast write send failed");
+
+    // Reclaim the raw stream and read directly off the wire: if the server incorrectly sent a
+    // response frame anyway, it would be sitting here.
+    let mut stream = client.into_inner().into_inner();
+    let mut buf = [0u8; 64];
+    let read = tokio::time::timeout(Duration::from_millis(300), stream.read(&mut buf)).await;
+    match read {
+        Err(_) => {}    // Timed out waiting for bytes: no response frame arrived. Correct.
+        Ok(Ok(0)) => {} // Connection closed with no bytes sent: also no response frame. Correct.
+        Ok(Ok(n)) => panic!(
+            "server sent {n} unexpected byte(s) after a broadcast write: {:?}",
+            &buf[..n]
+        ),
+        Ok(Err(e)) => panic!("unexpected read error: {e}"),
+    }
+
+    server.abort();
+}

--- a/ferrowl-modbus/tests/ascii_over_tcp_tls.rs
+++ b/ferrowl-modbus/tests/ascii_over_tcp_tls.rs
@@ -1,0 +1,173 @@
+//! ASCII-over-TCP TLS tests (MB-R-127): the same TLS glue plain TCP/RtuOverTcp uses
+//! (MB-R-104..MB-R-111), reused verbatim under ASCII framing.
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+
+use ferrowl_codec::Kind as RegKind;
+use ferrowl_modbus::ascii_over_tcp;
+use ferrowl_modbus::tcp;
+use ferrowl_modbus::{Command, FunctionCode, Key, Operation, SlaveKey, UnitId};
+use ferrowl_store::{CellKind as MemKind, CellType, Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn key(kind: RegKind) -> Key<SlaveKey> {
+    Key::new(SlaveKey {
+        slave_id: UnitId(1),
+        kind,
+    })
+}
+
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn server_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    mem.write(
+        key(RegKind::HoldingRegister),
+        &CellType::Register,
+        &Range::new(0, 4),
+        &[10, 20, 30, 40],
+    )
+    .unwrap();
+    Arc::new(MemLock::new(mem))
+}
+
+fn client_mem() -> Mem {
+    let mut mem = Memory::<Key<SlaveKey>>::default();
+    mem.add_ranges(
+        key(RegKind::HoldingRegister),
+        &MemKind::ReadWrite(CellType::Register),
+        &[Range::new(0, 4)],
+    );
+    Arc::new(MemLock::new(mem))
+}
+
+fn config(port: u16, tls: tcp::ModbusTlsConfig) -> tcp::Config {
+    tcp::Config {
+        ip: "127.0.0.1".to_string(),
+        port,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect: true,
+        tls: Some(tls),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// MB-R-127 — an AsciiOverTcp client and server, both configured for TLS, complete the
+/// handshake and exchange Modbus ASCII-framed traffic over it, exactly as plain TCP/RtuOverTcp
+/// does.
+async fn ascii_over_tcp_client_server_tls_roundtrip() {
+    let port = free_port();
+    let srv_mem = server_mem();
+    let cli_mem = client_mem();
+
+    // Server: an ephemeral self-signed cert (`self_signed = true`, no cert_file/key_file).
+    let server_tls = tcp::ModbusTlsConfig {
+        self_signed: true,
+        ..Default::default()
+    };
+    let server = ascii_over_tcp::ServerBuilder::new(
+        Arc::new(RwLock::new(config(port, server_tls))),
+        srv_mem,
+    )
+    .spawn(sink())
+    .await
+    .expect("server failed to start");
+
+    // Client: trusts whatever certificate the server presents (this test is about the
+    // AsciiOverTcp handshake plumbing, not certificate validation, which MB-R-109's
+    // tcp_tls_client.rs tests already cover in depth).
+    let client_tls = tcp::ModbusTlsConfig {
+        insecure_skip_verify: true,
+        ..Default::default()
+    };
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: UnitId(1),
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 4),
+    }]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ascii_over_tcp::ClientBuilder::new(
+        Arc::new(RwLock::new(config(port, client_tls))),
+        operations,
+        cli_mem.clone(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("client failed to connect");
+
+    sleep(std::time::Duration::from_millis(800)).await;
+
+    {
+        let g = cli_mem.read();
+        assert_eq!(
+            g.read(
+                key(RegKind::HoldingRegister),
+                &CellType::Register,
+                &Range::new(0, 4)
+            )
+            .unwrap(),
+            vec![10, 20, 30, 40]
+        );
+    }
+
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(std::time::Duration::from_secs(5), client)
+        .await
+        .expect("client did not terminate in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+    server.abort();
+}
+
+#[tokio::test]
+/// MB-R-127 — a TLS-configured AsciiOverTcp client against a plain (non-TLS) listener fails the
+/// connect with a handshake error, same as plain TCP/RtuOverTcp (MB-R-111).
+async fn ascii_over_tcp_tls_handshake_failure_is_connect_failure() {
+    let plain_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let plain_addr = plain_listener.local_addr().unwrap();
+    let plain_server = tokio::spawn(async move {
+        loop {
+            if plain_listener.accept().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let handshake_cfg = config(
+        plain_addr.port(),
+        tcp::ModbusTlsConfig {
+            insecure_skip_verify: true,
+            ..Default::default()
+        },
+    );
+    let result = ascii_over_tcp::Client::connect(&handshake_cfg).await;
+    assert!(
+        result.is_err(),
+        "expected TLS handshake against a plain listener to fail"
+    );
+    plain_server.abort();
+}

--- a/ferrowl-modbus/tests/ascii_serial.rs
+++ b/ferrowl-modbus/tests/ascii_serial.rs
@@ -1,0 +1,111 @@
+//! ASCII (serial) transport tests. A real serial loopback needs hardware (or a named
+//! PTY the ASCII builders can open by path), which isn't portable in CI, so these cover
+//! the serial-open failure paths — which is where the ASCII-specific lifecycle behavior
+//! (open-once-at-start for the server, reconnect-on-open-failure for the client) is
+//! observable. Mirrors `rtu_serial.rs`; ASCII reuses `rtu::Config` verbatim (MB-R-121).
+
+// Integration-test crate: an unwrap that fails is the test failing, same as an assertion.
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ferrowl_modbus::rtu; // Config type only — MB-R-121 reuses it verbatim
+use ferrowl_modbus::{
+    Command, Error, FunctionCode, Key, Operation, SerialError, SlaveKey, UnitId, ascii,
+};
+use ferrowl_store::{Memory, Range};
+use parking_lot::RwLock as MemLock;
+use tokio::sync::{RwLock, mpsc};
+use tokio::time::sleep;
+
+type Mem = Arc<MemLock<Memory<Key<SlaveKey>>>>;
+
+fn sink() -> impl ferrowl_modbus::LogFn + Clone {
+    |_s: String| async move {}
+}
+
+fn empty_mem() -> Mem {
+    Arc::new(MemLock::new(Memory::<Key<SlaveKey>>::default()))
+}
+
+/// A serial path that cannot be opened, so `SerialStream::open` fails.
+fn bad_config(reconnect: bool) -> rtu::Config {
+    rtu::Config {
+        path: "/nonexistent/ferrowl-no-such-serial-port".to_string(),
+        baud_rate: 115200,
+        slave: 1,
+        parity: None,
+        data_bits: None,
+        stop_bits: None,
+        timeout_ms: 1000,
+        delay_ms: 0,
+        interval_ms: 0,
+        reconnect,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-124 — failure to open the serial port fails an Ascii server's start with a serial
+/// error, exactly as MB-R-075 for RTU. MB-R-123 — the Ascii server opens the port once at
+/// start (there is no accept loop deferring it), so an unopenable port surfaces at `spawn`
+/// rather than being retried per connection.
+async fn ascii_server_open_failure_fails_start() {
+    let res = ascii::ServerBuilder::new(Arc::new(RwLock::new(bad_config(false))), empty_mem())
+        .spawn(sink())
+        .await;
+    assert!(matches!(res, Err(Error::Serial(SerialError::Error(_)))));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-124 — for an Ascii client, a serial-open failure is a failed connection attempt; with
+/// reconnect disabled it ends the client task with the error, exactly as MB-R-075 for RTU.
+async fn ascii_client_open_failure_reconnect_false_dies() {
+    let operations = Arc::new(RwLock::new(vec![Operation {
+        slave_id: UnitId(1),
+        fn_code: FunctionCode::ReadHoldingRegisters,
+        range: Range::new(0, 2),
+    }]));
+    let (_tx, rx) = mpsc::channel::<Command>(16);
+    let client = ascii::ClientBuilder::new(
+        Arc::new(RwLock::new(bad_config(false))),
+        operations,
+        empty_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("spawn succeeds; the open error surfaces from the task");
+
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("client task did not finish in time")
+        .expect("client task panicked");
+    assert!(joined.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// MB-R-124 — for an Ascii client, a serial-open failure with reconnect enabled is subject to
+/// the reconnect rules: the task keeps retrying rather than dying, and Terminate ends it
+/// cleanly, exactly as MB-R-075 for RTU.
+async fn ascii_client_open_failure_reconnect_true_retries() {
+    let operations = Arc::new(RwLock::new(vec![]));
+    let (tx, rx) = mpsc::channel::<Command>(16);
+    let client = ascii::ClientBuilder::new(
+        Arc::new(RwLock::new(bad_config(true))),
+        operations,
+        empty_mem(),
+    )
+    .spawn(rx, sink(), sink())
+    .await
+    .expect("spawn succeeds");
+
+    // The open keeps failing; with reconnect on, the task must still be alive (backing off), not
+    // finished. Terminate then ends it with success.
+    sleep(Duration::from_millis(200)).await;
+    tx.send(Command::Terminate).await.unwrap();
+    let joined = tokio::time::timeout(Duration::from_secs(5), client)
+        .await
+        .expect("Terminate did not end the retrying client in time")
+        .expect("client task panicked");
+    assert!(joined.is_ok());
+}

--- a/ferrowl/src/cli/mod.rs
+++ b/ferrowl/src/cli/mod.rs
@@ -251,9 +251,24 @@ pub fn parse_module_spec(input: &str) -> Result<ModuleSpec, String> {
                 .parse()
                 .map_err(|_| "invalid 'port'")?,
         },
+        "ascii" => Endpoint::Ascii {
+            path: get("path").ok_or("ascii module requires 'path'")?,
+            baud_rate: parse_opt(get("baud").or_else(|| get("baud_rate")), "baud")?
+                .unwrap_or(19200),
+            parity: get("parity"),
+            data_bits: parse_opt(get("data_bits"), "data_bits")?,
+            stop_bits: parse_opt(get("stop_bits"), "stop_bits")?,
+        },
+        "ascii_over_tcp" => Endpoint::AsciiOverTcp {
+            ip: get("ip").unwrap_or_else(|| "127.0.0.1".to_string()),
+            port: get("port")
+                .ok_or("ascii_over_tcp module requires 'port'")?
+                .parse()
+                .map_err(|_| "invalid 'port'")?,
+        },
         other => {
             return Err(format!(
-                "invalid transport '{other}' (expected tcp|rtu|rtu_over_tcp|udp)"
+                "invalid transport '{other}' (expected tcp|rtu|rtu_over_tcp|udp|ascii|ascii_over_tcp)"
             ));
         }
     };
@@ -395,9 +410,48 @@ mod tests {
 
     #[test]
     /// CL-R-002 — an unknown `transport` value is still a parse error, listing all
-    /// four valid options.
+    /// six valid options.
     fn ut_parse_invalid_transport_still_errors() {
         assert!(parse_module_spec("name=m,device=d,transport=usb").is_err());
+    }
+
+    #[test]
+    /// CL-R-002 — a --module Ascii descriptor parses like RTU (same path/baud/parity/
+    /// data_bits/stop_bits keys), tagged `ascii`.
+    fn ut_parse_ascii_module() {
+        let spec = parse_module_spec(
+            "name=m,device=d.toml,transport=ascii,path=/dev/ttyUSB0,baud=9600,role=client",
+        )
+        .unwrap();
+        assert_eq!(spec.role, Role::Client);
+        assert_eq!(
+            spec.endpoint,
+            Endpoint::Ascii {
+                path: "/dev/ttyUSB0".into(),
+                baud_rate: 9600,
+                parity: None,
+                data_bits: None,
+                stop_bits: None
+            }
+        );
+    }
+
+    #[test]
+    /// CL-R-002 — a --module AsciiOverTcp descriptor parses like TCP (same ip/port keys),
+    /// tagged `ascii_over_tcp`.
+    fn ut_parse_ascii_over_tcp_module() {
+        let spec = parse_module_spec(
+            "name=m,device=d.toml,transport=ascii_over_tcp,ip=10.0.0.5,port=502,role=client",
+        )
+        .unwrap();
+        assert_eq!(spec.role, Role::Client);
+        assert_eq!(
+            spec.endpoint,
+            Endpoint::AsciiOverTcp {
+                ip: "10.0.0.5".into(),
+                port: 502
+            }
+        );
     }
 
     #[test]

--- a/ferrowl/src/instance/builder.rs
+++ b/ferrowl/src/instance/builder.rs
@@ -1,6 +1,6 @@
 //! Transport/role-specific builder held by an [`Instance`](crate::instance::Instance).
 
-use ferrowl_modbus::{KeyParams, rtu, rtu_over_tcp, tcp, udp};
+use ferrowl_modbus::{KeyParams, ascii, ascii_over_tcp, rtu, rtu_over_tcp, tcp, udp};
 
 /// The underlying ferrowl-modbus builder for each transport/role combination.
 pub enum Builder<T: KeyParams> {
@@ -12,4 +12,8 @@ pub enum Builder<T: KeyParams> {
     RtuOverTcpServer(rtu_over_tcp::ServerBuilder<T>),
     UdpClient(udp::ClientBuilder<T>),
     UdpServer(udp::ServerBuilder<T>),
+    AsciiClient(ascii::ClientBuilder<T>),
+    AsciiServer(ascii::ServerBuilder<T>),
+    AsciiOverTcpClient(ascii_over_tcp::ClientBuilder<T>),
+    AsciiOverTcpServer(ascii_over_tcp::ServerBuilder<T>),
 }

--- a/ferrowl/src/instance/mod.rs
+++ b/ferrowl/src/instance/mod.rs
@@ -115,6 +115,53 @@ impl<T: KeyParams> Instance<T> {
         }
     }
 
+    pub fn with_ascii_client(config: ClientConfig<T, ferrowl_modbus::rtu::Config>) -> Self {
+        Self {
+            builder: Builder::AsciiClient(ferrowl_modbus::ascii::ClientBuilder::new(
+                config.config,
+                config.operations,
+                config.memory,
+            )),
+            handle: None,
+        }
+    }
+
+    pub fn with_ascii_server(config: ServerConfig<T, ferrowl_modbus::rtu::Config>) -> Self {
+        Self {
+            builder: Builder::AsciiServer(ferrowl_modbus::ascii::ServerBuilder::new(
+                config.config,
+                config.memory,
+            )),
+            handle: None,
+        }
+    }
+
+    pub fn with_ascii_over_tcp_client(
+        config: ClientConfig<T, ferrowl_modbus::tcp::Config>,
+    ) -> Self {
+        Self {
+            builder: Builder::AsciiOverTcpClient(
+                ferrowl_modbus::ascii_over_tcp::ClientBuilder::new(
+                    config.config,
+                    config.operations,
+                    config.memory,
+                ),
+            ),
+            handle: None,
+        }
+    }
+
+    pub fn with_ascii_over_tcp_server(
+        config: ServerConfig<T, ferrowl_modbus::tcp::Config>,
+    ) -> Self {
+        Self {
+            builder: Builder::AsciiOverTcpServer(
+                ferrowl_modbus::ascii_over_tcp::ServerBuilder::new(config.config, config.memory),
+            ),
+            handle: None,
+        }
+    }
+
     /// Spawns the endpoint's background task. Fails with
     /// [`InstanceError::AlreadyActive`] if it is still running.
     pub async fn start<L, S>(&mut self, log: L, status: S) -> Result<(), Error>
@@ -211,6 +258,52 @@ impl<T: KeyParams> Instance<T> {
                 }
             }
             Builder::UdpServer(builder) => {
+                let res = builder.spawn(log).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Server(handle::ServerHandle { handle }));
+                    }
+                }
+            }
+            Builder::AsciiClient(builder) => {
+                let (sender, receiver) = tokio::sync::mpsc::channel(10);
+                let res = builder.spawn(receiver, log, status).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Client(handle::ClientHandle { handle, sender }));
+                    }
+                }
+            }
+            Builder::AsciiServer(builder) => {
+                let res = builder.spawn(log).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Server(handle::ServerHandle { handle }));
+                    }
+                }
+            }
+            Builder::AsciiOverTcpClient(builder) => {
+                let (sender, receiver) = tokio::sync::mpsc::channel(10);
+                let res = builder.spawn(receiver, log, status).await;
+                match res {
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                    Ok(handle) => {
+                        self.handle = Some(Handle::Client(handle::ClientHandle { handle, sender }));
+                    }
+                }
+            }
+            Builder::AsciiOverTcpServer(builder) => {
                 let res = builder.spawn(log).await;
                 match res {
                     Err(e) => {
@@ -494,6 +587,115 @@ mod tests {
         let port = free_udp_port().await;
         let mut instance = Instance::with_udp_server(config::ServerConfig {
             config: Arc::new(RwLock::new(dead_udp_config(port))),
+            memory: Arc::new(MemLock::new(
+                ferrowl_store::Memory::<Key<SlaveKey>>::default(),
+            )),
+        });
+        instance.start(sink(), sink()).await.expect("start");
+        assert!(instance.active());
+        instance.stop().await.expect("stop");
+        assert!(!instance.active());
+    }
+
+    /// A serial path that cannot be opened, so `SerialStream::open` fails — mirrors
+    /// `ascii_serial.rs`'s `bad_config` at the `Instance` layer.
+    fn dead_rtu_config(reconnect: bool) -> ferrowl_modbus::rtu::Config {
+        ferrowl_modbus::rtu::Config {
+            path: "/nonexistent/ferrowl-no-such-serial-port".to_string(),
+            baud_rate: 115200,
+            slave: 1,
+            parity: None,
+            data_bits: None,
+            stop_bits: None,
+            timeout_ms: 1000,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect,
+        }
+    }
+
+    /// MB-R-122 — an Ascii client instance surfaces a serial-open failure from `start`
+    /// exactly like an RTU client instance (MB-R-075/124), ending the task (reconnect off).
+    #[tokio::test]
+    async fn ascii_client_open_failure_ends_task() {
+        let mut instance = Instance::with_ascii_client(config::ClientConfig {
+            config: Arc::new(RwLock::new(dead_rtu_config(false))),
+            operations: Arc::new(RwLock::new(vec![])),
+            memory: Arc::new(MemLock::new(
+                ferrowl_store::Memory::<Key<SlaveKey>>::default(),
+            )),
+        });
+        instance
+            .start(sink(), sink())
+            .await
+            .expect("spawn succeeds; the open error surfaces from the task");
+
+        for _ in 0..50 {
+            if !instance.active() {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        }
+        assert!(!instance.active());
+    }
+
+    /// MB-R-123 — an Ascii server instance fails `start` on a serial-open failure exactly
+    /// like an RTU server instance (MB-R-075/124).
+    #[tokio::test]
+    async fn ascii_server_open_failure_fails_start() {
+        let mut instance = Instance::with_ascii_server(config::ServerConfig {
+            config: Arc::new(RwLock::new(dead_rtu_config(false))),
+            memory: Arc::new(MemLock::new(
+                ferrowl_store::Memory::<Key<SlaveKey>>::default(),
+            )),
+        });
+        let err = instance.start(sink(), sink()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Net(ferrowl_modbus::Error::Serial(
+                ferrowl_modbus::SerialError::Error(_)
+            ))
+        ));
+    }
+
+    /// MB-R-126 — an AsciiOverTcp client instance starts, connects, and stops exactly like a
+    /// TCP/RtuOverTcp client instance (reuses `tcp::Config`, MB-R-125).
+    fn ascii_over_tcp_client_instance() -> Instance<SlaveKey> {
+        let operations = Arc::new(RwLock::new(vec![]));
+        Instance::with_ascii_over_tcp_client(config::ClientConfig {
+            config: Arc::new(RwLock::new(dead_tcp_config())),
+            operations,
+            memory: Arc::new(MemLock::new(
+                ferrowl_store::Memory::<Key<SlaveKey>>::default(),
+            )),
+        })
+    }
+
+    #[tokio::test]
+    async fn ascii_over_tcp_start_twice_is_already_active() {
+        let mut instance = ascii_over_tcp_client_instance();
+        instance.start(sink(), sink()).await.expect("first start");
+        assert!(instance.active());
+        let err = instance.start(sink(), sink()).await.unwrap_err();
+        assert!(matches!(err, Error::Instance(InstanceError::AlreadyActive)));
+        instance.stop().await.expect("cleanup stop");
+    }
+
+    /// MB-R-126 — an AsciiOverTcp server instance binds, reports active, and stops gracefully
+    /// like every other transport.
+    #[tokio::test]
+    async fn ascii_over_tcp_server_starts_and_stops() {
+        let port = free_port();
+        let mut instance = Instance::with_ascii_over_tcp_server(config::ServerConfig {
+            config: Arc::new(RwLock::new(tcp::Config {
+                ip: "127.0.0.1".to_string(),
+                port,
+                timeout_ms: 200,
+                delay_ms: 0,
+                interval_ms: 0,
+                reconnect: true,
+                tls: None,
+            })),
             memory: Arc::new(MemLock::new(
                 ferrowl_store::Memory::<Key<SlaveKey>>::default(),
             )),

--- a/ferrowl/src/module/modbus/build.rs
+++ b/ferrowl/src/module/modbus/build.rs
@@ -301,6 +301,35 @@ pub(crate) fn endpoint_to_config(
             interval_ms: timing.interval_ms,
             reconnect: timing.reconnect,
         }),
+        Endpoint::AsciiOverTcp { ip, port } => {
+            NetConfig::AsciiOverTcp(ferrowl_modbus::tcp::Config {
+                ip: ip.clone(),
+                port: *port,
+                timeout_ms: timing.timeout_ms,
+                delay_ms: timing.delay_ms,
+                interval_ms: timing.interval_ms,
+                reconnect: timing.reconnect,
+                tls,
+            })
+        }
+        Endpoint::Ascii {
+            path,
+            baud_rate,
+            parity,
+            data_bits,
+            stop_bits,
+        } => NetConfig::Ascii(ferrowl_modbus::rtu::Config {
+            path: path.clone(),
+            baud_rate: *baud_rate,
+            slave: 0,
+            parity: parity.clone(),
+            data_bits: *data_bits,
+            stop_bits: *stop_bits,
+            timeout_ms: timing.timeout_ms,
+            delay_ms: timing.delay_ms,
+            interval_ms: timing.interval_ms,
+            reconnect: timing.reconnect,
+        }),
     }
 }
 
@@ -351,6 +380,28 @@ pub(crate) fn build_instance(
             config: Arc::new(RwLock::new(cfg)),
             memory,
         }),
+        (Role::Client, NetConfig::Ascii(cfg)) => Instance::with_ascii_client(ClientConfig {
+            config: Arc::new(RwLock::new(cfg)),
+            operations,
+            memory,
+        }),
+        (Role::Server, NetConfig::Ascii(cfg)) => Instance::with_ascii_server(ServerConfig {
+            config: Arc::new(RwLock::new(cfg)),
+            memory,
+        }),
+        (Role::Client, NetConfig::AsciiOverTcp(cfg)) => {
+            Instance::with_ascii_over_tcp_client(ClientConfig {
+                config: Arc::new(RwLock::new(cfg)),
+                operations,
+                memory,
+            })
+        }
+        (Role::Server, NetConfig::AsciiOverTcp(cfg)) => {
+            Instance::with_ascii_over_tcp_server(ServerConfig {
+                config: Arc::new(RwLock::new(cfg)),
+                memory,
+            })
+        }
     }
 }
 
@@ -780,6 +831,69 @@ mod tests {
                 assert_eq!(cfg.timeout_ms, 1000);
             }
             _ => panic!("expected a Udp config"),
+        }
+    }
+
+    #[test]
+    /// MB-R-127 — `endpoint_to_config` threads `tls` through for an AsciiOverTcp endpoint
+    /// exactly as it does for Tcp/RtuOverTcp, producing `NetConfig::AsciiOverTcp(tcp::Config { .. })`.
+    fn ut_endpoint_to_config_carries_tls_for_ascii_over_tcp_endpoint() {
+        use super::{Timing, endpoint_to_config};
+        use crate::config::Endpoint;
+        use ferrowl_modbus::Transport as NetConfig;
+        use ferrowl_modbus::tcp::ModbusTlsConfig;
+
+        let timing = Timing {
+            timeout_ms: 1000,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let tls = Some(ModbusTlsConfig {
+            self_signed: true,
+            ..Default::default()
+        });
+        let endpoint = Endpoint::AsciiOverTcp {
+            ip: "127.0.0.1".to_string(),
+            port: 502,
+        };
+        let net_config = endpoint_to_config(&endpoint, &timing, tls.clone());
+        match net_config {
+            NetConfig::AsciiOverTcp(cfg) => assert_eq!(cfg.tls, tls),
+            _ => panic!("expected an AsciiOverTcp config"),
+        }
+    }
+
+    /// MB-R-121 — an `Ascii` endpoint resolves to a `Transport::Ascii` config carrying the
+    /// same timing fields every other transport gets from `Timing`, and (MB-R-112-equivalent)
+    /// no `tls` — `rtu::Config` has no such field.
+    #[test]
+    fn ut_endpoint_to_config_ascii() {
+        use super::{Timing, endpoint_to_config};
+        use crate::config::Endpoint;
+        use ferrowl_modbus::Transport as NetConfig;
+
+        let timing = Timing {
+            timeout_ms: 1000,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let endpoint = Endpoint::Ascii {
+            path: "/dev/ttyUSB0".to_string(),
+            baud_rate: 9600,
+            parity: None,
+            data_bits: None,
+            stop_bits: None,
+        };
+        let net_config = endpoint_to_config(&endpoint, &timing, None);
+        match net_config {
+            NetConfig::Ascii(cfg) => {
+                assert_eq!(cfg.path, "/dev/ttyUSB0");
+                assert_eq!(cfg.baud_rate, 9600);
+                assert_eq!(cfg.timeout_ms, 1000);
+            }
+            _ => panic!("expected an Ascii config"),
         }
     }
 }

--- a/ferrowl/src/module/modbus/config/session.rs
+++ b/ferrowl/src/module/modbus/config/session.rs
@@ -113,6 +113,28 @@ pub enum Endpoint {
         ip: String,
         port: u16,
     },
+    /// ASCII framing carried over a TCP socket (MB-R-125); same field set as `Tcp`/
+    /// `RtuOverTcp`, no separate struct. `rename_all = "lowercase"` alone would tag this
+    /// `"asciiovertcp"`, not the required `"ascii_over_tcp"`.
+    #[serde(rename = "ascii_over_tcp")]
+    AsciiOverTcp {
+        ip: String,
+        port: u16,
+    },
+    /// ASCII framing over a serial line (MB-R-121); same field set as `Rtu`, no separate
+    /// struct. `rename_all = "lowercase"` alone already produces the correct tag `"ascii"`
+    /// here (unlike the compound-name variants above), so no `#[serde(rename)]` needed.
+    Ascii {
+        path: String,
+        #[serde(default = "default_baud")]
+        baud_rate: u32,
+        #[serde(default)]
+        parity: Option<String>,
+        #[serde(default)]
+        data_bits: Option<u8>,
+        #[serde(default)]
+        stop_bits: Option<u8>,
+    },
 }
 
 impl std::fmt::Display for Endpoint {
@@ -126,6 +148,9 @@ impl std::fmt::Display for Endpoint {
             }
             Endpoint::Udp { ip, port } => {
                 write!(fmt, "{}:{} (udp)", ip, port)
+            }
+            Endpoint::AsciiOverTcp { ip, port } => {
+                write!(fmt, "{}:{} (ascii/tcp)", ip, port)
             }
             Endpoint::Rtu {
                 path,
@@ -147,6 +172,33 @@ impl std::fmt::Display for Endpoint {
                 write!(
                     fmt,
                     "{},{},{},{},{}",
+                    path,
+                    baud_rate,
+                    parity.as_ref().map_or("-", |v| v),
+                    data_bits,
+                    stop_bits
+                )
+            }
+            Endpoint::Ascii {
+                path,
+                baud_rate,
+                parity,
+                data_bits,
+                stop_bits,
+            } => {
+                let data_bits = if let Some(d) = data_bits {
+                    format!("{}", d)
+                } else {
+                    "-".to_string()
+                };
+                let stop_bits = if let Some(s) = stop_bits {
+                    format!("{}", s)
+                } else {
+                    "-".to_string()
+                };
+                write!(
+                    fmt,
+                    "{},{},{},{},{} (ascii)",
                     path,
                     baud_rate,
                     parity.as_ref().map_or("-", |v| v),
@@ -312,6 +364,25 @@ mod tests {
             .to_string(),
             "/dev/x,19200,-,-,-"
         );
+        assert_eq!(
+            Endpoint::AsciiOverTcp {
+                ip: "127.0.0.1".into(),
+                port: 502
+            }
+            .to_string(),
+            "127.0.0.1:502 (ascii/tcp)"
+        );
+        assert_eq!(
+            Endpoint::Ascii {
+                path: "/dev/ttyUSB0".into(),
+                baud_rate: 9600,
+                parity: Some("even".into()),
+                data_bits: Some(8),
+                stop_bits: Some(1),
+            }
+            .to_string(),
+            "/dev/ttyUSB0,9600,even,8,1 (ascii)"
+        );
     }
 
     #[test]
@@ -363,5 +434,40 @@ mod tests {
             .to_string(),
             "127.0.0.1:502 (udp)"
         );
+    }
+
+    #[test]
+    /// MB-R-125 — the `AsciiOverTcp` endpoint variant tags as `ascii_over_tcp` on the wire
+    /// (`rename_all = "lowercase"` alone would produce `asciiovertcp`) and carries exactly
+    /// `ip`/`port`, the same fields as `Tcp`/`RtuOverTcp`.
+    fn ut_endpoint_ascii_over_tcp_serde_tag() {
+        let ep = Endpoint::AsciiOverTcp {
+            ip: "10.0.0.1".into(),
+            port: 502,
+        };
+        let v = serde_json::to_value(&ep).unwrap();
+        assert_eq!(v["transport"], "ascii_over_tcp");
+        assert_eq!(v["ip"], "10.0.0.1");
+        assert_eq!(v["port"], 502);
+        let back: Endpoint = serde_json::from_value(v).unwrap();
+        assert_eq!(back, ep);
+    }
+
+    #[test]
+    /// MB-R-121 — the `Ascii` endpoint variant tags as `ascii` and carries exactly the same
+    /// fields as `Rtu` (path/baud_rate/parity/data_bits/stop_bits).
+    fn ut_endpoint_ascii_serde_tag() {
+        let ep = Endpoint::Ascii {
+            path: "/dev/ttyUSB0".into(),
+            baud_rate: 9600,
+            parity: None,
+            data_bits: None,
+            stop_bits: None,
+        };
+        let v = serde_json::to_value(&ep).unwrap();
+        assert_eq!(v["transport"], "ascii");
+        assert_eq!(v["path"], "/dev/ttyUSB0");
+        let back: Endpoint = serde_json::from_value(v).unwrap();
+        assert_eq!(back, ep);
     }
 }

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -388,7 +388,7 @@ impl SetupDialog {
             ))
             .tls_level(selection(
                 "TLS",
-                None,
+                Some(HorizontalAlignment::Center),
                 vec![TlsLevel::Off, TlsLevel::Tls, TlsLevel::MutualTls],
                 &selection_style,
             ))
@@ -855,6 +855,7 @@ impl SetupDialog {
             self.transport.state.get_value(),
             Transport::Rtu | Transport::Ascii
         );
+        let is_udp = matches!(self.transport.state.get_value(), Transport::Udp);
         // RTU needs two endpoint rows (path/baud, parity/data-bits/stop-bits); TCP one.
         let endpoint_rows: u16 = if is_rtu { 2 } else { 1 };
         let show_tls = self.tls_shown();
@@ -922,18 +923,16 @@ impl SetupDialog {
         render_field!(self, config_path, rows[idx], buf);
         idx += 1;
 
-        let [transport_area, tls_area, role_area] = Layout::horizontal([
-            Constraint::Percentage(if is_rtu { 50 } else { 35 }),
-            Constraint::Percentage(if is_rtu { 0 } else { 30 }),
-            Constraint::Percentage(if is_rtu { 50 } else { 35 }),
-        ])
-        .areas(rows[idx]);
-        idx += 1;
-        render_field!(self, transport, transport_area, buf);
-        if !is_rtu {
-            render_field!(self, tls_level, tls_area, buf);
+        if is_rtu || is_udp {
+            render_row!(self, rows[idx], buf; transport, role);
+        } else {
+            render_row!(self, rows[idx], buf;
+                transport => Constraint::Percentage(40),
+                tls_level => Constraint::Percentage(20),
+                role => Constraint::Percentage(40)
+            );
         }
-        render_field!(self, role, role_area, buf);
+        idx += 1;
 
         if show_tls {
             let is_server = self.role.state.get_value() == Role::Server;

--- a/ferrowl/src/module/modbus/setup_dialog.rs
+++ b/ferrowl/src/module/modbus/setup_dialog.rs
@@ -105,9 +105,9 @@ pub struct SetupDialog {
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<ConfigPath, FsPathProvider>>,
     #[focus]
     pub transport: Widget<SelectionState<Transport>, Selection<Transport>>,
-    /// TLS level, offered for TCP and RtuOverTcp (MB-R-115) — not RTU (MB-R-112: RTU carries
-    /// no `tls` field at all).
-    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp)})]
+    /// TLS level, offered for TCP, RtuOverTcp (MB-R-115), and AsciiOverTcp (MB-R-127) — not
+    /// RTU or Ascii (MB-R-112/121: neither carries a `tls` field at all).
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp | Transport::AsciiOverTcp)})]
     pub tls_level: Widget<SelectionState<TlsLevel>, Selection<TlsLevel>>,
     #[focus]
     pub role: Widget<SelectionState<Role>, Selection<Role>>,
@@ -139,19 +139,19 @@ pub struct SetupDialog {
     #[focus(when = {self.show_client_ca()})]
     pub client_ca_file:
         Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp | Transport::Udp)})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp | Transport::Udp | Transport::AsciiOverTcp)})]
     pub ip: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp | Transport::Udp)})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Tcp | Transport::RtuOverTcp | Transport::Udp | Transport::AsciiOverTcp)})]
     pub port: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Rtu | Transport::Ascii)})]
     pub path: Widget<SuggestInputState<FsPathProvider>, SuggestInput<String, FsPathProvider>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Rtu | Transport::Ascii)})]
     pub baud: Widget<InputFieldState, InputField<String>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Rtu | Transport::Ascii)})]
     pub parity: Widget<SelectionState<Parity>, Selection<Parity>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Rtu | Transport::Ascii)})]
     pub data_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
-    #[focus(when = {self.transport.get_value() == Transport::Rtu})]
+    #[focus(when = {matches!(self.transport.get_value(), Transport::Rtu | Transport::Ascii)})]
     pub stop_bits: Widget<SelectionState<U8Choice>, Selection<U8Choice>>,
     #[focus]
     pub timeout: Widget<InputFieldState, InputField<String>>,
@@ -198,6 +198,7 @@ impl SetupDialog {
             .role
             .state
             .set_selection(if role == Role::Client { 1 } else { 0 });
+        // Tcp=0, Rtu=1, RtuOverTcp=2, Udp=3, Ascii=4, AsciiOverTcp=5
         match endpoint {
             Endpoint::Tcp { ip, port } => {
                 dialog.transport.state.set_selection(0);
@@ -205,12 +206,17 @@ impl SetupDialog {
                 set_input(&mut dialog.port, &port.to_string());
             }
             Endpoint::RtuOverTcp { ip, port } => {
-                dialog.transport.state.set_selection(2); // Tcp=0, Rtu=1, RtuOverTcp=2
+                dialog.transport.state.set_selection(2);
                 set_input(&mut dialog.ip, ip);
                 set_input(&mut dialog.port, &port.to_string());
             }
             Endpoint::Udp { ip, port } => {
-                dialog.transport.state.set_selection(3); // Tcp=0, Rtu=1, RtuOverTcp=2, Udp=3
+                dialog.transport.state.set_selection(3);
+                set_input(&mut dialog.ip, ip);
+                set_input(&mut dialog.port, &port.to_string());
+            }
+            Endpoint::AsciiOverTcp { ip, port } => {
+                dialog.transport.state.set_selection(5);
                 set_input(&mut dialog.ip, ip);
                 set_input(&mut dialog.port, &port.to_string());
             }
@@ -222,6 +228,23 @@ impl SetupDialog {
                 stop_bits,
             } => {
                 dialog.transport.state.set_selection(1);
+                set_suggest_input(&mut dialog.path, path);
+                set_input(&mut dialog.baud, &baud_rate.to_string());
+                dialog
+                    .parity
+                    .state
+                    .set_selection(Parity::from_config(parity.as_deref()).index());
+                select_u8(&mut dialog.data_bits.state, *data_bits);
+                select_u8(&mut dialog.stop_bits.state, *stop_bits);
+            }
+            Endpoint::Ascii {
+                path,
+                baud_rate,
+                parity,
+                data_bits,
+                stop_bits,
+            } => {
+                dialog.transport.state.set_selection(4);
                 set_suggest_input(&mut dialog.path, path);
                 set_input(&mut dialog.baud, &baud_rate.to_string());
                 dialog
@@ -304,13 +327,15 @@ impl SetupDialog {
             .transport(selection(
                 "Transport",
                 None,
-                // Tcp=0, Rtu=1, RtuOverTcp=2, Udp=3 — each appended last to keep prior
-                // indices stable rather than reordering around them.
+                // Tcp=0, Rtu=1, RtuOverTcp=2, Udp=3, Ascii=4, AsciiOverTcp=5 — each appended
+                // last to keep prior indices stable rather than reordering around them.
                 vec![
                     Transport::Tcp,
                     Transport::Rtu,
                     Transport::RtuOverTcp,
                     Transport::Udp,
+                    Transport::Ascii,
+                    Transport::AsciiOverTcp,
                 ],
                 &selection_style,
             ))
@@ -505,11 +530,12 @@ impl SetupDialog {
     // dialog-height computation, so keyboard focus, painting and layout can never disagree about
     // which fields exist. Mirrors `ferrowl::module::ocpp::setup_dialog`'s own `show_*` methods.
 
-    /// The TLS level selection row (TCP or RtuOverTcp, MB-R-115; never RTU, MB-R-112).
+    /// The TLS level selection row (TCP, RtuOverTcp (MB-R-115), or AsciiOverTcp (MB-R-127);
+    /// never RTU or Ascii, MB-R-112/121).
     fn tls_shown(&self) -> bool {
         matches!(
             self.transport.get_value(),
-            Transport::Tcp | Transport::RtuOverTcp
+            Transport::Tcp | Transport::RtuOverTcp | Transport::AsciiOverTcp
         ) && self.tls_level.get_value() != TlsLevel::Off
     }
 
@@ -674,6 +700,21 @@ impl SetupDialog {
                 };
                 Endpoint::Udp { ip, port }
             }
+            Transport::AsciiOverTcp => {
+                let mut ip = self.ip.state.input().trim().to_string();
+                if ip.is_empty() {
+                    ip = "127.0.0.1".to_string();
+                }
+                let port = self.port.state.input();
+                let port = if !port.is_empty() {
+                    port.trim()
+                        .parse::<u16>()
+                        .map_err(|_| "Port must be a number (0-65535).".to_string())?
+                } else {
+                    502
+                };
+                Endpoint::AsciiOverTcp { ip, port }
+            }
             Transport::Rtu => {
                 let mut path = self.path.state.input().trim().to_string();
                 if path.is_empty() {
@@ -689,6 +730,28 @@ impl SetupDialog {
                     19200
                 };
                 Endpoint::Rtu {
+                    path,
+                    baud_rate,
+                    parity: self.parity.state.get_value().to_config(),
+                    data_bits: Some(self.data_bits.state.get_value().0),
+                    stop_bits: Some(self.stop_bits.state.get_value().0),
+                }
+            }
+            Transport::Ascii => {
+                let mut path = self.path.state.input().trim().to_string();
+                if path.is_empty() {
+                    path = "/dev/ttyUSB0".to_string();
+                }
+                let baud_rate = self.baud.state.input();
+                let baud_rate = if !baud_rate.is_empty() {
+                    baud_rate
+                        .trim()
+                        .parse::<u32>()
+                        .map_err(|_| "Baud rate must be a number.".to_string())?
+                } else {
+                    19200
+                };
+                Endpoint::Ascii {
                     path,
                     baud_rate,
                     parity: self.parity.state.get_value().to_config(),
@@ -726,10 +789,14 @@ impl SetupDialog {
             discrete: opt(self.discrete_ranges.state.input()),
         };
 
-        // TLS is hidden entirely for RTU (MB-R-112): report no value at all, so a save on an
-        // RTU instance never clobbers a device config's existing `tls` setting. RtuOverTcp
-        // carries TLS exactly like Tcp (MB-R-115).
-        let tls = if matches!(endpoint, Endpoint::Tcp { .. } | Endpoint::RtuOverTcp { .. }) {
+        // TLS is hidden entirely for RTU (MB-R-112) and Ascii (MB-R-121): report no value at
+        // all, so a save on an RTU/Ascii instance never clobbers a device config's existing
+        // `tls` setting — neither carries a `tls` field. RtuOverTcp carries TLS exactly like
+        // Tcp (MB-R-115), and so does AsciiOverTcp (MB-R-127).
+        let tls = if matches!(
+            endpoint,
+            Endpoint::Tcp { .. } | Endpoint::RtuOverTcp { .. } | Endpoint::AsciiOverTcp { .. }
+        ) {
             let level = self.tls_level.state.get_value();
             if level == TlsLevel::Off {
                 Some(None)
@@ -781,9 +848,13 @@ impl SetupDialog {
         }
 
         let is_new = self.mode == DialogMode::New;
-        // Deliberately not `!= Transport::Tcp`: RtuOverTcp uses the 1-row TCP-shaped ip/port
-        // layout, not RTU's 2-row serial layout, so it must stay excluded from `is_rtu` here.
-        let is_rtu = self.transport.state.get_value() == Transport::Rtu;
+        // Deliberately not `!= Transport::Tcp`: RtuOverTcp and AsciiOverTcp use the 1-row
+        // TCP-shaped ip/port layout, not RTU's/Ascii's 2-row serial layout, so both must stay
+        // excluded from `is_rtu` here, while Ascii must be included alongside Rtu.
+        let is_rtu = matches!(
+            self.transport.state.get_value(),
+            Transport::Rtu | Transport::Ascii
+        );
         // RTU needs two endpoint rows (path/baud, parity/data-bits/stop-bits); TCP one.
         let endpoint_rows: u16 = if is_rtu { 2 } else { 1 };
         let show_tls = self.tls_shown();
@@ -1389,6 +1460,134 @@ mod tests {
         dialog.role.state.set_selection(1); // Role::Server=0, Role::Client=1
         let outcome = dialog.resolve().unwrap();
         assert_eq!(outcome.values.role, Role::Client);
+    }
+
+    #[test]
+    /// MB-R-121 — selecting an Ascii endpoint sets the transport selector to index 4.
+    fn ut_edit_ascii_sets_transport_selection() {
+        let timing = Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let endpoint = Endpoint::Ascii {
+            path: "/dev/ttyUSB0".to_string(),
+            baud_rate: 9600,
+            parity: None,
+            data_bits: None,
+            stop_bits: None,
+        };
+        let dialog = SetupDialog::edit(
+            "dev",
+            "",
+            Role::Client,
+            &endpoint,
+            timing,
+            &ReadRanges::default(),
+            None,
+        );
+        assert_eq!(dialog.transport.state.get_value(), Transport::Ascii);
+    }
+
+    #[test]
+    /// MB-R-125 — selecting an AsciiOverTcp endpoint sets the transport selector to index 5.
+    fn ut_edit_ascii_over_tcp_sets_transport_selection() {
+        let timing = Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        };
+        let endpoint = Endpoint::AsciiOverTcp {
+            ip: "10.0.0.9".to_string(),
+            port: 1502,
+        };
+        let dialog = SetupDialog::edit(
+            "dev",
+            "",
+            Role::Client,
+            &endpoint,
+            timing,
+            &ReadRanges::default(),
+            None,
+        );
+        assert_eq!(dialog.transport.state.get_value(), Transport::AsciiOverTcp);
+    }
+
+    #[test]
+    /// MB-R-121 — resolving an Ascii dialog produces `Endpoint::Ascii` with the entered
+    /// path/baud/parity/data_bits/stop_bits, mirroring the Rtu resolve test.
+    fn ut_values_ascii_produces_endpoint() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        dialog.transport.state.set_selection(4); // Tcp=0, Rtu=1, RtuOverTcp=2, Udp=3, Ascii=4
+        assert_eq!(dialog.transport.state.get_value(), Transport::Ascii);
+        set_suggest_input(&mut dialog.path, "/dev/ttyUSB1");
+        set_input(&mut dialog.baud, "9600");
+        let outcome = dialog.resolve().unwrap();
+        assert_eq!(
+            outcome.values.endpoint,
+            Endpoint::Ascii {
+                path: "/dev/ttyUSB1".into(),
+                baud_rate: 9600,
+                parity: dialog.parity.state.get_value().to_config(),
+                data_bits: Some(dialog.data_bits.state.get_value().0),
+                stop_bits: Some(dialog.stop_bits.state.get_value().0),
+            }
+        );
+    }
+
+    #[test]
+    /// MB-R-125 — resolving an AsciiOverTcp dialog produces `Endpoint::AsciiOverTcp` with the
+    /// entered ip/port, mirroring the RtuOverTcp/Udp resolve tests.
+    fn ut_values_ascii_over_tcp_produces_endpoint() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        set_input(&mut dialog.name, "dev");
+        dialog.transport.state.set_selection(5); // ..Udp=3, Ascii=4, AsciiOverTcp=5
+        assert_eq!(dialog.transport.state.get_value(), Transport::AsciiOverTcp);
+        set_input(&mut dialog.ip, "10.0.0.9");
+        set_input(&mut dialog.port, "1502");
+        let outcome = dialog.resolve().unwrap();
+        assert_eq!(
+            outcome.values.endpoint,
+            Endpoint::AsciiOverTcp {
+                ip: "10.0.0.9".into(),
+                port: 1502
+            }
+        );
+    }
+
+    #[test]
+    /// MB-R-127 — TLS is offered (tls_shown() true once a level is picked) for AsciiOverTcp
+    /// exactly as for Tcp/RtuOverTcp, never for Ascii (MB-R-121: rtu::Config carries no tls
+    /// field).
+    fn ut_tls_shown_for_ascii_over_tcp_not_ascii() {
+        let mut dialog = SetupDialog::create(Timing {
+            timeout_ms: 0,
+            delay_ms: 0,
+            interval_ms: 0,
+            reconnect: true,
+        });
+        dialog.transport.state.set_selection(5); // AsciiOverTcp
+        assert_eq!(dialog.transport.state.get_value(), Transport::AsciiOverTcp);
+        assert!(!dialog.tls_shown());
+        dialog.tls_level.state.set_selection(TlsLevel::Tls.index());
+        assert!(dialog.tls_shown());
+
+        dialog.transport.state.set_selection(4); // Ascii
+        assert_eq!(dialog.transport.state.get_value(), Transport::Ascii);
+        assert!(!dialog.tls_shown());
     }
 
     #[test]

--- a/ferrowl/src/module/modbus/setup_dialog/choices.rs
+++ b/ferrowl/src/module/modbus/setup_dialog/choices.rs
@@ -24,6 +24,13 @@ pub enum Transport {
     /// MB-R-116 — shares `Tcp`'s ip/port field set, no TLS. Appended last (index 3) to
     /// keep `Tcp=0, Rtu=1, RtuOverTcp=2` stable, same convention as `RtuOverTcp`'s addition.
     Udp,
+    /// ASCII framing over a serial line (MB-R-121) — shares `Rtu`'s field set (path/
+    /// baud/parity/data_bits/stop_bits). Appended last (index 4) to keep prior indices stable.
+    Ascii,
+    /// ASCII framing carried over a TCP socket (MB-R-125) — shares `Tcp`/`RtuOverTcp`/
+    /// `Udp`'s ip/port field set, with TLS (MB-R-127) like `Tcp`/`RtuOverTcp`. Appended
+    /// last (index 5).
+    AsciiOverTcp,
 }
 
 impl ToLabel for Transport {
@@ -33,6 +40,8 @@ impl ToLabel for Transport {
             Transport::Rtu => "RTU",
             Transport::RtuOverTcp => "RTU over TCP",
             Transport::Udp => "UDP",
+            Transport::Ascii => "ASCII",
+            Transport::AsciiOverTcp => "ASCII over TCP",
         }
         .to_string()
     }
@@ -127,6 +136,8 @@ mod tests {
         assert_eq!(Transport::Rtu.to_label(), "RTU");
         assert_eq!(Transport::RtuOverTcp.to_label(), "RTU over TCP");
         assert_eq!(Transport::Udp.to_label(), "UDP");
+        assert_eq!(Transport::Ascii.to_label(), "ASCII");
+        assert_eq!(Transport::AsciiOverTcp.to_label(), "ASCII over TCP");
         assert_eq!(Parity::Even.to_label(), "Even");
         assert_eq!(ReconnectChoice::On.to_label(), "On");
         assert_eq!(U8Choice(8).to_label(), "8");


### PR DESCRIPTION
## Why

Some legacy serial Modbus deployments use ASCII framing (`:` start, hex-encoded PDU, LRC checksum, CR LF terminator) instead of RTU binary framing. Ferrowl previously supported TCP, RTU, RtuOverTcp, and UDP; `docs/specs/modbus/api-contract.md` explicitly called out the absence of Modbus ASCII.

## What changed

Adds two new Modbus transports, mirroring the existing RTU/RtuOverTcp pair structurally (MB-R-121–MB-R-127, plus MB-R-076/101/102/103/067):

- **`Ascii`** (tag `ascii`) — ASCII framing over a serial line. Reuses `rtu::Config` verbatim (MB-R-121); opens the port exactly as an RTU client/server (MB-R-122–MB-R-124), but frames requests/responses with `:`/hex/LRC/CRLF instead of RTU binary.
- **`AsciiOverTcp`** (tag `ascii_over_tcp`) — ASCII framing over a TCP socket. Reuses `tcp::Config` verbatim (MB-R-125); connects exactly as TCP (MB-R-126), with the same TLS support RtuOverTcp has (MB-R-127).
- Both inherit the RTU-family broadcast slave id 0 handling (MB-R-101–MB-R-103), unlike `Udp`.
- MB-R-076 (module transport list) and MB-R-067 (server per-request logging list) extended to include both new transports — MB-R-067 also picked up a pre-existing gap (missing `Udp`) from the prior UDP-transport addition, folded in here at the user's request.

## Approach

The pinned `rust-modbus` rev already ships full ASCII framing support (`Ascii` type, `AsciiClient`, LRC checksum, delimiter-based framing) — no rev bump needed. Unlike RTU (which needs a distinct `RtuOverTcp` marker type because RTU's binary framing relies on a *silence*-based boundary that doesn't work over a byte stream), ASCII's boundary is already delimiter-based (`:`/CRLF), so the same `rust_modbus::Ascii` type drives both the serial and TCP-carried ferrowl-modbus modules — `open_serial::<Ascii>` for the former, `connect_tcp_framed::<Ascii>`/`serve_framed::<Ascii>`/`serve_tls::<Ascii>` for the latter.

`ferrowl-modbus` gained two new modules (`ascii`, `ascii_over_tcp`) mirroring the existing per-transport shape, reusing `rtu::Config`/`tcp::Config` directly rather than defining new config structs. `ferrowl` wired both through `Transport`/`Endpoint`, the instance builder, `--module`/session-file parsing, and the TUI setup dialog — symmetric for `role: client` and `role: server`, matching the existing RTU/RtuOverTcp/UDP transports.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` all clean (0 failures, including new `ascii_serial`, `ascii_over_tcp_loopback`, and `ascii_over_tcp_tls` integration tests).
- `cargo llvm-cov --workspace --fail-under-lines 80` — 86.88% total lines.
- Independent gate-3 review (separate agent, didn't write the code) found zero issues across spec fidelity, standards compliance, and TDD honesty — including reproducing the intermediate cross-stage compile-breakage window (expected, same pattern as the prior RtuOverTcp addition) to confirm it wasn't masking a skipped verification step.

Closes #163
