### PR TITLE
deps: bump rust-modbus to ff9f305 (ASCII inter-character timeout)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "rust-modbus"
 version = "0.1.0"
-source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=7adcfcdae2000a125e8b5a958be27bfd1590f05f#7adcfcdae2000a125e8b5a958be27bfd1590f05f"
+source = "git+https://github.com/TumbleOwlee/rust-modbus?rev=ff9f3053546a075a784af202a08c100f4ef3a5d0#ff9f3053546a075a784af202a08c100f4ef3a5d0"
 dependencies = [
  "crc",
  "rustls",
@@ -2373,7 +2373,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ ratatui = { version = "0.30.2", features = [
 rcgen = "0.14.8"
 # Pinned by rev, not branch: `cargo update` must not silently move us to whatever the fork's
 # `main` points at. Bump the rev deliberately when pulling in upstream changes.
-rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "7adcfcdae2000a125e8b5a958be27bfd1590f05f", default-features = false }
+rust-modbus = { git = "https://github.com/TumbleOwlee/rust-modbus", rev = "ff9f3053546a075a784af202a08c100f4ef3a5d0", default-features = false }
 rust-ocpp = { git = "https://github.com/TumbleOwlee/rust-ocpp", rev = "1343bbbac095ed4f41709bda6ed0a3e5cf443190", default-features = false }
 # Already pulled in transitively by rustls's "ring" feature below; named directly so
 # ferrowl-modbus can hash a rejected TLS peer certificate (MB-R-111) without pinning its


### PR DESCRIPTION
## Summary
- Bumps the pinned `rust-modbus` rev to pick up TR-R-076 (ASCII inter-character timeout): an ASCII receive that stalls mid-frame now times out after a fixed 1s instead of hanging indefinitely.
- No ferrowl spec or code change: `open_serial` gives no way to override the new `TransportConfig` field (it's always the crate default), and the resulting timeout already flows through ferrowl's existing generic transport-error/reconnect handling (MB-R-050) with no new error variant to match on.

## Test plan
- [x] `cargo check -p ferrowl-modbus`
- [x] `cargo test -p ferrowl-modbus` (all suites pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p ferrowl-modbus -- -D warnings`